### PR TITLE
refactor(transactions): extract transaction defaults

### DIFF
--- a/components/transactions/transactions-config.ts
+++ b/components/transactions/transactions-config.ts
@@ -1,0 +1,14 @@
+/**
+ * Number of transactions shown on each transactions page and in matching
+ * loading skeleton rows.
+ */
+export const TRANSACTIONS_ITEMS_PER_PAGE = 6;
+
+/**
+ * Default date filters for the transactions view. Empty values intentionally
+ * leave the range unset so the data layer can include the available history.
+ */
+export const TRANSACTIONS_DEFAULT_DATE_RANGE = {
+  fromDate: "",
+  toDate: "",
+} as const;

--- a/components/transactions/transactions-content.test.tsx
+++ b/components/transactions/transactions-content.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import TransactionsContent from "./transactions-content";
+import { TransactionsTable } from "./transactions-table";
+import {
+  TRANSACTIONS_DEFAULT_DATE_RANGE,
+  TRANSACTIONS_ITEMS_PER_PAGE,
+} from "./transactions-config";
+
+const mockUseTransactions = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/useTransactions", () => ({
+  useTransactions: mockUseTransactions,
+}));
+
+vi.mock("./transactions-header", () => ({
+  default: () => <div data-testid="transactions-header" />,
+}));
+
+vi.mock("./transactions-filters", () => ({
+  default: () => <div data-testid="transactions-filters" />,
+}));
+
+vi.mock("./transactions-pagination", () => ({
+  default: () => <div data-testid="transactions-pagination" />,
+}));
+
+describe("TransactionsContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseTransactions.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
+  });
+
+  it("uses the shared transaction defaults for date range and page size", () => {
+    render(<TransactionsContent />);
+
+    expect(mockUseTransactions).toHaveBeenCalledWith({
+      filters: expect.objectContaining({
+        fromDate: TRANSACTIONS_DEFAULT_DATE_RANGE.fromDate,
+        toDate: TRANSACTIONS_DEFAULT_DATE_RANGE.toDate,
+      }),
+      page: 1,
+      pageSize: TRANSACTIONS_ITEMS_PER_PAGE,
+    });
+  });
+});
+
+describe("TransactionsTable loading rows", () => {
+  it("keeps desktop and mobile skeleton counts in sync with page size", () => {
+    render(<TransactionsTable transactions={[]} isLoading />);
+
+    expect(
+      screen.getAllByTestId("transaction-table-desktop-skeleton-row"),
+    ).toHaveLength(TRANSACTIONS_ITEMS_PER_PAGE);
+    expect(
+      screen.getAllByTestId("transaction-table-mobile-skeleton-row"),
+    ).toHaveLength(TRANSACTIONS_ITEMS_PER_PAGE);
+  });
+});

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -8,6 +8,10 @@ import TransactionsHeader from "./transactions-header";
 import TransactionsFilters from "./transactions-filters";
 import { TransactionsTable } from "./transactions-table";
 import TransactionsPagination from "./transactions-pagination";
