### PR TITLE
refactor(transactions): share page size and default filters

### DIFF
--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -9,14 +9,18 @@ import Filter from "@/components/transactions/filter";
 import Sort from "@/components/transactions/sort";
 import { TransactionTableSkeleton } from "@/components/ui/table-skeleton";
 import { useTransactions } from "@/hooks/useTransactions";
+import { TRANSACTIONS_PAGE_SIZE } from "@/lib/transactionDefaults";
 import type { TransactionProps } from "@/types/transaction";
 import { isDateInRange } from "@/utils/dateUtils";
 
 const getTokenIcon = (token: string): string => {
   switch (token) {
-    case "USDC": return "/usdc-logo.png";
-    case "XLM":  return "/stellar-xlm-logo.png";
-    default:     return "/usd.png";
+    case "USDC":
+      return "/usdc-logo.png";
+    case "XLM":
+      return "/stellar-xlm-logo.png";
+    default:
+      return "/usd.png";
   }
 };
 
@@ -25,7 +29,6 @@ const Transactions = () => {
   const [searchParams, setSearchParams] = useState("");
   const [startDate, setStartDate] = useState<Date | undefined>(undefined);
   const [endDate, setEndDate] = useState<Date | undefined>(undefined);
-  const itemsPerPage = 6;
 
   // Reset to page 1 whenever filters change
   useEffect(() => {
@@ -56,13 +59,14 @@ const Transactions = () => {
   }, [data]);
 
   const dateFiltered = useMemo(
-    () => allTransactions.filter((t) => isDateInRange(t.date, startDate, endDate)),
-    [allTransactions, startDate, endDate]
+    () =>
+      allTransactions.filter((t) => isDateInRange(t.date, startDate, endDate)),
+    [allTransactions, startDate, endDate],
   );
 
   const paginated = useMemo(() => {
-    const start = (currentPage - 1) * itemsPerPage;
-    return dateFiltered.slice(start, start + itemsPerPage);
+    const start = (currentPage - 1) * TRANSACTIONS_PAGE_SIZE;
+    return dateFiltered.slice(start, start + TRANSACTIONS_PAGE_SIZE);
   }, [dateFiltered, currentPage]);
 
   return (
@@ -79,11 +83,40 @@ const Transactions = () => {
         <div className="bg-foreground border rounded-[1.5rem] border-[#2D2D2D] p-2">
           <div className="grid items-center justify-between pb-2 md:pb-0 md:flex">
             <h1 className="flex items-center gap-1 p-2 mb-4 text-xl font-medium">
-              <div className="bg-[#121212] rounded-lg border border-[#2E2E2E] p-1" aria-hidden="true">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-                  <path d="M18.9999 10.5V9.99995C18.9999 6.22876 18.9998 4.34311 17.8283 3.17154C16.6567 2 14.7711 2 10.9999 2C7.22883 2 5.3432 2.00006 4.17163 3.17159C3.00009 4.34315 3.00007 6.22872 3.00004 9.99988L3 14.5C2.99997 17.7874 2.99996 19.4312 3.90788 20.5375C4.07412 20.7401 4.25986 20.9258 4.46243 21.0921C5.56877 22 7.21249 22 10.4999 22" stroke="#E5E5E5" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                  <path d="M7 7H15M7 11H11" stroke="#E5E5E5" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                  <path d="M18 18.5L16.5 17.95V15.5M12 17.5C12 19.9853 14.0147 22 16.5 22C18.9853 22 21 19.9853 21 17.5C21 15.0147 18.9853 13 16.5 13C14.0147 13 12 15.0147 12 17.5Z" stroke="#E5E5E5" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+              <div
+                className="bg-[#121212] rounded-lg border border-[#2E2E2E] p-1"
+                aria-hidden="true"
+              >
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <path
+                    d="M18.9999 10.5V9.99995C18.9999 6.22876 18.9998 4.34311 17.8283 3.17154C16.6567 2 14.7711 2 10.9999 2C7.22883 2 5.3432 2.00006 4.17163 3.17159C3.00009 4.34315 3.00007 6.22872 3.00004 9.99988L3 14.5C2.99997 17.7874 2.99996 19.4312 3.90788 20.5375C4.07412 20.7401 4.25986 20.9258 4.46243 21.0921C5.56877 22 7.21249 22 10.4999 22"
+                    stroke="#E5E5E5"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M7 7H15M7 11H11"
+                    stroke="#E5E5E5"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M18 18.5L16.5 17.95V15.5M12 17.5C12 19.9853 14.0147 22 16.5 22C18.9853 22 21 19.9853 21 17.5C21 15.0147 18.9853 13 16.5 13C14.0147 13 12 15.0147 12 17.5Z"
+                    stroke="#E5E5E5"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
                 </svg>
               </div>
               <span>All Transactions</span>
@@ -102,7 +135,9 @@ const Transactions = () => {
           </div>
 
           {/* Loading state */}
-          {isLoading && <TransactionTableSkeleton rows={itemsPerPage} />}
+          {isLoading && (
+            <TransactionTableSkeleton rows={TRANSACTIONS_PAGE_SIZE} />
+          )}
 
           {/* Error state */}
           {!isLoading && error && (
@@ -115,11 +150,16 @@ const Transactions = () => {
           {!isLoading && !error && (
             <>
               <TransactionsTable transactions={paginated} />
-              {(searchParams || startDate || endDate) && paginated.length === 0 && (
-                <div role="status" aria-live="polite" className="py-4 text-center text-gray-400">
-                  No Transactions Found
-                </div>
-              )}
+              {(searchParams || startDate || endDate) &&
+                paginated.length === 0 && (
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    className="py-4 text-center text-gray-400"
+                  >
+                    No Transactions Found
+                  </div>
+                )}
             </>
           )}
         </div>
@@ -129,7 +169,7 @@ const Transactions = () => {
         <TransactionsPagination
           totalItems={dateFiltered.length}
           currentPage={currentPage}
-          itemsPerPage={itemsPerPage}
+          itemsPerPage={TRANSACTIONS_PAGE_SIZE}
           onPageChange={setCurrentPage}
         />
       )}

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -1,9 +1,18 @@
 "use client";
 
 import { useState, useMemo, useCallback } from "react";
-import type { SortField, TransactionFilters, Transaction, TransactionProps } from "@/types/transaction";
+import type {
+  SortField,
+  TransactionFilters,
+  Transaction,
+  TransactionProps,
+} from "@/types/transaction";
 import { useTransactions } from "@/hooks/useTransactions";
 import { TransactionTableSkeleton } from "@/components/ui/table-skeleton";
+import {
+  DEFAULT_TRANSACTION_FILTERS,
+  TRANSACTIONS_PAGE_SIZE,
+} from "@/lib/transactionDefaults";
 import TransactionsHeader from "./transactions-header";
 import TransactionsFilters from "./transactions-filters";
 import { TransactionsTable } from "./transactions-table";
@@ -12,9 +21,12 @@ import TransactionsPagination from "./transactions-pagination";
 /** Map token symbol → icon path */
 const getTokenIcon = (token: string): string => {
   switch (token) {
-    case "USDC": return "/usdc-logo.png";
-    case "XLM":  return "/stellar-xlm-logo.png";
-    default:     return "/usd.png";
+    case "USDC":
+      return "/usdc-logo.png";
+    case "XLM":
+      return "/stellar-xlm-logo.png";
+    default:
+      return "/usd.png";
   }
 };
 
@@ -36,33 +48,30 @@ const toTransactionProps = (t: Transaction): TransactionProps => ({
 
 export default function TransactionsContent() {
   const [filters, setFilters] = useState<TransactionFilters>({
-    searchQuery: "",
-    fromDate: "2023-03-26",
-    toDate: "2023-04-15",
-    selectedFilter: "All Transactions",
-    sortField: "date",
-    sortDirection: "desc",
+    ...DEFAULT_TRANSACTION_FILTERS,
   });
   const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 6;
 
   const { data, isLoading, error } = useTransactions({
     filters,
     page: currentPage,
-    pageSize: itemsPerPage,
+    pageSize: TRANSACTIONS_PAGE_SIZE,
   });
 
   const paginatedTransactions: TransactionProps[] = useMemo(
     () => (data?.data ?? []).map(toTransactionProps),
-    [data]
+    [data],
   );
 
   const updateFilter = useCallback(
-    <K extends keyof TransactionFilters>(key: K, value: TransactionFilters[K]) => {
+    <K extends keyof TransactionFilters>(
+      key: K,
+      value: TransactionFilters[K],
+    ) => {
       setFilters((prev) => ({ ...prev, [key]: value }));
       setCurrentPage(1);
     },
-    []
+    [],
   );
 
   const handleSort = useCallback((field: SortField) => {
@@ -70,7 +79,9 @@ export default function TransactionsContent() {
       ...prev,
       sortField: field,
       sortDirection:
-        prev.sortField === field && prev.sortDirection === "asc" ? "desc" : "asc",
+        prev.sortField === field && prev.sortDirection === "asc"
+          ? "desc"
+          : "asc",
     }));
     setCurrentPage(1);
   }, []);
@@ -98,7 +109,9 @@ export default function TransactionsContent() {
 
           <div className="py-4">
             {/* Loading state */}
-            {isLoading && <TransactionTableSkeleton rows={itemsPerPage} />}
+            {isLoading && (
+              <TransactionTableSkeleton rows={TRANSACTIONS_PAGE_SIZE} />
+            )}
 
             {/* Error state */}
             {!isLoading && error && (
@@ -117,7 +130,7 @@ export default function TransactionsContent() {
                 <TransactionsPagination
                   totalItems={data?.total ?? 0}
                   currentPage={currentPage}
-                  itemsPerPage={itemsPerPage}
+                  itemsPerPage={TRANSACTIONS_PAGE_SIZE}
                   onPageChange={setCurrentPage}
                 />
               </>

--- a/components/transactions/transactions-table.test.tsx
+++ b/components/transactions/transactions-table.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_TRANSACTION_FILTERS,
+  TRANSACTIONS_PAGE_SIZE,
+} from "@/lib/transactionDefaults";
+import { TransactionsTable } from "./transactions-table";
+
+vi.mock("next/image", () => ({
+  default: () => null,
+}));
+
+describe("transaction display defaults", () => {
+  it("starts with an unset date range instead of a stale fixed window", () => {
+    expect(DEFAULT_TRANSACTION_FILTERS.fromDate).toBe("");
+    expect(DEFAULT_TRANSACTION_FILTERS.toDate).toBe("");
+    expect(DEFAULT_TRANSACTION_FILTERS.fromDate).not.toBe("2023-03-26");
+    expect(DEFAULT_TRANSACTION_FILTERS.toDate).not.toBe("2023-04-15");
+  });
+});
+
+describe("TransactionsTable loading skeleton", () => {
+  it("uses the shared transaction page size for desktop and mobile skeleton rows", () => {
+    render(<TransactionsTable transactions={[]} isLoading />);
+
+    expect(
+      screen.getAllByTestId("transaction-table-skeleton-row"),
+    ).toHaveLength(TRANSACTIONS_PAGE_SIZE);
+    expect(screen.getAllByTestId("transaction-card-skeleton")).toHaveLength(
+      TRANSACTIONS_PAGE_SIZE,
+    );
+  });
+
+  it("keeps desktop and mobile skeleton counts in sync when a row count is supplied", () => {
+    render(<TransactionsTable transactions={[]} isLoading skeletonRows={3} />);
+
+    expect(
+      screen.getAllByTestId("transaction-table-skeleton-row"),
+    ).toHaveLength(3);
+    expect(screen.getAllByTestId("transaction-card-skeleton")).toHaveLength(3);
+  });
+});

--- a/components/transactions/transactions-table.tsx
+++ b/components/transactions/transactions-table.tsx
@@ -12,12 +12,18 @@ import { TransactionsTableProps } from "@/types/transaction";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TRANSACTIONS_PAGE_SIZE } from "@/lib/transactionDefaults";
 
 interface TransactionsTablePropsExtended extends TransactionsTableProps {
   isLoading?: boolean;
+  skeletonRows?: number;
 }
 
-export function TransactionsTable({ transactions, isLoading = false }: TransactionsTablePropsExtended) {
+export function TransactionsTable({
+  transactions,
+  isLoading = false,
+  skeletonRows = TRANSACTIONS_PAGE_SIZE,
+}: TransactionsTablePropsExtended) {
   const isEmpty = !isLoading && transactions.length === 0;
 
   return (
@@ -29,30 +35,52 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
           <caption className="sr-only">Transaction history</caption>
           <TableHeader>
             <TableRow className="bg-[#191919]">
-              <TableHead scope="col" className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-6">
+              <TableHead
+                scope="col"
+                className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-6"
+              >
                 Transaction Type
               </TableHead>
-              <TableHead scope="col" className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-6">
+              <TableHead
+                scope="col"
+                className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-6"
+              >
                 Address
               </TableHead>
-              <TableHead scope="col" className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-6">
+              <TableHead
+                scope="col"
+                className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-6"
+              >
                 Date
               </TableHead>
-              <TableHead scope="col" className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-6">
+              <TableHead
+                scope="col"
+                className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-6"
+              >
                 Token
               </TableHead>
-              <TableHead scope="col" className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-6">
+              <TableHead
+                scope="col"
+                className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-6"
+              >
                 Amount
               </TableHead>
-              <TableHead scope="col" className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-6">
+              <TableHead
+                scope="col"
+                className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-6"
+              >
                 Status
               </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {isLoading ? (
-              Array.from({ length: 6 }).map((_, index) => (
-                <TableRow key={`skeleton-${index}`} className="border border-[#2D2D2D]">
+              Array.from({ length: skeletonRows }).map((_, index) => (
+                <TableRow
+                  key={`skeleton-${index}`}
+                  className="border border-[#2D2D2D]"
+                  data-testid="transaction-table-skeleton-row"
+                >
                   <TableCell className="font-medium border border-[#2D2D2D] py-4 px-6">
                     <Skeleton className="h-4 w-20 mb-1" />
                     <Skeleton className="h-3 w-16" />
@@ -78,14 +106,21 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
             ) : isEmpty ? (
               <TableRow>
                 <TableCell colSpan={6} className="py-12 text-center">
-                  <div role="status" aria-live="polite" className="text-muted-foreground">
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    className="text-muted-foreground"
+                  >
                     No transactions found. Try adjusting your filters.
                   </div>
                 </TableCell>
               </TableRow>
             ) : (
               transactions.map((transaction, index) => (
-                <TableRow key={transaction.id ?? index} className="border border-[#2D2D2D]">
+                <TableRow
+                  key={transaction.id ?? index}
+                  className="border border-[#2D2D2D]"
+                >
                   <TableCell className="font-medium border border-[#2D2D2D] py-4 px-6">
                     <span className="text-[#D7E0EF]">{transaction.type}</span>
                     <p>#{transaction.id}</p>
@@ -113,7 +148,7 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
                   <TableCell className="py-4 px-6">
                     <Badge
                       aria-label={`Status: ${transaction.status}`}
-                      className={`${transaction.status === "Completed" ? "bg-[#102B19] text-[#04842E]" : transaction.status === "Pending" ? "bg-[#191919] text-[#9F6603]" : "bg-[#1A1A1A] text-[#B70B05]" }`}
+                      className={`${transaction.status === "Completed" ? "bg-[#102B19] text-[#04842E]" : transaction.status === "Pending" ? "bg-[#191919] text-[#9F6603]" : "bg-[#1A1A1A] text-[#B70B05]"}`}
                     >
                       <span className="text-sm">{transaction.status}</span>
                     </Badge>
@@ -128,8 +163,12 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
       {/* Mobile Cards */}
       <div className="md:hidden space-y-4">
         {isLoading ? (
-          Array.from({ length: 6 }).map((_, index) => (
-            <div key={`skeleton-mobile-${index}`} className="p-4 border rounded-lg border-[#2D2D2D]">
+          Array.from({ length: skeletonRows }).map((_, index) => (
+            <div
+              key={`skeleton-mobile-${index}`}
+              className="p-4 border rounded-lg border-[#2D2D2D]"
+              data-testid="transaction-card-skeleton"
+            >
               <div className="flex justify-between items-start">
                 <div className="space-y-2">
                   <Skeleton className="h-4 w-32" />
@@ -151,7 +190,11 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
           ))
         ) : isEmpty ? (
           <div className="p-8 text-center border rounded-lg border-[#2D2D2D]">
-            <div role="status" aria-live="polite" className="text-muted-foreground">
+            <div
+              role="status"
+              aria-live="polite"
+              className="text-muted-foreground"
+            >
               No transactions found. Try adjusting your filters.
             </div>
           </div>

--- a/components/ui/table-skeleton.tsx
+++ b/components/ui/table-skeleton.tsx
@@ -1,5 +1,6 @@
 import { Skeleton } from "./skeleton";
 import { cn } from "@/utils/commonUtils";
+import { TRANSACTIONS_PAGE_SIZE } from "@/lib/transactionDefaults";
 
 interface TableSkeletonProps {
   /**
@@ -32,7 +33,10 @@ export function TableSkeleton({
   return (
     <div className={cn("w-full", className)}>
       {showHeader && (
-        <div className="grid gap-4 py-3 px-4 border-b border-[#2D2D2D]" style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}>
+        <div
+          className="grid gap-4 py-3 px-4 border-b border-[#2D2D2D]"
+          style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
+        >
           {Array.from({ length: columns }).map((_, i) => (
             <Skeleton key={`header-${i}`} className="h-4 w-20" />
           ))}
@@ -50,7 +54,11 @@ export function TableSkeleton({
                 key={`cell-${rowIndex}-${colIndex}`}
                 className={cn(
                   "h-4",
-                  colIndex === 0 ? "w-24" : colIndex === columns - 1 ? "w-16" : "w-full"
+                  colIndex === 0
+                    ? "w-24"
+                    : colIndex === columns - 1
+                      ? "w-16"
+                      : "w-full",
                 )}
               />
             ))}
@@ -64,7 +72,11 @@ export function TableSkeleton({
 /**
  * Transaction Table Skeleton - matches the design of transaction history table
  */
-export function TransactionTableSkeleton({ rows = 6 }: { rows?: number }) {
+export function TransactionTableSkeleton({
+  rows = TRANSACTIONS_PAGE_SIZE,
+}: {
+  rows?: number;
+}) {
   return (
     <div className="w-full">
       {/* Header */}

--- a/hooks/useTransactions.ts
+++ b/hooks/useTransactions.ts
@@ -7,6 +7,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { getTransactions, PaginatedTransactions } from "@/lib/api";
+import { TRANSACTIONS_PAGE_SIZE } from "@/lib/transactionDefaults";
 import type { TransactionFilters } from "@/types/transaction";
 
 interface UseTransactionsOptions {
@@ -28,9 +29,9 @@ interface UseTransactionsResult {
  * @param options - filters, page, and pageSize
  */
 export function useTransactions(
-  options: UseTransactionsOptions = {}
+  options: UseTransactionsOptions = {},
 ): UseTransactionsResult {
-  const { filters, page = 1, pageSize = 6 } = options;
+  const { filters, page = 1, pageSize = TRANSACTIONS_PAGE_SIZE } = options;
 
   const [data, setData] = useState<PaginatedTransactions | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -54,7 +55,7 @@ export function useTransactions(
       .catch((err: unknown) => {
         if (!cancelled) {
           setError(
-            err instanceof Error ? err.message : "Failed to load transactions"
+            err instanceof Error ? err.message : "Failed to load transactions",
           );
           setIsLoading(false);
         }

--- a/lib/api/transactions.ts
+++ b/lib/api/transactions.ts
@@ -8,6 +8,7 @@
 
 import type { Transaction, TransactionFilters } from "@/types/transaction";
 import { allTransactions } from "@/lib/transactions";
+import { TRANSACTIONS_PAGE_SIZE } from "@/lib/transactionDefaults";
 import { filterTransactions, sortTransactions } from "@/utils/transactionUtils";
 
 export interface PaginatedTransactions {
@@ -33,9 +34,9 @@ const MOCK_TO_DATE = "2099-12-31";
  * Today returns mock data; swap the body for a fetch() when the backend is ready.
  */
 export async function getTransactions(
-  params: GetTransactionsParams = {}
+  params: GetTransactionsParams = {},
 ): Promise<PaginatedTransactions> {
-  const { filters = {}, page = 1, pageSize = 6 } = params;
+  const { filters = {}, page = 1, pageSize = TRANSACTIONS_PAGE_SIZE } = params;
 
   const {
     searchQuery = "",
@@ -63,7 +64,7 @@ export async function getTransactions(
     searchQuery,
     selectedFilter,
     fromDate || MOCK_FROM_DATE,
-    toDate || MOCK_TO_DATE
+    toDate || MOCK_TO_DATE,
   );
 
   const sorted = sortTransactions(filtered, sortField, sortDirection);

--- a/lib/transactionDefaults.ts
+++ b/lib/transactionDefaults.ts
@@ -1,0 +1,16 @@
+import type { TransactionFilters } from "@/types/transaction";
+
+export const TRANSACTIONS_PAGE_SIZE = 6;
+
+/**
+ * Leave the date range unset so the initial transaction view is not anchored
+ * to a stale historical window.
+ */
+export const DEFAULT_TRANSACTION_FILTERS: TransactionFilters = {
+  searchQuery: "",
+  fromDate: "",
+  toDate: "",
+  selectedFilter: "All Transactions",
+  sortField: "date",
+  sortDirection: "desc",
+};


### PR DESCRIPTION
## Summary
- add shared transaction defaults for the page size and initial filter state
- remove the stale fixed 2023 transaction date window from the transaction content defaults
- wire transaction page size through the page, hook, API fallback, table loading state, and transaction table skeleton
- add Vitest coverage for the unset date range default and desktop/mobile skeleton row count parity

Closes #346

## Validation
- `npm exec -- vitest run components/transactions/transactions-table.test.tsx` passed
- `npm exec -- prettier --check app/transactions/page.tsx components/transactions/transactions-content.tsx components/transactions/transactions-table.tsx components/transactions/transactions-table.test.tsx components/ui/table-skeleton.tsx hooks/useTransactions.ts lib/api/transactions.ts lib/transactionDefaults.ts` passed
- `npm run test` is blocked on current main by the existing Vitest/PostCSS config failure in `app/metadata.test.ts`
- `npm run lint` and `npm run build` are blocked on current main by the existing `@typescript-eslint/no-explicit-any` lint failure in `components/analytics/analytics-view.test.tsx`

## Notes
- This PR does not include unrelated test-harness fixes already covered by #355, so the transaction change stays scoped to #346.