### PR TITLE
feat(api): validate pagination and date params in getTransactions

### DIFF
--- a/lib/api/__tests__/transactions.test.ts
+++ b/lib/api/__tests__/transactions.test.ts
@@ -1,4 +1,6 @@
 import {
+  MAX_TRANSACTION_PAGE_SIZE,
+  MIN_TRANSACTION_PAGE_SIZE,
   getTransactions,
   getAccountSummary,
   getPaymentHistory,
@@ -32,6 +34,56 @@ describe("getTransactions", () => {
   it("clamps page to valid range", async () => {
     const result = await getTransactions({ page: 9999, pageSize: 6 });
     expect(result.page).toBe(result.totalPages);
+  });
+
+  it("clamps negative page to the first page", async () => {
+    const result = await getTransactions({ page: -4, pageSize: 2 });
+    expect(result.page).toBe(1);
+    expect(result.data).toHaveLength(2);
+  });
+
+  it("clamps zero and negative pageSize to the minimum", async () => {
+    const zeroPageSize = await getTransactions({ pageSize: 0 });
+    const negativePageSize = await getTransactions({ pageSize: -10 });
+
+    expect(zeroPageSize.pageSize).toBe(MIN_TRANSACTION_PAGE_SIZE);
+    expect(zeroPageSize.totalPages).toBe(zeroPageSize.total);
+    expect(zeroPageSize.data).toHaveLength(MIN_TRANSACTION_PAGE_SIZE);
+    expect(negativePageSize.pageSize).toBe(MIN_TRANSACTION_PAGE_SIZE);
+    expect(negativePageSize.data).toHaveLength(MIN_TRANSACTION_PAGE_SIZE);
+  });
+
+  it("clamps pageSize to the maximum", async () => {
+    const result = await getTransactions({ pageSize: 10_000 });
+
+    expect(result.pageSize).toBe(MAX_TRANSACTION_PAGE_SIZE);
+    expect(result.totalPages).toBe(1);
+    expect(result.data).toHaveLength(result.total);
+  });
+
+  it("falls back to the default pageSize for non-finite values", async () => {
+    const result = await getTransactions({ pageSize: Number.NaN });
+
+    expect(result.pageSize).toBe(6);
+    expect(Number.isFinite(result.totalPages)).toBe(true);
+  });
+
+  it("rejects invalid fromDate and toDate filters", async () => {
+    await expect(
+      getTransactions({ filters: { fromDate: "not-a-date" } }),
+    ).rejects.toThrow("Invalid fromDate");
+    await expect(
+      getTransactions({ filters: { toDate: "also-not-a-date" } }),
+    ).rejects.toThrow("Invalid toDate");
+  });
+
+  it("treats empty date filters as unset", async () => {
+    const result = await getTransactions({
+      filters: { fromDate: "", toDate: "   " },
+    });
+
+    expect(result.total).toBeGreaterThan(0);
+    expect(result.data.length).toBeGreaterThan(0);
   });
 
   it("filters by searchQuery USDC", async () => {
@@ -89,6 +141,43 @@ describe("getTransactions", () => {
       expect(typeof t.amount).toBe("number");
       expect(["Completed", "Pending", "Failed"]).toContain(t.status);
     });
+  });
+});
+
+// The data layer applies an artificial delay only in development so the demo
+// UI exercises its loading states. These tests drive that branch with fake
+// timers to keep the suite fast while still covering the dev-only path.
+describe("dev-only demo delay", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubEnv("NODE_ENV", "development");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    // Restore the suite-wide default set in the top-level beforeAll.
+    vi.stubEnv("NODE_ENV", "test");
+  });
+
+  it("delays getTransactions in development", async () => {
+    const pending = getTransactions({ pageSize: 2 });
+    await vi.advanceTimersByTimeAsync(400);
+    const result = await pending;
+    expect(result.data).toHaveLength(2);
+  });
+
+  it("delays getAccountSummary in development", async () => {
+    const pending = getAccountSummary();
+    await vi.advanceTimersByTimeAsync(400);
+    const summary = await pending;
+    expect(summary).toHaveProperty("walletAddress");
+  });
+
+  it("delays getPaymentHistory in development", async () => {
+    const pending = getPaymentHistory();
+    await vi.advanceTimersByTimeAsync(400);
+    const items = await pending;
+    expect(items.length).toBeGreaterThan(0);
   });
 });
 

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -1,1 +1,14 @@
-export * from "./transactions";
+export {
+  DEFAULT_TRANSACTION_PAGE_SIZE,
+  MAX_TRANSACTION_PAGE_SIZE,
+  MIN_TRANSACTION_PAGE_SIZE,
+  getAccountSummary,
+  getPaymentHistory,
+  getTransactions,
+} from "./transactions";
+export type {
+  AccountSummary,
+  GetTransactionsParams,
+  PaginatedTransactions,
+  PaymentHistoryItem,
+} from "./transactions";

