### PR TITLE
chore: centralize demo PII and landing stats into placeholder config

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,12 @@ stellopay-frontend
    └─ NotificationItem.tsx
 
 ```
+
+## Centralized Demo Data & Illustrative Stats
+
+To prevent hardcoded realistic PII (Personal Identifiable Information) and fabricated marketing trust metrics from being shipped inline in production components, this project uses a centralized demo-data configuration located at `lib/demo-data.ts`.
+
+- **Security Compliance**: All mockup emails, phone numbers, and wallet addresses are set to standard, obvious placeholder domains/values (e.g. `example.com`, `+1 555 0100`, and redacted addresses like `GB-REDACTED-DEMO-STELLAR-ADDRESS-XXXX`). This reduces compliance exposure and prevents test/seed data from being mistaken for active production credentials.
+- **Illustrative Marketing Stats**: Landing page statistics are managed via the same config file and clearly decorated with visual badges indicating they are illustrative placeholders.
+- **Backend Integration**: These structures are designed to be easily replaced by backend API hooks once user authentication, profile retrieval, and wallet connectivity endpoints are finalized.
+

--- a/app/settings/preferences/components/account-section.tsx
+++ b/app/settings/preferences/components/account-section.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { FormMessage } from "@/components/ui/form";
 import DestructiveActionDialog from "./destructive-action-dialog";
+import { DEMO_PROFILE } from "@/lib/demo-data";
 
 interface ProfileState {
   firstName: string;
@@ -49,14 +50,19 @@ const sectionMap = [
   },
 ];
 
+/**
+ * AccountSection component.
+ * Renders user profile information, identity details, and regional settings.
+ * Uses placeholder demo data pending full backend API integration.
+ */
 export default function AccountSection() {
   const [profile, setProfile] = useState<ProfileState>({
-    firstName: "Maya",
-    lastName: "Sullivan",
-    displayName: "Maya Sullivan",
-    email: "maya.sullivan@stellopay.app",
-    timezone: "Africa/Lagos",
-    currency: "USD",
+    firstName: DEMO_PROFILE.firstName,
+    lastName: DEMO_PROFILE.lastName,
+    displayName: DEMO_PROFILE.displayName,
+    email: DEMO_PROFILE.email,
+    timezone: DEMO_PROFILE.timezone,
+    currency: DEMO_PROFILE.currency,
   });
   const [statusMessage, setStatusMessage] = useState("");
 
@@ -85,8 +91,11 @@ export default function AccountSection() {
                 <span className="absolute -bottom-1 -right-1 h-5 w-5 rounded-full border-2 border-white bg-emerald-500 dark:border-[#09090B]" />
               </div>
               <div className="space-y-1">
-                <CardTitle className="font-general text-2xl text-zinc-950 dark:text-white">
+                <CardTitle className="font-general text-2xl text-zinc-950 dark:text-white flex flex-wrap items-center gap-2">
                   Account identity
+                  <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800 ring-1 ring-inset ring-amber-600/20 dark:bg-amber-400/10 dark:text-amber-500 dark:ring-amber-400/20">
+                    Demo Data
+                  </span>
                 </CardTitle>
                 <CardDescription className="max-w-lg text-zinc-600 dark:text-zinc-400">
                   High-frequency profile fields are visible immediately, while
@@ -178,14 +187,14 @@ export default function AccountSection() {
               <Field
                 id="legal-name"
                 label="Legal entity"
-                value="Stellopay Labs"
+                value={DEMO_PROFILE.legalEntity}
                 onChange={() => undefined}
                 disabled
               />
               <Field
                 id="billing-country"
                 label="Billing country"
-                value="Nigeria"
+                value={DEMO_PROFILE.billingCountry}
                 onChange={() => undefined}
                 disabled
               />

--- a/app/settings/preferences/components/security-tab.tsx
+++ b/app/settings/preferences/components/security-tab.tsx
@@ -23,6 +23,7 @@ import { checkPasswordRequirements } from "@/utils/authUtils";
 import DestructiveActionDialog from "./destructive-action-dialog";
 import { Label } from "@/components/ui/label";
 import { FormMessage } from "@/components/ui/form";
+import { DEMO_SECURITY } from "@/lib/demo-data";
 
 const sessions = [
   {
@@ -39,6 +40,11 @@ const sessions = [
   },
 ];
 
+/**
+ * SecurityTab component.
+ * Renders security-sensitive forms (password updates, two-factor authentication, active sessions).
+ * Uses placeholder demo data pending full backend API integration.
+ */
 export default function SecurityTab() {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -74,8 +80,11 @@ export default function SecurityTab() {
               <KeyRound className="size-5" />
             </span>
             <div className="space-y-1">
-              <CardTitle className="font-general text-xl text-zinc-950 dark:text-white">
+              <CardTitle className="font-general text-xl text-zinc-950 dark:text-white flex flex-wrap items-center gap-2">
                 Password and recovery
+                <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800 ring-1 ring-inset ring-amber-600/20 dark:bg-amber-400/10 dark:text-amber-500 dark:ring-amber-400/20">
+                  Demo Data
+                </span>
               </CardTitle>
               <CardDescription className="text-zinc-600 dark:text-zinc-400">
                 Keep password work scoped to one card and show validation before
@@ -163,9 +172,9 @@ export default function SecurityTab() {
               Show recovery methods
             </summary>
             <div className="mt-4 grid gap-3 text-sm text-zinc-600 dark:text-zinc-400">
-              <p>Primary email: maya.sullivan@stellopay.app</p>
-              <p>Recovery codes: generated and stored offline</p>
-              <p>Backup contact: +234 801 234 5678</p>
+              <p>Primary email: {DEMO_SECURITY.primaryEmail}</p>
+              <p>Recovery codes: {DEMO_SECURITY.recoveryCodesStatus}</p>
+              <p>Backup contact: {DEMO_SECURITY.backupContact}</p>
             </div>
           </details>
         </CardContent>

--- a/app/settings/preferences/components/wallets-section.tsx
+++ b/app/settings/preferences/components/wallets-section.tsx
@@ -12,21 +12,9 @@ import {
 } from "@/components/ui/card";
 import ToggleCard from "@/components/common/toggle-card";
 import DestructiveActionDialog from "./destructive-action-dialog";
+import { DEMO_WALLETS } from "@/lib/demo-data";
 
-const connectedWallets = [
-  {
-    name: "Primary Treasury",
-    network: "Stellar Mainnet",
-    address: "GBSL...4KQ2",
-    status: "Default settlement wallet",
-  },
-  {
-    name: "Operations Wallet",
-    network: "Starknet",
-    address: "0x47f...12ce",
-    status: "Approvals required for outbound transfers",
-  },
-];
+const connectedWallets = DEMO_WALLETS;
 
 interface WalletSettingsState {
   transferApprovals: boolean;
@@ -34,6 +22,11 @@ interface WalletSettingsState {
   travelRuleChecks: boolean;
 }
 
+/**
+ * WalletsSection component.
+ * Renders connected wallet configurations, region settings, and outbound transfer safeguards.
+ * Uses placeholder demo data pending full backend API integration.
+ */
 export default function WalletsSection() {
   const [settings, setSettings] = useState<WalletSettingsState>({
     transferApprovals: true,
@@ -53,8 +46,11 @@ export default function WalletsSection() {
     <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
       <Card className="border-zinc-200 bg-white/90 shadow-sm dark:border-white/10 dark:bg-white/5">
         <CardHeader className="border-b border-zinc-200/80 dark:border-white/10">
-          <CardTitle className="font-general text-2xl text-zinc-950 dark:text-white">
+          <CardTitle className="font-general text-2xl text-zinc-950 dark:text-white flex flex-wrap items-center gap-2">
             Connected wallets
+            <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800 ring-1 ring-inset ring-amber-600/20 dark:bg-amber-400/10 dark:text-amber-500 dark:ring-amber-400/20">
+              Demo Data
+            </span>
           </CardTitle>
           <CardDescription className="text-zinc-600 dark:text-zinc-400">
             Wallet identity and transfer controls stay on the same surface so

--- a/e2e/demo-data.spec.ts
+++ b/e2e/demo-data.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+
+test("landing page renders illustrative demo stats badge and config stats", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByText("Illustrative Demo Data").first()).toBeVisible();
+  await expect(page.getByText("Transaction Volume").first()).toBeVisible();
+  await expect(page.getByText("Active Users").first()).toBeVisible();
+  await expect(page.getByText("Uptime").first()).toBeVisible();
+});
+
+test("account preferences renders demo data badge and placeholder info", async ({ page }) => {
+  await page.goto("/settings/preferences?section=account");
+  await expect(page.getByText("Demo Data").first()).toBeVisible();
+  await expect(page.locator("#first-name")).toHaveValue("Demo");
+  await expect(page.locator("#last-name")).toHaveValue("User");
+  await expect(page.locator("#email-address")).toHaveValue("user@example.com");
+
+  // Advanced fields
+  await page.getByText("Show advanced identity and billing fields").click();
+  await expect(page.locator("#legal-name")).toHaveValue("Demo Labs Inc.");
+  await expect(page.locator("#billing-country")).toHaveValue("United States");
+});
+
+test("security preferences renders placeholder recovery contacts", async ({ page }) => {
+  await page.goto("/settings/preferences?section=security");
+  await expect(page.getByText("Demo Data").first()).toBeVisible();
+  await page.getByText("Show recovery methods").click();
+  await expect(page.getByText("Primary email: user@example.com")).toBeVisible();
+  await expect(page.getByText("Backup contact: +1 555 0100")).toBeVisible();
+});
+
+test("wallets section renders redacted placeholder addresses", async ({ page }) => {
+  await page.goto("/settings/preferences?section=wallets");
+  await expect(page.getByText("Demo Data").first()).toBeVisible();
+  await expect(page.getByText("Address: GB-REDACTED-DEMO-STELLAR-ADDRESS-XXXX")).toBeVisible();
+  await expect(page.getByText("Address: 0x-REDACTED-DEMO-STARKNET-ADDRESS-XXXX")).toBeVisible();
+});

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -1,0 +1,61 @@
+import type { StatCardItem } from "@/types/landing";
+
+/**
+ * @file demo-data.ts
+ * @description Centralized placeholder demo data and illustrative landing stats.
+ * This ensures no realistic personal identifiable information (PII) or fake
+ * trust signals are hardcoded inside individual UI components.
+ *
+ * NOTE: These values are placeholders pending full backend integration.
+ */
+
+/**
+ * Demo profile placeholder data.
+ */
+export const DEMO_PROFILE = {
+  firstName: "Demo",
+  lastName: "User",
+  displayName: "Demo User",
+  email: "user@example.com",
+  timezone: "Africa/Lagos",
+  currency: "USD",
+  legalEntity: "Demo Labs Inc.",
+  billingCountry: "United States",
+} as const;
+
+/**
+ * Demo security and recovery placeholder contacts.
+ */
+export const DEMO_SECURITY = {
+  primaryEmail: "user@example.com",
+  backupContact: "+1 555 0100", // Standard safe US placeholder phone number
+  recoveryCodesStatus: "generated and stored offline",
+} as const;
+
+/**
+ * Demo connected wallets with clearly redacted/placeholder addresses.
+ */
+export const DEMO_WALLETS = [
+  {
+    name: "Primary Treasury",
+    network: "Stellar Mainnet",
+    address: "GB-REDACTED-DEMO-STELLAR-ADDRESS-XXXX",
+    status: "Default settlement wallet",
+  },
+  {
+    name: "Operations Wallet",
+    network: "Starknet",
+    address: "0x-REDACTED-DEMO-STARKNET-ADDRESS-XXXX",
+    status: "Approvals required for outbound transfers",
+  },
+] as const;
+
+/**
+ * Landing page marketing metrics, marked as illustrative placeholder statistics.
+ */
+export const ILLUSTRATIVE_STATS: StatCardItem[] = [
+  { value: "$2.5B+", label: "Transaction Volume" },
+  { value: "150K+", label: "Active Users" },
+  { value: "99.9%", label: "Uptime" },
+  { value: "<3s", label: "Transaction Speed" },
+];

--- a/pages/landing/index.tsx
+++ b/pages/landing/index.tsx
@@ -9,14 +9,13 @@ import FAQSection from "@/components/landing/faq-section";
 import { StatsCards } from "@/components/landing/stats-cards";
 import Navbar from "@/components/landing/navbar";
 import EnterpriseSolutionSection from "@/components/landing/enterprise-section";
+import { ILLUSTRATIVE_STATS } from "@/lib/demo-data";
 
-const defaultStats = [
-  { value: "$2.5B+", label: "Transaction Volume" },
-  { value: "150K+", label: "Active Users" },
-  { value: "99.9%", label: "Uptime" },
-  { value: "<3s", label: "Transaction Speed" },
-];
-
+/**
+ * LandingPage component.
+ * Renders the marketing landing page including features, benefits, FAQs, and illustrative statistics.
+ * The statistics are loaded from a centralized demo-data configuration and marked as illustrative.
+ */
 export default function LandingPage() {
   return (
     <div>
@@ -24,7 +23,16 @@ export default function LandingPage() {
       <Hero />
       <section className="bg-[#F5F3FF] dark:bg-[#0F0A14] py-12 md:py-16 px-4">
         <div className="max-w-6xl mx-auto">
-          <StatsCards stats={defaultStats} />
+          <div className="flex flex-col items-center gap-2 mb-6">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-violet-100 px-3 py-1 text-xs font-medium text-violet-700 dark:bg-violet-900/30 dark:text-violet-300">
+              <span className="h-1.5 w-1.5 rounded-full bg-violet-500 animate-pulse" />
+              Illustrative Demo Data
+            </span>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              Stats shown below are for demonstration and testing purposes.
+            </p>
+          </div>
+          <StatsCards stats={ILLUSTRATIVE_STATS} />
         </div>
       </section>
       <KeyFeatures />

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
-  testDir: "./tests",
+  testDir: ".",
+  testMatch: ["tests/**/*.spec.ts", "e2e/**/*.spec.ts"],
   timeout: 60_000,
   fullyParallel: false,
   workers: 1,


### PR DESCRIPTION
Closes #257

### Description
This PR addresses issue #257 by centralizing mock/fabricated Personal Identifiable Information (PII) and marketing trust metrics into a single configuration file at `lib/demo-data.ts`.

### Changes
- Created `lib/demo-data.ts` containing safe, obvious placeholder details (e.g. `user@example.com`, redacted wallet addresses, and illustrative landing page stats).
- Updated settings components (`account-section.tsx`, `security-tab.tsx`, `wallets-section.tsx`) to use the centralized placeholders.
- Added a visual "Demo Data" badge on the settings tabs and an "Illustrative Demo Data" badge/caption on the landing page stats card section.
- Moved landing stats out of raw literals in `pages/landing/index.tsx` to the config file.
- Added a comprehensive Playwright test suite (`e2e/demo-data.spec.ts`) verifying that demo data and placeholders render correctly.
- Added comments, inline TSDoc annotations, and updated the `README.md` to document the placeholder architecture and backend integration status.