### PR TITLE
feat: tambah fallback badge untuk token tidak dikenal di TokenIcon

### DIFF
--- a/components/transactions/token-icon.test.tsx
+++ b/components/transactions/token-icon.test.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import TokenIcon from "./token-icon";
+
+describe("TokenIcon Component", () => {
+  it("renders USDC token with image", () => {
+    render(<TokenIcon token="USDC" />);
+    const img = screen.getByAltText("USDC");
+    expect(img).toBeInTheDocument();
+    // next/image optimizes the URL in JSDOM, so we check it contains the filename
+    expect(img).toHaveAttribute("src");
+    expect((img as HTMLImageElement).src).toContain("usdc-logo.png");
+  });
+
+  it("renders XLM token with image", () => {
+    render(<TokenIcon token="XLM" />);
+    const img = screen.getByAltText("XLM");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src");
+    expect((img as HTMLImageElement).src).toContain("stellar-xlm-logo.png");
+  });
+
+  it("renders fallback badge for unknown token", () => {
+    render(<TokenIcon token="ETH" />);
+    const badge = screen.getByTitle("ETH");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("ET");
+    expect(badge).toHaveClass("rounded-full");
+  });
+
+  it("renders fallback badge with correct initials (first 2 chars)", () => {
+    render(<TokenIcon token="BTC" />);
+    const badge = screen.getByTitle("BTC");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("BT");
+  });
+
+  it("renders fallback badge with uppercase initials for lowercase input", () => {
+    render(<TokenIcon token="sol" />);
+    const badge = screen.getByTitle("sol");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("SO");
+  });
+
+  it("renders fallback badge for empty token string", () => {
+    render(<TokenIcon token="" />);
+    // Empty string yields no initials — getInitials("") returns ""
+    const container = screen.getByTitle("");
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveTextContent("");
+  });
+
+  it("renders fallback badge with title attribute set to full token name", () => {
+    render(<TokenIcon token="YIELD" />);
+    const badge = screen.getByTitle("YIELD");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("YI");
+  });
+
+  it("renders a container div with the correct class structure for known tokens", () => {
+    const { container } = render(<TokenIcon token="USDC" />);
+    const outerDiv = container.firstChild as HTMLElement;
+    expect(outerDiv.className).toContain("rounded-full");
+    expect(outerDiv.className).toContain("overflow-hidden");
+  });
+
+  it("renders a container div with the correct class structure for fallback tokens", () => {
+    const { container } = render(<TokenIcon token="SHIB" />);
+    const outerDiv = container.firstChild as HTMLElement;
+    expect(outerDiv.className).toContain("rounded-full");
+    expect(outerDiv.className).toContain("bg-gray-200");
+  });
+});

--- a/components/transactions/token-icon.tsx
+++ b/components/transactions/token-icon.tsx
@@ -1,13 +1,24 @@
 import Image from "next/image";
 import { TokenIconProps } from "@/types/transaction";
 
+const KNOWN_TOKENS: Record<string, { src: string; label: string }> = {
+  USDC: { src: "/usdc-logo.png", label: "USDC" },
+  XLM: { src: "/stellar-xlm-logo.png", label: "XLM" },
+};
+
+function getInitials(token: string): string {
+  return token.slice(0, 2).toUpperCase();
+}
+
 export default function TokenIcon({ token }: TokenIconProps) {
-  if (token === "USDC") {
+  const known = KNOWN_TOKENS[token];
+
+  if (known) {
     return (
-      <div className="w-5 h-5 rounded-full overflow-hidden flex items-center justify-center ">
+      <div className="w-5 h-5 rounded-full overflow-hidden flex items-center justify-center">
         <Image
-          src="/usdc-logo.png"
-          alt="USDC"
+          src={known.src}
+          alt={known.label}
           width={20}
           height={20}
           className="w-full h-full object-cover"
@@ -15,17 +26,14 @@ export default function TokenIcon({ token }: TokenIconProps) {
       </div>
     );
   }
-  if (token === "XLM") {
-    return (
-      <div className="w-5 h-5 rounded-full overflow-hidden flex items-center justify-center ">
-        <Image
-          src="/stellar-xlm-logo.png"
-          alt="XLM"
-          width={20}
-          height={20}
-          className="w-full h-full object-cover"
-        />
-      </div>
-    );
-  }
+
+  // Fallback: circular badge with the first two characters of the token code
+  return (
+    <div
+      className="w-5 h-5 rounded-full flex items-center justify-center bg-gray-200 text-[10px] font-semibold text-gray-600"
+      title={token}
+    >
+      {getInitials(token)}
+    </div>
+  );
 }


### PR DESCRIPTION
## Deskripsi

Komponen `TokenIcon` sebelumnya hanya merender ikon untuk token **USDC** dan **XLM**. Token lain yang tidak dikenal mengembalikan `undefined`, menyebabkan komponen tidak tampil sama sekali di halaman transaksi.

## Perubahan

- Fallback badge: Token yang tidak dikenal sekarang dirender sebagai circular badge dengan inisial 2 karakter pertama (uppercase) — misal ETH -> badge ET, BTC -> badge BT
- Struktur kode di-refactor: Gunakan lookup object KNOWN_TOKENS agar lebih mudah menambahkan token baru di masa depan
- Test file baru: token-icon.test.tsx dengan 9 test cases

## Related Issue

Closes #320