### PR TITLE
test(utils): add edge-case coverage for formatUtils

### DIFF
--- a/utils/formatUtils.test.ts
+++ b/utils/formatUtils.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  capitalizeFirst,
+  formatChartValue,
+  formatCurrency,
+  formatNumber,
+  truncateText,
+} from "@/utils/formatUtils";
+
+describe("formatCurrency", () => {
+  it("formats zero, positive, and negative amounts with an explicit sign policy", () => {
+    expect(formatCurrency(0)).toBe("+$0.00");
+    expect(formatCurrency(1234.5)).toBe("+$1234.50");
+    expect(formatCurrency(-1234.5)).toBe("$1234.50");
+  });
+
+  it("supports custom currency symbols and decimal precision", () => {
+    expect(formatCurrency(42, "USD ", 0)).toBe("+USD 42");
+    expect(formatCurrency(-0.125, "USDC ", 3)).toBe("USDC 0.125");
+  });
+
+  it("rounds fractional values deterministically", () => {
+    expect(formatCurrency(1.005)).toBe("+$1.00");
+    expect(formatCurrency(1.999)).toBe("+$2.00");
+  });
+});
+
+describe("formatNumber", () => {
+  it("uses en-US separators for zero, negative, and large values", () => {
+    expect(formatNumber(0)).toBe("0");
+    expect(formatNumber(-1234)).toBe("-1,234");
+    expect(formatNumber(1234567.89)).toBe("1,234,567.89");
+  });
+});
+
+describe("formatChartValue", () => {
+  it("returns raw values below 1000", () => {
+    expect(formatChartValue(0)).toBe("0");
+    expect(formatChartValue(999)).toBe("999");
+    expect(formatChartValue(-1500)).toBe("-1500");
+  });
+
+  it("formats thousands with a k suffix", () => {
+    expect(formatChartValue(1000)).toBe("1k");
+    expect(formatChartValue(24000)).toBe("24k");
+    expect(formatChartValue(12500)).toBe("13k");
+    expect(formatChartValue(1234567)).toBe("1235k");
+  });
+});
+
+describe("truncateText", () => {
+  it("leaves empty, short, and exact-length strings unchanged", () => {
+    expect(truncateText("", 8)).toBe("");
+    expect(truncateText("abc", 8)).toBe("abc");
+    expect(truncateText("abcd", 4)).toBe("abcd");
+  });
+
+  it("truncates long address-like strings and appends an ellipsis", () => {
+    expect(truncateText("GABCDEFGHIJKLMNOPQRSTUVWXYZ", 8)).toBe("GABCDEFG...");
+    expect(truncateText("hello", 0)).toBe("...");
+  });
+});
+
+describe("capitalizeFirst", () => {
+  it("capitalizes mixed-case, lowercase, and single-letter values", () => {
+    expect(capitalizeFirst("pending")).toBe("Pending");
+    expect(capitalizeFirst("cOmPLETED")).toBe("Completed");
+    expect(capitalizeFirst("x")).toBe("X");
+  });
+
+  it("keeps empty strings empty", () => {
+    expect(capitalizeFirst("")).toBe("");
+  });
+});

--- a/utils/formatUtils.ts
+++ b/utils/formatUtils.ts
@@ -24,7 +24,7 @@ export const formatCurrency = (
  * @returns Formatted number string
  */
 export const formatNumber = (num: number): string => {
-  return num.toLocaleString();
+  return num.toLocaleString("en-US");
 };
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       reporter: ['text', 'json', 'html'],
       include: [
         'utils/authUtils.ts',
+        'utils/formatUtils.ts',
         'utils/transactionUtils.ts',
         'utils/paginationUtils.ts',
         'types/auth.ts',


### PR DESCRIPTION
Closes #295

## Summary
- Add `utils/formatUtils.test.ts` covering every export in `formatUtils.ts`.
- Cover zero, negative, large, fractional, short/exact/empty truncation, chart-value boundaries, and capitalization edge cases.
- Make `formatNumber` explicitly locale-stable with `en-US` separators.
- Include `utils/formatUtils.ts` in Vitest coverage so the 95% module coverage requirement is enforced.

## Verification
- `npm test` - 6 files / 106 tests passed, coverage summary 100%
- `npm run type-check`
- `npm run lint`

## Build note
- `npm run build` was attempted, but Next.js failed while fetching `Inter` from Google Fonts with network `ECONNRESET` / TLS disconnect errors. This is unrelated to the utils changes; no local TypeScript/lint/test failures remained.

## Security
No user input is rendered or executed. The formatting helpers now have malformed/boundary input coverage and locale-stable number formatting.