### PR TITLE
 fix(landing): remove dashboard from root route

### DIFF
--- a/pages/landing/index.tsx
+++ b/pages/landing/index.tsx
@@ -1,7 +1,6 @@
 import { KeyFeatures } from "@/components/landing/key-features";
 import Hero from "./hero";
 import Footer from "@/components/common/footer";
-import DashBoard from "@/components/dashboard/dashboard-page"
 // import LandingPageNavBar from "@/components/landing/landing-page-nav-bar";
 import BenefitsSection from "@/components/landing/benefits";
 
@@ -9,7 +8,6 @@ export default function LandingPage() {
   return (
     <div>
       {/* <LandingPageNavBar /> */}
-       <DashBoard />
       <Hero />
       <KeyFeatures />
       <BenefitsSection />


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes introduced in this pull request. -->
  This PR addresses an issue where the Dashboard
      component was being rendered on the root route ('/')
      along with the landing page. The root route should
      exclusively display the landing page content.
         **Changes Made:**
    
     * Removed the `DashBoard` component import and its
      usage from `pages/landing/index.tsx`.
    
         **How to Test:**
   
        1.  Navigate to the root URL ('/').
        2.  Verify that only the landing page (Hero,
      Features, Benefits, Footer) is displayed.
       3.  Navigate to '/dashboard'.
        4.  Verify that the dashboard is displayed correctly.
        5.  Check the browser console for any errors.
## Related Issue
Close #128 

<!-- Link to the issue(s) this pull request addresses, if any. -->

## Checklist

- [x] I have tested the changes locally.
- [ ] I have added/updated documentation as needed.
- [ ] I have reviewed the code and ensured it follows the project guidelines.
- [ ] I have added necessary tests.

## Screenshots/Recordings

<!-- Attach relevant images or videos to show the effect of your changes. -->
<img width="1920" height="1080" alt="Screenshot (70)" src="https://github.com/user-attachments/assets/9e55b6f6-0344-4423-82bb-15527d6bc1b5" />
<img width="1920" height="1080" alt="Screenshot (71)" src="https://github.com/user-attachments/assets/ae8a8358-d0b5-4eb1-9d68-b82bf2815a32" />


## Additional Notes

<!-- Any other information reviewers should be aware of. -->
