### PR TITLE
fix(verify-email): label and validate code input

### DIFF
--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -6,16 +6,52 @@ import { X, Loader2 } from "lucide-react";
 
 type StatusType = "idle" | "loading" | "success" | "error";
 
+const CODE_INPUT_ID = "verification-code";
+const CODE_HELP_ID = "verification-code-help";
+const CODE_FEEDBACK_ID = "verification-code-feedback";
+
 export default function VerifyEmail() {
   const [code, setCode] = useState("");
   const router = useRouter();
   const [status, setStatus] = useState<StatusType>("idle");
   const [message, setMessage] = useState("");
   const [resendStatus, setResendStatus] = useState<StatusType>("idle");
+  const [codeFeedback, setCodeFeedback] = useState("");
+
+  const updateCode = (rawValue: string) => {
+    const numericValue = rawValue.replace(/\D/g, "");
+    const nextCode = numericValue.slice(0, 6);
+
+    setCode(nextCode);
+
+    if (rawValue !== numericValue) {
+      setCodeFeedback("Use numbers only for the verification code.");
+    } else if (numericValue.length > 6) {
+      setCodeFeedback("Verification codes are 6 digits. Extra digits were ignored.");
+    } else if (nextCode.length > 0 && nextCode.length < 6) {
+      setCodeFeedback("Enter all 6 digits.");
+    } else {
+      setCodeFeedback("");
+    }
+
+    if (status === "error") {
+      setStatus("idle");
+      setMessage("");
+    }
+  };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/[^0-9a-zA-Z]/g, "");
-    if (value.length <= 6) setCode(value);
+    updateCode(e.target.value);
+  };
+
+  const handleInputPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    const pastedText = e.clipboardData.getData("text");
+    const numericValue = pastedText.replace(/\D/g, "");
+
+    if (numericValue.length > 6 || pastedText !== numericValue) {
+      e.preventDefault();
+      updateCode(pastedText);
+    }
   };
 
   const handleResend = async () => {
@@ -51,10 +87,17 @@ export default function VerifyEmail() {
     } catch {
       setStatus("error");
       setMessage("Invalid verification code. Please try again.");
+      setCodeFeedback("Invalid verification code. Please try again.");
     } finally {
       setTimeout(() => setStatus("idle"), 3000);
     }
   };
+
+  const codeDescribedBy = codeFeedback
+    ? `${CODE_HELP_ID} ${CODE_FEEDBACK_ID}`
+    : CODE_HELP_ID;
+  const codeHasError =
+    (codeFeedback.length > 0 && code.length !== 6) || status === "error";
 
   return (
     <div className="min-h-screen flex items-center justify-center px-4 relative">
@@ -89,15 +132,47 @@ export default function VerifyEmail() {
         </p>
 
         {/* Input */}
-        <input
-          type="text"
-          inputMode="numeric"
-          maxLength={6}
-          value={code}
-          onChange={handleInputChange}
-          className="w-full text-left py-3 px-4 rounded-[8px] border border-[#2D2D2D] bg-transparent text-white mb-4 outline-none mt-5"
-          placeholder="- - - - - - - -"
-        />
+        <div className="mt-5 space-y-2 text-left">
+          <label
+            htmlFor={CODE_INPUT_ID}
+            className="block text-sm font-medium text-white"
+          >
+            Verification code
+          </label>
+          <p id={CODE_HELP_ID} className="text-xs text-[#ACB4B5]">
+            Enter the 6-digit code sent to your email.
+          </p>
+          <input
+            id={CODE_INPUT_ID}
+            name="verificationCode"
+            type="text"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            pattern="[0-9]{6}"
+            maxLength={6}
+            required
+            aria-label="Verification code"
+            aria-describedby={codeDescribedBy}
+            aria-invalid={codeHasError}
+            value={code}
+            onChange={handleInputChange}
+            onPaste={handleInputPaste}
+            className="w-full rounded-[8px] border border-[#2D2D2D] bg-transparent px-4 py-3 text-left text-white outline-none focus:border-[#F8D2FE]"
+            placeholder="- - - - - -"
+          />
+          {codeFeedback && (
+            <p
+              id={CODE_FEEDBACK_ID}
+              role="status"
+              aria-live="polite"
+              className={`text-xs ${
+                codeHasError ? "text-red-300" : "text-[#ACB4B5]"
+              }`}
+            >
+              {codeFeedback}
+            </p>
+          )}
+        </div>
 
         {/* Status Messages */}
         {message && (

--- a/tests/verify-email.spec.ts
+++ b/tests/verify-email.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Verify email code input", () => {
+  test("code input is labeled, described, and validates while typing", async ({
+    page,
+  }) => {
+    await page.goto("/verify-email");
+
+    const codeInput = page.getByLabel("Verification code");
+
+    await expect(codeInput).toBeVisible();
+    await expect(codeInput).toHaveAttribute("id", "verification-code");
+    await expect(codeInput).toHaveAttribute("name", "verificationCode");
+    await expect(codeInput).toHaveAttribute(
+      "aria-describedby",
+      /verification-code-help/,
+    );
+    await expect(codeInput).toHaveAttribute("required", "");
+
+    await codeInput.fill("12");
+    await expect(page.getByText("Enter all 6 digits.")).toBeVisible();
+    await expect(codeInput).toHaveAttribute("aria-invalid", "true");
+
+    await codeInput.fill("123456");
+    await expect(codeInput).toHaveValue("123456");
+    await expect(codeInput).toHaveAttribute("aria-invalid", "false");
+  });
+
+  test("code input filters non-numeric input and reports truncated paste", async ({
+    page,
+  }) => {
+    await page.goto("/verify-email");
+
+    const codeInput = page.getByLabel("Verification code");
+
+    await codeInput.fill("abc");
+    await expect(codeInput).toHaveValue("");
+    await expect(
+      page.getByText("Use numbers only for the verification code."),
+    ).toBeVisible();
+
+    await codeInput.focus();
+    await codeInput.evaluate((input) => {
+      const clipboard = new DataTransfer();
+      clipboard.setData("text/plain", "123456789");
+      input.dispatchEvent(
+        new ClipboardEvent("paste", {
+          bubbles: true,
+          cancelable: true,
+          clipboardData: clipboard,
+        }),
+      );
+    });
+
+    await expect(codeInput).toHaveValue("123456");
+    await expect(
+      page.getByText("Verification codes are 6 digits. Extra digits were ignored."),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #329

## Summary
- add an explicit label, id, name, required state, one-time-code autocomplete, and aria-describedby/aria-invalid wiring to the verify-email code input
- restrict the code field to numeric input, provide inline feedback while typing, and report when pasted input is filtered or truncated to six digits
- add Playwright coverage for the labeled input, inline validation, non-numeric filtering, and too-long paste feedback

## Validation
- verified the fork compare against upstream main contains only `app/verify-email/page.tsx` and `tests/verify-email.spec.ts`
- static checks confirmed the required id/name/label/aria attributes, numeric filtering, paste handling, inline feedback, Playwright assertions, and no payout/wallet details in the submitted files
- `npx playwright test tests/verify-email.spec.ts` was not run locally because this desktop has no Node/npm runtime configured on PATH

## Security
- the code field accepts only digits and never logs the entered verification code
- no real user data, credentials, payout details, or wallet addresses are included