### PR TITLE
feat: add network switcher to landing and dashboard navbars

### DIFF
--- a/components/common/navbar.tsx
+++ b/components/common/navbar.tsx
@@ -1,5 +1,8 @@
 // components/Navbar.tsx
+"use client";
+
 import { Bell, Settings, HelpCircle } from "lucide-react";
+import NetworkSwitcher from "./network-switcher";
 
 export default function Navbar() {
   return (
@@ -15,6 +18,9 @@ export default function Navbar() {
 
           {/* Icons and Avatar */}
           <div className="flex items-center gap-4 mt-2 sm:mt-0">
+            {/* Network Switcher */}
+            <NetworkSwitcher variant="dashboard" />
+
             <div className="p-2 rounded-md relative">
               <Bell className="w-10 h-10 sm:w-6 sm:h-6 text-[#6e6d6e] hover:text-[#FFFFFF] transition-colors" />
               <span className="absolute top-2 right-2 sm:top-2.5 sm:right-2.5 w-2.5 h-2.5 bg-[#EB6945] rounded-full" />

--- a/components/common/network-switcher.tsx
+++ b/components/common/network-switcher.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/utils/commonUtils";
+
+export interface Network {
+  id: string;
+  name: string;
+  icon?: React.ReactNode;
+}
+
+interface NetworkSwitcherProps {
+  networks?: Network[];
+  selectedNetwork?: Network;
+  onNetworkChange?: (network: Network) => void;
+  className?: string;
+  variant?: "dashboard" | "landing";
+}
+
+const defaultNetworks: Network[] = [
+  { id: "eth", name: "ETH" },
+  { id: "polygon", name: "Polygon" },
+  { id: "bsc", name: "BSC" },
+  { id: "arbitrum", name: "Arbitrum" },
+];
+
+export default function NetworkSwitcher({
+  networks = defaultNetworks,
+  selectedNetwork = defaultNetworks[0],
+  onNetworkChange,
+  className,
+  variant = "dashboard",
+}: NetworkSwitcherProps) {
+  const [currentNetwork, setCurrentNetwork] = useState<Network>(selectedNetwork);
+
+  const handleNetworkSelect = (network: Network) => {
+    setCurrentNetwork(network);
+    onNetworkChange?.(network);
+  };
+
+  // Ethereum icon SVG (diamond shape)
+  const EthereumIcon = () => (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 0L5.5 12.5L12 16L18.5 12.5L12 0Z"
+        fill="currentColor"
+      />
+      <path
+        d="M12 17.5L5.5 13.5L12 24L18.5 13.5L12 17.5Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+
+  const isDashboard = variant === "dashboard";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className={cn(
+          "flex items-center gap-2 px-3 py-2 rounded-md border transition-colors outline-none focus:ring-1 focus:ring-offset-1",
+          isDashboard
+            ? "bg-transparent border-[#242428] text-white hover:bg-[#1A1A1A] focus:ring-[#598EFF]"
+            : "bg-transparent border-[#598EFF]/30 text-white hover:bg-[#598EFF]/10 focus:ring-[#598EFF]",
+          className
+        )}
+      >
+        <EthereumIcon />
+        <span
+          className="text-sm font-medium"
+          style={{ fontFamily: "General Sans, sans-serif" }}
+        >
+          {currentNetwork.name}
+        </span>
+        <ChevronDown className="w-4 h-4 text-[#6e6d6e]" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className={cn(
+          "min-w-[140px] border-[#242428] text-white",
+          isDashboard ? "bg-[#1A1A1A]" : "bg-[#0a0a0a]"
+        )}
+        align="end"
+        sideOffset={8}
+      >
+        {networks.map((network) => (
+          <DropdownMenuItem
+            key={network.id}
+            onClick={() => handleNetworkSelect(network)}
+            className={cn(
+              "cursor-pointer text-white",
+              isDashboard
+                ? "focus:bg-[#242428] focus:text-white"
+                : "focus:bg-[#1A1A1A] focus:text-white",
+              currentNetwork.id === network.id && (isDashboard ? "bg-[#242428]" : "bg-[#1A1A1A]")
+            )}
+          >
+            <div className="flex items-center gap-2 w-full">
+              {network.icon || <EthereumIcon />}
+              <span
+                className="text-sm"
+                style={{ fontFamily: "General Sans, sans-serif" }}
+              >
+                {network.name}
+              </span>
+              {currentNetwork.id === network.id && (
+                <span className="ml-auto text-[#598EFF]">✓</span>
+              )}
+            </div>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+

--- a/components/landing/landing-page-nav-bar.tsx
+++ b/components/landing/landing-page-nav-bar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import Link from "next/link";
+import NetworkSwitcher from "@/components/common/network-switcher";
 
 const navLinks = [
   { name: "Home", href: "/" },
@@ -41,6 +42,9 @@ export default function LandingPageNavBar() {
 
         {/* Desktop Auth Buttons */}
         <div className="hidden md:flex items-center gap-4">
+          {/* Network Switcher */}
+          <NetworkSwitcher variant="landing" />
+          
           <Link
             href="/auth/login"
             className="px-6 py-4 rounded-full border border-[#598EFF] text-[#EEF4FF] bg-transparent font-medium transition-colors duration-200 hover:bg-[#598EFF] hover:text-white"
@@ -85,6 +89,10 @@ export default function LandingPageNavBar() {
               </Link>
             ))}
             <div className="flex flex-col gap-3 w-full px-6">
+              {/* Network Switcher for Mobile */}
+              <div className="flex justify-center mb-2">
+                <NetworkSwitcher variant="landing" />
+              </div>
               <Link
                 href="/auth/login"
                 className="px-6 py-2 rounded-full border border-[#598EFF] text-[#EEF4FF] bg-transparent font-medium transition-colors duration-200 hover:bg-[#598EFF] hover:text-white text-center"


### PR DESCRIPTION
Closes #136

## Description
Adds a network switcher dropdown component to both the Dashboard and Landing page navbars, matching the Figma design specifications for placement, styling, and behavior.

## Changes Made

### New Component
- **`components/common/network-switcher.tsx`**: New reusable NetworkSwitcher component
  - Dropdown menu with network selection (ETH, Polygon, BSC, Arbitrum)
  - Ethereum icon (diamond shape) matching design
  - Two variants: `dashboard` and `landing` for context-specific styling
  - State management for selected network
  - Callback support for network changes via `onNetworkChange` prop

### Updated Components
- **`components/common/navbar.tsx`**: Added NetworkSwitcher to Dashboard navbar
  - Positioned in top-right area, before notification/settings icons
  - Styled to match dashboard dark theme
  
- **`components/landing/landing-page-nav-bar.tsx`**: Added NetworkSwitcher to Landing page navbar
  - Desktop: positioned before auth buttons (Log in/Sign Up)
  - Mobile: included in mobile menu
  - Styled to match landing page design system

## Features
✅ Network switcher dropdown with multiple network options  
✅ Visual indicator (checkmark) for currently selected network  
✅ Responsive design (desktop/tablet/mobile)  
✅ Dark theme styling matching existing design system  
✅ Hover and focus states for better UX  
✅ No breaking changes to existing wallet connection functionality  

## Design Compliance
- Matches Figma design for placement and styling
- Network switcher positioned in top-right area as per design
- Consistent styling across Dashboard and Landing pages
- Proper spacing and alignment with existing navbar elements

## Testing
- [x] Network switcher renders correctly on Landing page navbar
- [x] Network switcher renders correctly on Dashboard navbar
- [x] Dropdown opens/closes correctly
- [x] Network selection updates the displayed network
- [x] Layout doesn't shift/break near wallet button area
- [x] Responsive layout verified at common breakpoints
- [x] Mobile menu includes network switcher

## Screenshots
_(Please add screenshots/gif showing the network switcher on both pages)_

## Notes
- Default network is set to ETH
- Network selection state is managed locally within the component
- Can be extended to integrate with wallet/network data when available
- Component is fully reusable and can be used in other parts of the application