### PR TITLE
added the dashboard to get started

### DIFF
--- a/pages/landing/hero.tsx
+++ b/pages/landing/hero.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 import { HeroContent } from "@/types/landing";
 export default function Hero() {
   return (
@@ -12,9 +13,11 @@ export default function Hero() {
           {HeroContent.description}
         </p>
         <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-          <button className="bg-[#598EFF] hover:bg-[#598EFF]/80 text-white font-semibold py-3 px-8 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[#5b5bf6] focus:ring-offset-2 cursor-pointer">
-            {HeroContent.button}
-          </button>
+          <Link href="/dashboard" passHref>
+            <button className="bg-[#598EFF] hover:bg-[#598EFF]/80 text-white font-semibold py-3 px-8 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[#5b5bf6] focus:ring-offset-2 cursor-pointer">
+              {HeroContent.button}
+            </button>
+          </Link>
           <button className="border border-[#598EFF] text-[#FFFFFF] hover:bg-[#23213a] font-semibold py-3 px-8 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[#5b5bf6] focus:ring-offset-2 cursor-pointer">
             {HeroContent.buttonSecondary}
           </button>


### PR DESCRIPTION
## Description

Updated the 'Get started' button on the landing page to use Next.js's `Link` component for navigation to `/dashboard`. This ensures smooth client-side routing and improves the onboarding flow by taking users directly to the dashboard when the button is clicked.

Close : #102 

## Related Issue

Fixes: Users not being routed to `/dashboard` when clicking 'Get started' on the landing page.

## Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code and ensured it follows the project guidelines.
- [ ] I have added/updated documentation as needed.
- [ ] I have added necessary tests.

## Screenshots/Recordings

https://github.com/user-attachments/assets/f8038b99-d418-4677-ba60-fb323972f895

## Additional Notes

- Navigation is now handled using Next.js best practices (`Link`).
- The routing is smooth and does not cause


Sorry for the delay, got stuck with some laptop OS for last few days :)