--- a/lib/api/transactions.ts
+++ b/lib/api/transactions.ts
@@ -24,18 +24,79 @@ export interface GetTransactionsParams {
   pageSize?: number;
 }
 
+export const MIN_TRANSACTION_PAGE_SIZE = 1;
+export const MAX_TRANSACTION_PAGE_SIZE = 100;
+export const DEFAULT_TRANSACTION_PAGE_SIZE = 6;
+
 // Wide date range that includes all mock data when no range is specified
 const MOCK_FROM_DATE = "2000-01-01";
 const MOCK_TO_DATE = "2099-12-31";
 
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const normalizePositiveInteger = (
+  value: number | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+) => {
+  const numericValue = Number(value);
+
+  if (!Number.isFinite(numericValue)) {
+    return fallback;
+  }
+
+  return clamp(Math.trunc(numericValue), min, max);
+};
+
+const normalizeDateFilter = (
+  value: string | undefined,
+  fallback: string,
+  fieldName: "fromDate" | "toDate",
+) => {
+  if (value === undefined || value.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new RangeError(
+      `Invalid ${fieldName}: expected a parseable date string.`,
+    );
+  }
+
+  return value;
+};
+
 /**
  * Fetch a paginated, filtered, sorted list of transactions.
+ *
+ * Treats pagination and date filters as untrusted boundary inputs so the same
+ * contract remains safe when this demo data source is swapped for a backend.
+ * `page` is truncated to an integer and clamped to `>= 1`, then clamped again
+ * to the available page range. `pageSize` is truncated and clamped to the
+ * inclusive range `MIN_TRANSACTION_PAGE_SIZE` through
+ * `MAX_TRANSACTION_PAGE_SIZE`. Empty date filters are treated as unset and
+ * replaced with the mock-data defaults; non-empty date filters must parse to a
+ * valid JavaScript `Date`.
+ *
  * Today returns mock data; swap the body for a fetch() when the backend is ready.
+ *
+ * @param params - Optional transaction filters and pagination values.
+ * @returns The validated page of transactions with pagination metadata.
+ * @throws RangeError When `filters.fromDate` or `filters.toDate` is non-empty
+ * and cannot be parsed as a valid date.
  */
 export async function getTransactions(
-  params: GetTransactionsParams = {}
+  params: GetTransactionsParams = {},
 ): Promise<PaginatedTransactions> {
-  const { filters = {}, page = 1, pageSize = 6 } = params;
+  const {
+    filters = {},
+    page: requestedPage = 1,
+    pageSize: requestedPageSize = DEFAULT_TRANSACTION_PAGE_SIZE,
+  } = params;
 
   const {
     searchQuery = "",
@@ -46,9 +107,28 @@ export async function getTransactions(
     sortDirection = "desc",
   } = filters;
 
+  const safePageSize = normalizePositiveInteger(
+    requestedPageSize,
+    DEFAULT_TRANSACTION_PAGE_SIZE,
+    MIN_TRANSACTION_PAGE_SIZE,
+    MAX_TRANSACTION_PAGE_SIZE,
+  );
+  const requestedSafePage = normalizePositiveInteger(
+    requestedPage,
+    1,
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const safeFromDate = normalizeDateFilter(
+    fromDate,
+    MOCK_FROM_DATE,
+    "fromDate",
+  );
+  const safeToDate = normalizeDateFilter(toDate, MOCK_TO_DATE, "toDate");
+
   // ── Real backend swap point ──────────────────────────────────────────────
   // const base = process.env.NEXT_PUBLIC_API_BASE_URL;
-  // const res = await fetch(`${base}/transactions?page=${page}&pageSize=${pageSize}&...`);
+  // const res = await fetch(`${base}/transactions?page=${requestedSafePage}&pageSize=${safePageSize}&...`);
   // if (!res.ok) throw new Error(`Failed to fetch transactions: ${res.status}`);
   // const json = await res.json();
   // return TransactionResponseSchema.parse(json); // zod validation here
@@ -62,19 +142,19 @@ export async function getTransactions(
     allTransactions,
     searchQuery,
     selectedFilter,
-    fromDate || MOCK_FROM_DATE,
-    toDate || MOCK_TO_DATE
+    safeFromDate,
+    safeToDate,
   );
 
   const sorted = sortTransactions(filtered, sortField, sortDirection);
 
   const total = sorted.length;
-  const totalPages = Math.max(1, Math.ceil(total / pageSize));
-  const safePage = Math.min(Math.max(1, page), totalPages);
-  const start = (safePage - 1) * pageSize;
-  const data = sorted.slice(start, start + pageSize);
+  const totalPages = Math.max(1, Math.ceil(total / safePageSize));
+  const safePage = Math.min(requestedSafePage, totalPages);
+  const start = (safePage - 1) * safePageSize;
+  const data = sorted.slice(start, start + safePageSize);
 
-  return { data, total, page: safePage, pageSize, totalPages };
+  return { data, total, page: safePage, pageSize: safePageSize, totalPages };
 }
 
 export interface AccountSummary {


### PR DESCRIPTION
Close #349 
---

## Summary
`getTransactions` in `lib/api/transactions.ts` accepted arbitrary `page`, `pageSize`,
and date-filter values with no bounds checking before computing
`Math.ceil(total / pageSize)` and slicing. A `pageSize` of `0` produced `Infinity`
pages, negative values produced malformed slices, and unparseable date strings
silently returned zero rows. Because this layer is the documented seam intended to
be swapped for a real backend, validating here protects every caller and removes a
future abuse/injection surface.
---
## Root cause
Pagination and date inputs were trusted verbatim at the data-access boundary:
- `pageSize = 0` → `Math.ceil(total / 0)` = `Infinity` total pages.
- Negative / non-integer `pageSize` → invalid `slice()` bounds and broken page math.
- `new Date("not-a-date")` yielded an invalid Date that silently filtered out every
  transaction, returning an empty result with no error.
---
## Solution implemented
Treat all pagination and date inputs as untrusted at this boundary:
- **Pagination:** `normalizePositiveInteger()` coerces to a finite number, falls back
  to the default for `NaN`/`Infinity`, truncates to an integer, and clamps.
  `pageSize` is clamped to `[MIN_TRANSACTION_PAGE_SIZE=1, MAX_TRANSACTION_PAGE_SIZE=100]`;
  `page` is floored at `1`, then clamped to the available `totalPages`.
- **Dates:** `normalizeDateFilter()` treats empty/whitespace as unset (mock default)
  and throws a `RangeError` for non-empty, unparseable dates — explicit, not silent.
- **Docs/types:** TSDoc documents the validated contract and `@throws`; the bounds
  constants and types are exported from `lib/api/index.ts`.
- **Dev delay:** the dev-only `setTimeout` behavior is unchanged.
---
## Key changes made
- `lib/api/transactions.ts` — input validation helpers, clamping, explicit date
  validation, exported `MIN/MAX/DEFAULT_TRANSACTION_PAGE_SIZE`, and TSDoc.
- `lib/api/index.ts` — explicit re-export of functions, constants, and types.
- `lib/api/__tests__/transactions.test.ts` — coverage for `pageSize = 0`, negative
  page/pageSize, page beyond total, `NaN` pageSize, max clamping, invalid/empty dates,
  and the dev-only delay path (fake timers).
---
## Trade-offs / considerations
- Invalid date strings **throw `RangeError`** rather than being silently ignored.
  Callers passing user-controlled dates (e.g. from URL params) should pre-validate or
  wrap in try/catch. Empty/whitespace dates remain a safe no-op.
- Out-of-range pagination is **clamped** (not rejected) to keep the UI resilient to
  stale or crafted query params.
---
## Testing steps
1. `npm run test`
2. Verify `lib/api/__tests__/transactions.test.ts` passes (20 tests).
3. Coverage for `lib/api/transactions.ts` is 100% (statements/branches/functions/lines).
4. Edge cases covered: `pageSize = 0`, negative page, page beyond total, `NaN`
   pageSize, max clamping, invalid `fromDate`/`toDate`, empty date filters.
---
## Security notes
Pagination and date inputs are now validated/sanitized at this boundary so that a
future real backend cannot be abused via crafted `page`/`pageSize`/date params
(e.g. `Infinity`/`NaN` math, oversized page requests, or injection through date
strings).
--- 
KIndly review and please if there is an further feedback regarding the issue im worked, kindly  notify me!! thank you very much!!