### PR TITLE
Add Figma design links for redesigned Account Summary, Agreements, and Transactions pages

### DIFF
--- a/design/figma-design.txt
+++ b/design/figma-design.txt
@@ -2,5 +2,8 @@ https://www.figma.com/design/TuvTv502EmhaloPswIF3jc/StelloPay?node-id=22-277&t=i
 https://www.figma.com/design/TuvTv502EmhaloPswIF3jc/StelloPay?node-id=8-91&t=kkz6wnDHildwypLq-1
 
 Dashboard + Transaction UI Design + Help/Support Page + Profile/Settings Page + Login Page
-FIGMA LINK: https://www.figma.com/design/wcDLcVPO7I0HZVb6zJr6Ep/Stellopay?node-id=0-1&t=6tyXbOo2ntkV8sxc-1
+FIGMA LINK (legacy): https://www.figma.com/design/wcDLcVPO7I0HZVb6zJr6Ep/Stellopay?node-id=0-1&t=6tyXbOo2ntkV8sxc-1
+
+Redesigned pages – Account Summary, Agreements, Transactions
+FIGMA LINK (redesign): https://www.figma.com/design/74oIRaFdQHOJ1A2hXMOnll/Stellopay?node-id=0-1&p=f&t=UdOvEZFmdxnp7D1E-0
 


### PR DESCRIPTION
**PR Description**

### Summary
- **Added Figma design link** for the redesigned **Transactions**, **Agreements**, and **Account Summary** pages.
- This PR is **design-reference only** and does **not** include any frontend implementation changes.

### Design Link
- Figma: [StelloPay Product Designs](https://www.figma.com/design/74oIRaFdQHOJ1A2hXMOnll/Stellopay?node-id=0-1&p=f&t=UdOvEZFmdxnp7D1E-0)

### Related Issues
- Transactions Page Redesign – #152  
- Agreements Page Redesign – #151  
- Account Summary Page Redesign – #150  

### Scope
- **Code changes**: Only adding/updating references to the Figma file where design documentation is kept (e.g. README / design docs / comments).
- **No UI behavior or layout changes** in this PR.

### Testing
- N/A – documentation / design-link only.