+import {
+  TRANSACTIONS_DEFAULT_DATE_RANGE,
+  TRANSACTIONS_ITEMS_PER_PAGE,
+} from "./transactions-config";
 
 /** Map token symbol → icon path */
 const getTokenIcon = (token: string): string => {
@@ -37,19 +41,18 @@ const toTransactionProps = (t: Transaction): TransactionProps => ({
 export default function TransactionsContent() {
   const [filters, setFilters] = useState<TransactionFilters>({
     searchQuery: "",
-    fromDate: "2023-03-26",
-    toDate: "2023-04-15",
+    fromDate: TRANSACTIONS_DEFAULT_DATE_RANGE.fromDate,
+    toDate: TRANSACTIONS_DEFAULT_DATE_RANGE.toDate,
     selectedFilter: "All Transactions",
     sortField: "date",
     sortDirection: "desc",
   });
   const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 6;
 
   const { data, isLoading, error } = useTransactions({
     filters,
     page: currentPage,
-    pageSize: itemsPerPage,
+    pageSize: TRANSACTIONS_ITEMS_PER_PAGE,
   });
 
   const paginatedTransactions: TransactionProps[] = useMemo(
@@ -98,7 +101,9 @@ export default function TransactionsContent() {
 
           <div className="py-4">
             {/* Loading state */}
-            {isLoading && <TransactionTableSkeleton rows={itemsPerPage} />}
+            {isLoading && (
+              <TransactionTableSkeleton rows={TRANSACTIONS_ITEMS_PER_PAGE} />
+            )}
 
             {/* Error state */}
             {!isLoading && error && (
@@ -117,7 +122,7 @@ export default function TransactionsContent() {
                 <TransactionsPagination
                   totalItems={data?.total ?? 0}
                   currentPage={currentPage}
-                  itemsPerPage={itemsPerPage}
+                  itemsPerPage={TRANSACTIONS_ITEMS_PER_PAGE}
                   onPageChange={setCurrentPage}
                 />
               </>

--- a/components/transactions/transactions-table.tsx
+++ b/components/transactions/transactions-table.tsx
@@ -12,6 +12,7 @@ import { TransactionsTableProps } from "@/types/transaction";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TRANSACTIONS_ITEMS_PER_PAGE } from "./transactions-config";
 
 interface TransactionsTablePropsExtended extends TransactionsTableProps {
   isLoading?: boolean;
@@ -51,8 +52,12 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
           </TableHeader>
           <TableBody>
             {isLoading ? (
-              Array.from({ length: 6 }).map((_, index) => (
-                <TableRow key={`skeleton-${index}`} className="border border-[#2D2D2D]">
+              Array.from({ length: TRANSACTIONS_ITEMS_PER_PAGE }).map((_, index) => (
+                <TableRow
+                  key={`skeleton-${index}`}
+                  className="border border-[#2D2D2D]"
+                  data-testid="transaction-table-desktop-skeleton-row"
+                >
                   <TableCell className="font-medium border border-[#2D2D2D] py-4 px-6">
                     <Skeleton className="h-4 w-20 mb-1" />
                     <Skeleton className="h-3 w-16" />
@@ -128,8 +133,12 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
       {/* Mobile Cards */}
       <div className="md:hidden space-y-4">
         {isLoading ? (
-          Array.from({ length: 6 }).map((_, index) => (
-            <div key={`skeleton-mobile-${index}`} className="p-4 border rounded-lg border-[#2D2D2D]">
+          Array.from({ length: TRANSACTIONS_ITEMS_PER_PAGE }).map((_, index) => (
+            <div
+              key={`skeleton-mobile-${index}`}
+              className="p-4 border rounded-lg border-[#2D2D2D]"
+              data-testid="transaction-table-mobile-skeleton-row"
+            >
               <div className="flex justify-between items-start">
                 <div className="space-y-2">
                   <Skeleton className="h-4 w-32" />

--- a/utils/transactionUtils.test.ts
+++ b/utils/transactionUtils.test.ts
@@ -193,7 +193,15 @@ describe("filterTransactions", () => {
     ).toEqual(["april-sent"]);
   });
 
-  it("excludes every transaction for invalid or empty date ranges", () => {
+  it("ignores invalid or empty date bounds instead of excluding all rows", () => {
+    const allTransactionIds = [
+      "boundary-start",
+      "march-received",
+      "april-swap",
+      "april-sent",
+      "boundary-end",
+    ];
+
     expect(
       filterTransactions(
         transactions,
@@ -202,7 +210,7 @@ describe("filterTransactions", () => {
         "not-a-date",
         fixtureEndDate,
       ).map((transaction) => transaction.id),
-    ).toEqual([]);
+    ).toEqual(allTransactionIds);
     expect(
       filterTransactions(
         transactions,
@@ -211,12 +219,12 @@ describe("filterTransactions", () => {
         fixtureStartDate,
         "not-a-date",
       ).map((transaction) => transaction.id),
-    ).toEqual([]);
+    ).toEqual(allTransactionIds);
     expect(
       filterTransactions(transactions, "", "All Transactions", "", "").map(
         (transaction) => transaction.id,
       ),
-    ).toEqual([]);
+    ).toEqual(allTransactionIds);
     expect(
       filterTransactions(
         transactions,
@@ -225,7 +233,7 @@ describe("filterTransactions", () => {
         "",
         fixtureEndDate,
       ).map((transaction) => transaction.id),
-    ).toEqual([]);
+    ).toEqual(allTransactionIds);
     expect(
       filterTransactions(
         transactions,
@@ -234,7 +242,7 @@ describe("filterTransactions", () => {
         fixtureStartDate,
         "",
       ).map((transaction) => transaction.id),
-    ).toEqual([]);
+    ).toEqual(allTransactionIds);
     expect(
       filterTransactions(
         transactions,

--- a/utils/transactionUtils.ts
+++ b/utils/transactionUtils.ts
@@ -6,6 +6,13 @@ import type {
 import { formatCurrency } from "./formatUtils";
 import { formatDate } from "./dateUtils";
 
+const toValidDate = (dateStr: string): Date | null => {
+  if (!dateStr) return null;
+
+  const date = new Date(dateStr);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
 /**
  * Formats transaction amount with proper currency formatting
  * @param amount - The amount to format
@@ -63,10 +70,15 @@ export const filterTransactions = (
 
   // Filter by date range
   filtered = filtered.filter((transaction) => {
-    const transactionDate = new Date(transaction.date);
-    const from = new Date(fromDate);
-    const to = new Date(toDate);
-    return transactionDate >= from && transactionDate <= to;
+    const transactionDate = toValidDate(transaction.date);
+    const from = toValidDate(fromDate);
+    const to = toValidDate(toDate);
+
+    if (!transactionDate) return false;
+    if (from && transactionDate < from) return false;
+    if (to && transactionDate > to) return false;
+
+    return true;
   });
 
   return filtered;


### PR DESCRIPTION
## Summary

Extracts the transaction page defaults out of `transactions-content.tsx` so the default date range is unset instead of fixed to a stale 2023 window, and the page size is shared with loading skeleton rows.

## Changes

- Added documented transaction config constants for default date filters and `TRANSACTIONS_ITEMS_PER_PAGE`.
- Updated `TransactionsContent` to use the shared defaults for filters, API page size, skeleton rows, and pagination.
- Updated `TransactionsTable` loading skeleton rows to derive from the shared page-size source.
- Added Vitest coverage for content defaults and desktop/mobile skeleton-count parity.
- Hardened transaction date filtering so invalid or empty date bounds are treated as absent bounds instead of silently filtering out all valid rows.

## Testing/Verification

- `npx vitest run components/transactions/transactions-content.test.tsx utils/transactionUtils.test.ts` - passed, 2 files / 17 tests.
- `git diff --check` - passed.

Broader checks were attempted but are currently blocked by existing baseline issues outside this change:

- `npm run type-check` fails in `vitest.config.ts` on `css.postcss: false`.
- `npm run test` fails in existing PostCSS/localStorage test setup.
- `npm run build` compiles successfully, then fails lint/type validation on existing `components/analytics/analytics-view.test.tsx`.

## Related Issue

Closes https://github.com/Stellopay/stellopay-frontend/issues/346
