### PR TITLE
Feature/create global error

### DIFF
--- a/app/global-error.test.tsx
+++ b/app/global-error.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import GlobalError from "./global-error";
+
+// Helpers 
+// Builds the props that Next.js passes to global-error.tsx. 
+function makeProps(overrides?: { reset?: () => void }) {
+  return {
+    error: Object.assign(new Error("boom"), { digest: "abc123" }),
+    reset: overrides?.reset ?? vi.fn(),
+  };
+}
+
+// Tests 
+describe("GlobalError", () => {
+  it("renders an html element as the document root", () => {
+    const { container } = render(<GlobalError {...makeProps()} />);
+    /* When @testing-library renders <html>, jsdom hoists its children into
+       the existing document; the rendered output lives in document.documentElement. */
+    expect(
+      container.querySelector("html") ??
+        container.ownerDocument.documentElement,
+    ).toBeTruthy();
+  });
+
+  it("renders a body element", () => {
+    const { container } = render(<GlobalError {...makeProps()} />);
+    expect(
+      container.querySelector("body") ?? container.ownerDocument.body,
+    ).toBeTruthy();
+  });
+
+  it("renders a visible heading", () => {
+    render(<GlobalError {...makeProps()} />);
+    expect(
+      screen.getByRole("heading", { name: /something went wrong/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a Try again button", () => {
+    render(<GlobalError {...makeProps()} />);
+    expect(
+      screen.getByRole("button", { name: /try again/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls reset() when the button is clicked", () => {
+    const reset = vi.fn();
+    render(<GlobalError {...makeProps({ reset })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to window.location.reload() when reset is not provided", () => {
+    /* Next.js 15 + React 19 does not always inject reset when the error
+     originates in a Server Component. This test covers that branch. */
+    const reloadMock = vi.fn();
+    vi.stubGlobal("location", { ...window.location, reload: reloadMock });
+
+    const error = Object.assign(new Error("boom"), { digest: "abc123" });
+    render(<GlobalError error={error} />);
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+
+  it("does not render the raw error message or stack trace", () => {
+    render(<GlobalError {...makeProps()} />);
+    expect(screen.queryByText("boom")).not.toBeInTheDocument();
+  });
+
+  it("does not render the error digest", () => {
+    render(<GlobalError {...makeProps()} />);
+    expect(screen.queryByText("abc123")).not.toBeInTheDocument();
+  });
+
+  it("renders a generic user-facing description", () => {
+    render(<GlobalError {...makeProps()} />);
+    expect(screen.getByText(/unexpected error occurred/i)).toBeInTheDocument();
+  });
+});

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+/**
+  Global error boundary for the root layout.
+ 
+  Next.js segment `error.tsx` files only catch errors thrown by the *children*
+  of a layout, never by the layout itself. Because `app/layout.tsx` is the
+  root layout, any failure inside ThemeProvider or SidebarProvider would
+  escape every inner boundary and crash the whole app silently in production.
+ 
+  `global-error.tsx` is the one file Next.js checks for this case. It must
+  render its own `<html>/<body>` shell because the root layout's shell is
+  exactly what failed — it cannot be reused here.
+ 
+  Security: only a generic message is shown. The `error` object is intentionally
+  not rendered to avoid leaking stack traces or internal paths in production.
+ */
+
+interface GlobalErrorProps {
+  /** The error thrown by the root layout or one of its providers. */
+  error: Error & { digest?: string };
+  /**
+    Next.js callback that re-renders the segment tree without a full page reload.
+    Optional because Next.js 15 + React 19 does not always inject it when the
+    error originates in a Server Component — `handleReset` falls back to
+    `window.location.reload()` in that case.
+   */
+  reset?: () => void;
+}
+
+/*
+  Minimal full-document fallback rendered when `app/layout.tsx` itself throws.
+ 
+  Inline styles are intentional: `globals.css` (and every stylesheet loaded
+  through the layout) is unavailable at this point, so Tailwind classes would
+  have no effect. The styles below are self-contained and dependency-free.
+ */
+export default function GlobalError({ reset }: GlobalErrorProps) {
+  function handleReset() {
+    if (typeof reset === "function") reset();
+    else window.location.reload();
+  }
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily:
+            "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+          backgroundColor: "#f9fafb",
+          color: "#111827",
+        }}
+      >
+        <div
+          style={{
+            textAlign: "center",
+            padding: "2rem",
+            maxWidth: "400px",
+          }}
+        >
+          <h1
+            style={{
+              fontSize: "1.5rem",
+              fontWeight: 600,
+              marginBottom: "0.75rem",
+            }}
+          >
+            Something went wrong
+          </h1>
+          <p
+            style={{
+              fontSize: "0.95rem",
+              color: "#6b7280",
+              marginBottom: "1.5rem",
+            }}
+          >
+            An unexpected error occurred. Please try again.
+          </p>
+          <button
+            onClick={handleReset}
+            style={{
+              padding: "0.6rem 1.4rem",
+              fontSize: "0.95rem",
+              fontWeight: 500,
+              color: "#ffffff",
+              backgroundColor: "#111827",
+              border: "none",
+              borderRadius: "0.375rem",
+              cursor: "pointer",
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         'utils/transactionUtils.ts',
         'utils/paginationUtils.ts',
         'types/auth.ts',
+        'app/global-error.tsx',
       ],
       exclude: [
         '**/*.test.{ts,tsx}',


### PR DESCRIPTION
## Description

Implemented `app/global-error.tsx` the Next.js global error boundary that catches failures thrown inside `app/layout.tsx` itself (ThemeProvider, SidebarProvider, fonts). Without this file, any root layout crash produces a white screen with no recovery path in production.

**Changes made:**

- Created `app/global-error.tsx` as a `"use client"` component that renders its own `<html lang="en"><body>` shell, as required by Next.js when the root layout fails.
- Used inline styles throughout `globals.css` is loaded by the layout that crashed and may not be available, making Tailwind classes ineffective at this point.
- Wired the reset button via `handleReset`, which calls Next.js's `reset()` prop when available (soft re-render, no page reload) and falls back to `window.location.reload()` when it is not discovered in practice that Next.js 15 + React 19 does not always inject `reset` when the error originates in a Server Component.
- Kept the component fully self-contained no imports of ThemeProvider, SidebarProvider, or any provider it is meant to backstop.
- Renders only a generic error message; the `error` object is intentionally never rendered to avoid exposing stack traces or internal paths in production.
- Created `app/global-error.test.tsx` with 9 tests covering: html/body shell, heading, reset button, reset() call, `window.location.reload()` fallback, no error message leaked, no digest leaked, and generic description.
- Added `app/global-error.tsx` to the coverage include list in `vitest.config.ts`.

**Security notes:**

- The `error` prop is received but never rendered no stack trace, no file paths, no internal details reach the user.
- Two dedicated tests assert that neither `error.message` nor `error.digest` appear in the DOM.

## Related Issue

Closes #281

## Checklist

- [x] I have tested the changes locally.
- [x] I have added/updated documentation as needed.
- [x] I have added necessary tests.

## Screenshots/Recordings
**Clicking "Try again" recovers the app via reload**

<img width="1225" height="817" alt="image" src="https://github.com/user-attachments/assets/08404d78-d574-41a2-8848-fd401ca7de71" />

## Test output

<img width="601" height="238" alt="image" src="https://github.com/user-attachments/assets/7a32addb-a842-4566-beae-d1b3ffddc820" />

