### PR TITLE
feat(landing): add StatsCards component to display key statistics

### DIFF
--- a/components/landing/stats-cards.tsx
+++ b/components/landing/stats-cards.tsx
@@ -1,0 +1,46 @@
+import { FC } from "react";
+import type { StatCardItem } from "@/types/landing";
+
+export interface StatsCardsProps {
+  stats: StatCardItem[];
+}
+
+export const StatsCards: FC<StatsCardsProps> = ({ stats }) => {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 w-full">
+      {stats.map((item, index) => (
+        <div
+          key={index}
+          className="
+            bg-white dark:bg-[#18181B]
+            rounded-2xl
+            border border-[#E5E5E5] dark:border-[#333333]
+            shadow-sm dark:shadow-[0_1px_3px_rgba(0,0,0,0.3)]
+            px-6 py-8 md:px-8 md:py-10
+            flex flex-col items-center justify-center
+            text-center
+          "
+        >
+          <span
+            className="
+              text-2xl sm:text-3xl md:text-4xl font-bold
+              text-[#6B47ED] dark:text-[#A78BFA]
+              tracking-tight
+              block
+            "
+          >
+            {item.value}
+          </span>
+          <span
+            className="
+              mt-2 text-sm md:text-base font-normal
+              text-[#52525B] dark:text-[#A3A3A3]
+            "
+          >
+            {item.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/pages/landing/index.tsx
+++ b/pages/landing/index.tsx
@@ -7,6 +7,14 @@ import BenefitsSection from "@/components/landing/benefits";
 import ValuePropositions from "@/components/landing/value-propositions";
 import GetStartedCTA from "@/components/landing/get-started-cta";
 import { FeaturesIntro } from "@/components/landing/features-intro";
+import { StatsCards } from "@/components/landing/stats-cards";
+
+const defaultStats = [
+  { value: "$2.5B+", label: "Transaction Volume" },
+  { value: "150K+", label: "Active Users" },
+  { value: "99.9%", label: "Uptime" },
+  { value: "<3s", label: "Transaction Speed" },
+];
 
 export default function LandingPage() {
   return (
@@ -14,6 +22,11 @@ export default function LandingPage() {
       {<LandingPageNavBar />}
       {/* Removed: <DashBoard /> - this shouldn't be on the landing page */}
       <Hero />
+      <section className="bg-[#F5F3FF] dark:bg-[#0F0A14] py-12 md:py-16 px-4">
+        <div className="max-w-6xl mx-auto">
+          <StatsCards stats={defaultStats} />
+        </div>
+      </section>
       <FeaturesIntro id="features" />
       <KeyFeatures />
       <ValuePropositions />

--- a/types/landing.ts
+++ b/types/landing.ts
@@ -5,6 +5,11 @@ export interface FeatureCardProps {
   description: string;
 }
 
+export interface StatCardItem {
+  value: string;
+  label: string;
+}
+
 export const HeroContent = {
   titleOne: "Secure Digital Payments",
   titleTwo: "For a Smarter Future",


### PR DESCRIPTION
closes #170 

Screenshot: 

<img width="1326" height="252" alt="image" src="https://github.com/user-attachments/assets/3a656545-72d5-4df0-8315-99ea3a87b898" />
