### PR TITLE
fix(network): label switch confirmation dialog

### DIFF
--- a/components/common/network-switcher.tsx
+++ b/components/common/network-switcher.tsx
@@ -65,6 +65,9 @@ const EthereumIcon = () => (
   </svg>
 );
 
+const NETWORK_DIALOG_TITLE_ID = "network-switcher-dialog-title";
+const NETWORK_DIALOG_DESCRIPTION_ID = "network-switcher-dialog-description";
+
 export default function NetworkSwitcher({
   networks,
   selectedNetwork,
@@ -131,7 +134,10 @@ export default function NetworkSwitcher({
             aria-hidden="true"
           />
           {currentNetwork.icon || <EthereumIcon />}
-          <span className="text-sm font-medium" style={{ fontFamily: "General Sans, sans-serif" }}>
+          <span
+            className="text-sm font-medium"
+            style={{ fontFamily: "General Sans, sans-serif" }}
+          >
             {currentNetwork.name}
           </span>
           <ChevronDown className="w-4 h-4 text-[#6e6d6e]" aria-hidden="true" />
@@ -163,7 +169,10 @@ export default function NetworkSwitcher({
               >
                 <div className="flex items-center gap-2 w-full">
                   {network.icon || <EthereumIcon />}
-                  <span className="text-sm" style={{ fontFamily: "General Sans, sans-serif" }}>
+                  <span
+                    className="text-sm"
+                    style={{ fontFamily: "General Sans, sans-serif" }}
+                  >
                     {network.name}
                   </span>
                   {/* Active badge */}
@@ -173,7 +182,9 @@ export default function NetworkSwitcher({
                         className="w-1.5 h-1.5 rounded-full bg-green-500"
                         aria-hidden="true"
                       />
-                      <span className="text-xs text-green-400 font-medium">Active</span>
+                      <span className="text-xs text-green-400 font-medium">
+                        Active
+                      </span>
                     </span>
                   )}
                 </div>
@@ -184,18 +195,41 @@ export default function NetworkSwitcher({
       </DropdownMenu>
 
       {/* ── Confirmation dialog ───────────────────────────────────────── */}
-      <Dialog open={!!pendingNetwork} onOpenChange={(open) => { if (!open) cancelSwitch(); }}>
+      <Dialog
+        open={!!pendingNetwork}
+        onOpenChange={(open) => {
+          if (!open) cancelSwitch();
+        }}
+      >
         <DialogContent
+          aria-labelledby={NETWORK_DIALOG_TITLE_ID}
+          aria-describedby={NETWORK_DIALOG_DESCRIPTION_ID}
           className="bg-[#1A1A1A] border-[#242428] text-white max-w-sm"
           showCloseButton={false}
         >
           <DialogHeader>
-            <DialogTitle className="text-white">Switch network?</DialogTitle>
-            <DialogDescription className="text-[#9CA3AF]">
+            <DialogTitle id={NETWORK_DIALOG_TITLE_ID} className="text-white">
+              Switch network?
+            </DialogTitle>
+            <DialogDescription
+              id={NETWORK_DIALOG_DESCRIPTION_ID}
+              className="text-[#9CA3AF]"
+            >
               You are switching from{" "}
-              <span className="font-semibold text-white">{currentNetwork.name}</span>{" "}
+              <span
+                className="font-semibold text-white"
+                data-testid="network-switch-current-network"
+              >
+                {currentNetwork.name}
+              </span>{" "}
               to{" "}
-              <span className="font-semibold text-white">{pendingNetwork?.name}</span>.
+              <span
+                className="font-semibold text-white"
+                data-testid="network-switch-target-network"
+              >
+                {pendingNetwork?.name}
+              </span>
+              .
               <br />
               <br />
               Your displayed balances and transaction history will reflect the

--- a/tests/network-switcher.spec.ts
+++ b/tests/network-switcher.spec.ts
@@ -28,11 +28,13 @@ test.describe("NetworkSwitcher — active badge", () => {
     await expect(trigger).toBeVisible();
 
     // The green dot is inside the trigger
-    const dot = trigger.locator('.bg-green-500').first();
+    const dot = trigger.locator(".bg-green-500").first();
     await expect(dot).toBeVisible();
   });
 
-  test("trigger aria-label announces the current network name", async ({ page }) => {
+  test("trigger aria-label announces the current network name", async ({
+    page,
+  }) => {
     await page.goto(LANDING_URL);
 
     const trigger = page.locator('[aria-label*="Current network"]').first();
@@ -40,7 +42,9 @@ test.describe("NetworkSwitcher — active badge", () => {
     await expect(trigger).toHaveAttribute("aria-label", /Stellar/i);
   });
 
-  test("active network item shows 'Active' badge in dropdown", async ({ page }) => {
+  test("active network item shows 'Active' badge in dropdown", async ({
+    page,
+  }) => {
     await page.goto(LANDING_URL);
 
     const trigger = page.locator('[aria-label*="Current network"]').first();
@@ -53,7 +57,9 @@ test.describe("NetworkSwitcher — active badge", () => {
 });
 
 test.describe("NetworkSwitcher — no-op on active network", () => {
-  test("clicking the already-active network does not open a dialog", async ({ page }) => {
+  test("clicking the already-active network does not open a dialog", async ({
+    page,
+  }) => {
     await page.goto(LANDING_URL);
 
     const trigger = page.locator('[aria-label*="Current network"]').first();
@@ -70,13 +76,17 @@ test.describe("NetworkSwitcher — no-op on active network", () => {
 });
 
 test.describe("NetworkSwitcher — confirmation dialog", () => {
-  test("switching to a different network opens the confirmation dialog", async ({ page }) => {
+  test("switching to a different network opens the confirmation dialog", async ({
+    page,
+  }) => {
     await page.goto(LANDING_URL);
 
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await trigger.click();
 
-    const polygonItem = page.getByRole("menuitem", { name: /Polygon/i }).first();
+    const polygonItem = page
+      .getByRole("menuitem", { name: /Polygon/i })
+      .first();
     await polygonItem.click();
 
     const dialog = page.getByRole("dialog");
@@ -89,20 +99,59 @@ test.describe("NetworkSwitcher — confirmation dialog", () => {
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await trigger.click();
 
-    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+    await page
+      .getByRole("menuitem", { name: /Polygon/i })
+      .first()
+      .click();
 
     const dialog = page.getByRole("dialog");
     await expect(dialog).toContainText("Stellar");
     await expect(dialog).toContainText("Polygon");
   });
 
-  test("dialog warns about balance/transaction context change", async ({ page }) => {
+  test("dialog is named, described, and exposes emphasized network labels", async ({
+    page,
+  }) => {
     await page.goto(LANDING_URL);
 
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await trigger.click();
 
-    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+    await page
+      .getByRole("menuitem", { name: /Polygon/i })
+      .first()
+      .click();
+
+    const dialog = page.getByRole("dialog", { name: /switch network/i });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute(
+      "aria-labelledby",
+      "network-switcher-dialog-title",
+    );
+    await expect(dialog).toHaveAttribute(
+      "aria-describedby",
+      "network-switcher-dialog-description",
+    );
+
+    const currentNetwork = page.getByTestId("network-switch-current-network");
+    const targetNetwork = page.getByTestId("network-switch-target-network");
+    await expect(currentNetwork).toHaveText("Stellar");
+    await expect(targetNetwork).toHaveText("Polygon");
+    await expect(targetNetwork).toHaveClass(/font-semibold/);
+  });
+
+  test("dialog warns about balance/transaction context change", async ({
+    page,
+  }) => {
+    await page.goto(LANDING_URL);
+
+    const trigger = page.locator('[aria-label*="Current network"]').first();
+    await trigger.click();
+
+    await page
+      .getByRole("menuitem", { name: /Polygon/i })
+      .first()
+      .click();
 
     const dialog = page.getByRole("dialog");
     await expect(dialog).toContainText(/balances/i);
@@ -117,7 +166,10 @@ test.describe("NetworkSwitcher — confirmation dialog", () => {
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await trigger.click();
 
-    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+    await page
+      .getByRole("menuitem", { name: /Polygon/i })
+      .first()
+      .click();
 
     await page.getByRole("button", { name: /cancel/i }).click();
 
@@ -125,17 +177,24 @@ test.describe("NetworkSwitcher — confirmation dialog", () => {
     await expect(page.getByRole("dialog")).not.toBeVisible();
 
     // Trigger still shows ETH
-    const updatedTrigger = page.locator('[aria-label*="Current network"]').first();
+    const updatedTrigger = page
+      .locator('[aria-label*="Current network"]')
+      .first();
     await expect(updatedTrigger).toHaveAttribute("aria-label", /Stellar/i);
   });
 
-  test("confirming the switch updates the displayed network", async ({ page }) => {
+  test("confirming the switch updates the displayed network", async ({
+    page,
+  }) => {
     await page.goto(LANDING_URL);
 
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await trigger.click();
 
-    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+    await page
+      .getByRole("menuitem", { name: /Polygon/i })
+      .first()
+      .click();
 
     await page.getByTestId("confirm-network-switch").click();
 
@@ -143,18 +202,25 @@ test.describe("NetworkSwitcher — confirmation dialog", () => {
     await expect(page.getByRole("dialog")).not.toBeVisible();
 
     // Trigger now shows Polygon
-    const updatedTrigger = page.locator('[aria-label*="Current network"]').first();
+    const updatedTrigger = page
+      .locator('[aria-label*="Current network"]')
+      .first();
     await expect(updatedTrigger).toHaveAttribute("aria-label", /Polygon/i);
   });
 });
 
 test.describe("NetworkSwitcher — rapid switching", () => {
-  test("switching back and forth quickly ends on the last confirmed network", async ({ page }) => {
+  test("switching back and forth quickly ends on the last confirmed network", async ({
+    page,
+  }) => {
     await page.goto(LANDING_URL);
 
     // Switch ETH → Polygon
     await page.locator('[aria-label*="Current network"]').first().click();
-    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+    await page
+      .getByRole("menuitem", { name: /Polygon/i })
+      .first()
+      .click();
     await page.getByTestId("confirm-network-switch").click();
 
     // Switch Polygon → BSC
@@ -164,19 +230,27 @@ test.describe("NetworkSwitcher — rapid switching", () => {
 
     // Switch BSC → ETH
     await page.locator('[aria-label*="Current network"]').first().click();
-    await page.getByRole("menuitem", { name: /Stellar/i }).first().click();
+    await page
+      .getByRole("menuitem", { name: /Stellar/i })
+      .first()
+      .click();
     await page.getByTestId("confirm-network-switch").click();
 
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await expect(trigger).toHaveAttribute("aria-label", /Stellar/i);
   });
 
-  test("cancelling mid-sequence preserves the last confirmed network", async ({ page }) => {
+  test("cancelling mid-sequence preserves the last confirmed network", async ({
+    page,
+  }) => {
     await page.goto(LANDING_URL);
 
     // Confirm ETH → Polygon
     await page.locator('[aria-label*="Current network"]').first().click();
-    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+    await page
+      .getByRole("menuitem", { name: /Polygon/i })
+      .first()
+      .click();
     await page.getByTestId("confirm-network-switch").click();
 
     // Start Polygon → BSC but cancel
@@ -191,7 +265,9 @@ test.describe("NetworkSwitcher — rapid switching", () => {
 });
 
 test.describe("NetworkSwitcher — security", () => {
-  test("no private keys or secrets are visible in the component", async ({ page }) => {
+  test("no private keys or secrets are visible in the component", async ({
+    page,
+  }) => {
     await page.goto(LANDING_URL);
 
     const trigger = page.locator('[aria-label*="Current network"]').first();
@@ -202,7 +278,10 @@ test.describe("NetworkSwitcher — security", () => {
 
     // Open dropdown and check
     await trigger.click();
-    const dropdownText = await page.locator('[role="menu"]').first().textContent();
+    const dropdownText = await page
+      .locator('[role="menu"]')
+      .first()
+      .textContent();
     expect(dropdownText).not.toMatch(/[0-9a-fA-F]{64}/);
   });
 });
@@ -247,11 +326,14 @@ test.describe("NetworkSwitcher — keyboard accessibility", () => {
 });
 
 test.describe("Performance & Trace Validation", () => {
-  test("main pages load and have no major layout shift or console errors", async ({ page, context }) => {
+  test("main pages load and have no major layout shift or console errors", async ({
+    page,
+    context,
+  }) => {
     // Start tracing before navigating
     try {
       await context.tracing.stop();
-    } catch (e) {}
+    } catch {}
     await context.tracing.start({ screenshots: true, snapshots: true });
 
     // Navigate to landing page /
@@ -266,4 +348,3 @@ test.describe("Performance & Trace Validation", () => {
     await context.tracing.stop({ path: "test-results/performance-trace.zip" });
   });
 });
-


### PR DESCRIPTION
## Summary
Closes #343.

- Adds stable aria-labelledby/aria-describedby wiring for the NetworkSwitcher confirmation dialog.
- Adds explicit current/target network markers so the dialog copy is easy to assert and review.
- Extends the existing Playwright coverage for dialog naming, description, and emphasized target network text.

## Validation
- npx prettier --check components/common/network-switcher.tsx tests/network-switcher.spec.ts
- npx next lint --file components/common/network-switcher.tsx --file tests/network-switcher.spec.ts
- git diff --check
- System Chrome page check: opened /, selected Polygon in NetworkSwitcher, verified dialog role/name, aria-labelledby, aria-describedby, current/target labels, and emphasized target text.

## Notes
- The local Playwright bundled Chromium headless shell was missing in this desktop environment, and installing it timed out, so the focused browser behavior was verified with system Chrome.
- Full type-check/lint still have unrelated existing failures on main; this PR's targeted files passed the scoped checks above.
