### PR TITLE
fix(pagination): guard invalid page bounds

### DIFF
--- a/utils/paginationUtils.test.ts
+++ b/utils/paginationUtils.test.ts
@@ -41,12 +41,29 @@ describe("paginationUtils", () => {
       expect(getPageItems(items, 4, itemsPerPage)).toEqual([]);
     });
 
-    it("does not clamp page zero to the first page", () => {
-      expect(getPageItems(items, 0, itemsPerPage)).toEqual([]);
+    it("clamps page zero to the first page", () => {
+      expect(getPageItems(items, 0, itemsPerPage)).toEqual([
+        "alpha",
+        "bravo",
+        "charlie",
+      ]);
     });
 
-    it("returns an empty list for a negative page instead of slicing from the end", () => {
-      expect(getPageItems(items, -1, itemsPerPage)).toEqual([]);
+    it("clamps a negative page instead of slicing from the end", () => {
+      expect(getPageItems(items, -1, itemsPerPage)).toEqual([
+        "alpha",
+        "bravo",
+        "charlie",
+      ]);
+    });
+
+    it("uses a safe one-item page size when itemsPerPage is zero", () => {
+      expect(getPageItems(items, 2, 0)).toEqual(["bravo"]);
+    });
+
+    it("handles a huge page size without layout-shifting slices", () => {
+      expect(getPageItems(items, 1, 1000)).toEqual(items);
+      expect(getPageItems(items, 2, 1000)).toEqual([]);
     });
   });
 
@@ -62,6 +79,17 @@ describe("paginationUtils", () => {
     it("returns zero pages when there are no items", () => {
       expect(getTotalPages(0, 4)).toBe(0);
     });
+
+    it("never returns Infinity or NaN for zero or negative page sizes", () => {
+      expect(getTotalPages(7, 0)).toBe(7);
+      expect(getTotalPages(7, -2)).toBe(7);
+      expect(Number.isFinite(getTotalPages(7, 0))).toBe(true);
+      expect(Number.isNaN(getTotalPages(7, Number.NaN))).toBe(false);
+    });
+
+    it("returns one page for a page size larger than the item count", () => {
+      expect(getTotalPages(7, 1000)).toBe(1);
+    });
   });
 
   describe("index helpers", () => {
@@ -73,6 +101,13 @@ describe("paginationUtils", () => {
     it("returns start and end indexes for page 2", () => {
       expect(getStartIndex(2, 10)).toBe(10);
       expect(getEndIndex(2, 10)).toBe(20);
+    });
+
+    it("clamps negative pages and non-positive page sizes", () => {
+      expect(getStartIndex(-3, 10)).toBe(0);
+      expect(getEndIndex(-3, 10)).toBe(10);
+      expect(getStartIndex(3, 0)).toBe(2);
+      expect(getEndIndex(3, 0)).toBe(3);
     });
   });
 

--- a/utils/paginationUtils.ts
+++ b/utils/paginationUtils.ts
@@ -2,8 +2,23 @@
  * Pagination utility functions
  */
 
+const MIN_PAGE = 1;
+const MIN_ITEMS_PER_PAGE = 1;
+
+const normalizePage = (currentPage: number): number => {
+  if (!Number.isFinite(currentPage)) return MIN_PAGE;
+  return Math.max(MIN_PAGE, Math.floor(currentPage));
+};
+
+const normalizeItemsPerPage = (itemsPerPage: number): number => {
+  if (!Number.isFinite(itemsPerPage)) return MIN_ITEMS_PER_PAGE;
+  return Math.max(MIN_ITEMS_PER_PAGE, Math.floor(itemsPerPage));
+};
+
 /**
- * Calculates the start index for pagination
+ * Calculates the start index for pagination.
+ * Guarantees a non-negative finite index by clamping page to at least 1
+ * and itemsPerPage to at least 1.
  * @param currentPage - Current page number (1-based)
  * @param itemsPerPage - Number of items per page
  * @returns Start index for the current page
@@ -12,11 +27,15 @@ export const getStartIndex = (
   currentPage: number,
   itemsPerPage: number,
 ): number => {
-  return (currentPage - 1) * itemsPerPage;
+  const safePage = normalizePage(currentPage);
+  const safeItemsPerPage = normalizeItemsPerPage(itemsPerPage);
+  return (safePage - 1) * safeItemsPerPage;
 };
 
 /**
- * Calculates the end index for pagination
+ * Calculates the end index for pagination.
+ * Guarantees a positive finite index by clamping page to at least 1
+ * and itemsPerPage to at least 1.
  * @param currentPage - Current page number (1-based)
  * @param itemsPerPage - Number of items per page
  * @returns End index for the current page
@@ -25,11 +44,14 @@ export const getEndIndex = (
   currentPage: number,
   itemsPerPage: number,
 ): number => {
-  return currentPage * itemsPerPage;
+  const safePage = normalizePage(currentPage);
+  const safeItemsPerPage = normalizeItemsPerPage(itemsPerPage);
+  return safePage * safeItemsPerPage;
 };
 
 /**
- * Calculates the total number of pages
+ * Calculates the total number of pages.
+ * Returns a finite integer and treats invalid or non-positive page sizes as 1.
  * @param totalItems - Total number of items
  * @param itemsPerPage - Number of items per page
  * @returns Total number of pages
@@ -38,11 +60,14 @@ export const getTotalPages = (
   totalItems: number,
   itemsPerPage: number,
 ): number => {
-  return Math.ceil(totalItems / itemsPerPage);
+  if (!Number.isFinite(totalItems) || totalItems <= 0) return 0;
+  return Math.ceil(totalItems / normalizeItemsPerPage(itemsPerPage));
 };
 
 /**
- * Gets a slice of items for the current page
+ * Gets a slice of items for the current page.
+ * Negative and non-finite page values are clamped to page 1; invalid page
+ * sizes are clamped to 1 so slices never use Infinity or negative offsets.
  * @param items - Array of all items
  * @param currentPage - Current page number (1-based)
  * @param itemsPerPage - Number of items per page
@@ -53,9 +78,6 @@ export const getPageItems = <T>(
   currentPage: number,
   itemsPerPage: number,
 ): T[] => {
-  if (currentPage <= 0) {
-    return [];
-  }
   const startIndex = getStartIndex(currentPage, itemsPerPage);
   const endIndex = getEndIndex(currentPage, itemsPerPage);
   return items.slice(startIndex, endIndex);


### PR DESCRIPTION
Closes #331.

## Summary
- Clamps invalid page values to page 1 and invalid `itemsPerPage` values to 1 in the pagination helpers.
- Ensures `getTotalPages` returns finite values for zero, negative, NaN, and huge page-size inputs.
- Adds TSDoc invariants and regression tests for zero page size, negative page, and huge page size.

## Validation
- Static review of `utils/paginationUtils.ts` and `utils/paginationUtils.test.ts`.
- GitHub compare confirms only the intended pagination utility and test files changed.
- No secrets or payment details included.