### PR TITLE
fix(a11y): add pressed state to toggle card

### DIFF
--- a/components/analytics/analytics-view.test.tsx
+++ b/components/analytics/analytics-view.test.tsx
@@ -29,7 +29,11 @@ vi.mock("recharts", () => {
       <div data-testid="x-axis" data-key={dataKey} />
     ),
     YAxis: () => <div data-testid="y-axis" />,
-    Tooltip: ({ content }: { content: React.ReactElement<any> }) => (
+    Tooltip: ({
+      content,
+    }: {
+      content: React.ReactElement<Record<string, unknown>>;
+    }) => (
       <div data-testid="tooltip">
         {React.cloneElement(content, {
           active: true,
@@ -70,7 +74,9 @@ describe("AnalyticsViews Component", () => {
 
   it("renders the loading skeleton when isLoading is true and showNotifications is false", () => {
     render(<AnalyticsViews isLoading={true} showNotifications={false} />);
-    expect(screen.getByText("Loading analytics views chart...")).toBeInTheDocument();
+    expect(
+      screen.getByText("Loading analytics views chart..."),
+    ).toBeInTheDocument();
   });
 
   it("renders the loading skeleton when isLoading is true and showNotifications is true", () => {
@@ -114,7 +120,7 @@ describe("AnalyticsViews Component", () => {
 
   it("handles year selector dropdown interactions", () => {
     render(<AnalyticsViews showDropdown={true} />);
-    
+
     // Toggle dropdown open
     const dropdownButton = screen.getByText("This Year");
     fireEvent.click(dropdownButton);
@@ -147,7 +153,9 @@ describe("ClientAnalyticsView Component", () => {
 
   it("renders default loading state when isLoading is true", () => {
     render(<ClientAnalyticsView isLoading={true} />);
-    expect(screen.getByText("Loading analytics views chart...")).toBeInTheDocument();
+    expect(
+      screen.getByText("Loading analytics views chart..."),
+    ).toBeInTheDocument();
   });
 
   it("renders notifications loading state when isLoading is true and showNotifications is true", () => {
@@ -157,10 +165,12 @@ describe("ClientAnalyticsView Component", () => {
 
   it("renders the loaded AnalyticsViews component after mounting", async () => {
     render(<ClientAnalyticsView />);
-    
+
     // After mounting, the loading state should disappear and the chart should appear
     await waitFor(() => {
-      expect(screen.queryByText("Loading analytics views chart...")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Loading analytics views chart..."),
+      ).not.toBeInTheDocument();
     });
     expect(screen.getByText("Analytics views")).toBeInTheDocument();
   });

--- a/components/common/toggle-card.test.tsx
+++ b/components/common/toggle-card.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+
+import ToggleCard from "./toggle-card";
+
+function ControlledToggleCard({
+  disabled = false,
+  onToggle = vi.fn(),
+}: {
+  disabled?: boolean;
+  onToggle?: (enabled: boolean) => void;
+}) {
+  const [enabled, setEnabled] = useState(false);
+
+  return (
+    <ToggleCard
+      title="Security alerts"
+      description="Receive critical security updates."
+      badge="Required"
+      enabled={enabled}
+      disabled={disabled}
+      onToggle={(nextEnabled) => {
+        setEnabled(nextEnabled);
+        onToggle(nextEnabled);
+      }}
+    />
+  );
+}
+
+describe("ToggleCard", () => {
+  it("exposes the current toggle state in ARIA attributes and label", () => {
+    render(<ControlledToggleCard />);
+
+    const toggle = screen.getByRole("button", {
+      name: "Security alerts is off",
+    });
+
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+    expect(toggle).toHaveAttribute("aria-label", "Security alerts is off");
+    expect(toggle).toHaveClass("focus-visible:ring-2");
+  });
+
+  it("flips aria-checked and aria-pressed when clicked", () => {
+    render(<ControlledToggleCard />);
+
+    const toggle = screen.getByRole("button", {
+      name: "Security alerts is off",
+    });
+    fireEvent.click(toggle);
+
+    expect(
+      screen.getByRole("button", { name: "Security alerts is on" }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("activates with Enter and Space", () => {
+    const onToggle = vi.fn();
+    render(<ControlledToggleCard onToggle={onToggle} />);
+
+    const toggle = screen.getByRole("button", {
+      name: "Security alerts is off",
+    });
+
+    fireEvent.keyDown(toggle, { key: "Enter" });
+    expect(onToggle).toHaveBeenLastCalledWith(true);
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.keyDown(toggle, { key: " " });
+    expect(onToggle).toHaveBeenLastCalledWith(false);
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("ignores unrelated keys", () => {
+    const onToggle = vi.fn();
+    render(<ControlledToggleCard onToggle={onToggle} />);
+
+    const toggle = screen.getByRole("button", {
+      name: "Security alerts is off",
+    });
+
+    fireEvent.keyDown(toggle, { key: "Escape" });
+
+    expect(onToggle).not.toHaveBeenCalled();
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("does not toggle while disabled", () => {
+    const onToggle = vi.fn();
+    render(<ControlledToggleCard disabled onToggle={onToggle} />);
+
+    const toggle = screen.getByRole("button", {
+      name: "Security alerts is off",
+    });
+
+    fireEvent.click(toggle);
+    fireEvent.keyDown(toggle, { key: "Enter" });
+
+    expect(toggle).toBeDisabled();
+    expect(onToggle).not.toHaveBeenCalled();
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("keeps rapid clicks aligned with the controlled value", () => {
+    render(<ControlledToggleCard />);
+
+    const toggle = screen.getByRole("button", {
+      name: "Security alerts is off",
+    });
+
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+    expect(toggle).toHaveAttribute("aria-label", "Security alerts is off");
+  });
+
+  it("renders optional badge and description only when provided", () => {
+    render(
+      <ToggleCard title="Payment notices" enabled={true} onToggle={vi.fn()} />,
+    );
+
+    const toggle = screen.getByRole("button", {
+      name: "Payment notices is on",
+    });
+
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+    expect(toggle.firstElementChild).toHaveClass("translate-x-6");
+    expect(screen.queryByText("Required")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Receive critical security updates."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/components/common/toggle-card.tsx
+++ b/components/common/toggle-card.tsx
@@ -3,7 +3,12 @@
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/utils/commonUtils";
 import { ToggleCardProps } from "@/types/ui";
+import type { KeyboardEvent } from "react";
 
+/**
+ * Renders a controlled preference toggle whose visual, button, and ARIA states
+ * all reflect the same `enabled` value.
+ */
 export default function ToggleCard({
   title,
   description,
@@ -12,6 +17,26 @@ export default function ToggleCard({
   disabled = false,
   onToggle,
 }: ToggleCardProps) {
+  const stateLabel = enabled ? "on" : "off";
+  const accessibleLabel = `${title} is ${stateLabel}`;
+
+  const handleToggle = () => {
+    if (disabled) {
+      return;
+    }
+
+    onToggle(!enabled);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== "Enter" && event.key !== " ") {
+      return;
+    }
+
+    event.preventDefault();
+    handleToggle();
+  };
+
   return (
     <div className="flex items-center justify-between gap-4 rounded-2xl border border-zinc-200/80 bg-white p-4 text-zinc-900 shadow-sm transition-all dark:border-white/10 dark:bg-white/5 dark:text-white">
       <div className="space-y-1">
@@ -34,11 +59,11 @@ export default function ToggleCard({
       </div>
       <button
         type="button"
-        role="switch"
-        aria-checked={enabled}
-        aria-label={title}
+        aria-pressed={enabled}
+        aria-label={accessibleLabel}
         disabled={disabled}
-        onClick={() => onToggle(!enabled)}
+        onClick={handleToggle}
+        onKeyDown={handleKeyDown}
         className={cn(
           "flex h-8 w-14 items-center rounded-full p-1 duration-300 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-white dark:focus-visible:ring-offset-[#09090B]",
           enabled

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,46 +1,49 @@
-import react from '@vitejs/plugin-react';
-import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'vitest/config';
+import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
 
-const repoRoot = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
   css: {
-    postcss: false,
+    postcss: {
+      plugins: [],
+    },
   },
   resolve: {
     alias: {
-      '@': repoRoot,
+      "@": repoRoot,
     },
   },
   test: {
     globals: true,
-    include: ['**/*.test.ts', '**/*.test.tsx'],
-    environment: 'jsdom',
-    setupFiles: './vitest.setup.ts',
+    include: ["**/*.test.ts", "**/*.test.tsx"],
+    environment: "jsdom",
+    setupFiles: "./vitest.setup.ts",
     coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      provider: "v8",
+      reporter: ["text", "json", "html"],
       include: [
-        'utils/authUtils.ts',
-        'utils/dateUtils.ts',
-        'utils/formatUtils.ts',
-        'utils/transactionUtils.ts',
-        'utils/paginationUtils.ts',
-        'types/auth.ts',
-        'app/global-error.tsx',
-        'context/wallet-context.tsx',
-        'components/analytics/analytics-view.tsx',
-        'components/analytics/client-analytics-view.tsx',
+        "utils/authUtils.ts",
+        "utils/dateUtils.ts",
+        "utils/formatUtils.ts",
+        "utils/transactionUtils.ts",
+        "utils/paginationUtils.ts",
+        "types/auth.ts",
+        "app/global-error.tsx",
+        "context/wallet-context.tsx",
+        "components/analytics/analytics-view.tsx",
+        "components/analytics/client-analytics-view.tsx",
+        "components/common/toggle-card.tsx",
       ],
       exclude: [
-        '**/*.test.{ts,tsx}',
-        '**/*.spec.{ts,tsx}',
-        '**/*.config.*',
-        'vitest.config.ts',
-        'tests/**',
-        'vitest.setup.ts',
+        "**/*.test.{ts,tsx}",
+        "**/*.spec.{ts,tsx}",
+        "**/*.config.*",
+        "vitest.config.ts",
+        "tests/**",
+        "vitest.setup.ts",
       ],
       thresholds: {
         lines: 95,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,52 @@
-import '@testing-library/jest-dom/vitest';
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+const mockFont = () => ({
+  className: "mock-font",
+  variable: "mock-font-variable",
+  style: {},
+});
+
+vi.mock("next/font/google", () => ({
+  Inter: mockFont,
+}));
+
+vi.mock("next/font/local", () => ({
+  default: mockFont,
+}));
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => {
+      store.clear();
+    },
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+  };
+}
+
+if (typeof window !== "undefined") {
+  const storage = window.localStorage;
+
+  if (
+    typeof storage?.clear !== "function" ||
+    typeof storage?.getItem !== "function" ||
+    typeof storage?.setItem !== "function"
+  ) {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createMemoryStorage(),
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #345.
- Updates `ToggleCard` to expose a state-aware `aria-pressed` value and accessible label.
- Adds explicit Space/Enter activation coverage for the toggle control.

## Changes
- Use a native pressed-button pattern with `aria-pressed` and labels like `Security alerts is on/off`.
- Keep visual state, disabled behavior, and ARIA state aligned with the controlled `enabled` prop.
- Add Vitest coverage for click, keyboard activation, disabled state, rapid toggles, optional rendering, and focus styling.
- Include `toggle-card.tsx` in coverage and stabilize Vitest setup for Next font/localStorage test environments.

## Testing/Verification
- `npm exec -- vitest run components/common/toggle-card.test.tsx`
- `npm exec -- vitest run components/common/toggle-card.test.tsx --coverage --coverage.include=components/common/toggle-card.tsx`
- `npm run test`
- `npm run lint`
- `npm run type-check`
- `npm run build`

## Security
- Toggle state remains controlled by the `enabled` prop, so visual and ARIA state are derived from the same source.
- Disabled toggles ignore click and keyboard activation, preventing misleading preference state changes.

Related issue: https://github.com/Stellopay/stellopay-frontend/issues/345