### PR TITLE
feat: debounce transaction search input

### DIFF
--- a/components/transactions/table-searchbar.test.tsx
+++ b/components/transactions/table-searchbar.test.tsx
@@ -1,0 +1,85 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import TableSearchbar from "./table-searchbar";
+
+describe("TableSearchbar", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("labels the transaction search input for assistive technology", () => {
+    render(<TableSearchbar onSearch={vi.fn()} />);
+
+    expect(
+      screen.getByRole("textbox", { name: "Search transactions" }),
+    ).toBeInTheDocument();
+  });
+
+  it("debounces search changes before notifying the parent", () => {
+    vi.useFakeTimers();
+    const onSearch = vi.fn();
+
+    render(<TableSearchbar onSearch={onSearch} />);
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Search transactions" }),
+      {
+        target: { value: "ste" },
+      },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(onSearch).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onSearch).toHaveBeenCalledWith("ste");
+    expect(onSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("only emits the latest value when typing continues within the debounce window", () => {
+    vi.useFakeTimers();
+    const onSearch = vi.fn();
+
+    render(<TableSearchbar onSearch={onSearch} />);
+    const input = screen.getByRole("textbox", { name: "Search transactions" });
+
+    fireEvent.change(input, { target: { value: "s" } });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    fireEvent.change(input, { target: { value: "stellar" } });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledWith("stellar");
+  });
+
+  it("clears the pending debounce timer on unmount", () => {
+    vi.useFakeTimers();
+    const onSearch = vi.fn();
+
+    const { unmount } = render(<TableSearchbar onSearch={onSearch} />);
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Search transactions" }),
+      {
+        target: { value: "cancelled" },
+      },
+    );
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+});

--- a/components/transactions/table-searchbar.tsx
+++ b/components/transactions/table-searchbar.tsx
@@ -1,20 +1,44 @@
-import React from "react";
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Search } from "lucide-react";
 
 interface TableSearchbarProps {
   onSearch: (value: string) => void;
+  debounceMs?: number;
 }
 
-const TableSearchbar = ({ onSearch }: TableSearchbarProps) => {
+const TableSearchbar = ({
+  onSearch,
+  debounceMs = 300,
+}: TableSearchbarProps) => {
+  const [query, setQuery] = useState("");
+  const hasMounted = useRef(false);
+
+  useEffect(() => {
+    if (!hasMounted.current) {
+      hasMounted.current = true;
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      onSearch(query);
+    }, debounceMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [debounceMs, onSearch, query]);
+
   return (
     <div className="flex items-center bg-transparent rounded-[6.25rem]   ">
-      <Search className="w-5 h-5 text-gray-600 " />
+      <Search className="w-5 h-5 text-gray-600 " aria-hidden="true" />
 
       <Input
+        aria-label="Search transactions"
         type="text"
         placeholder="Search"
-        onChange={(e) => onSearch(e.target.value)}
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
         className="border-none py-1 focus-visible:ring-0 text-[13px] p-1 sm:text-[14px]"
       />
     </div>


### PR DESCRIPTION
Closes #323.

## Summary
- add a labelled transaction search input for screen-reader users
- debounce search updates so the transactions page does not refetch on every keystroke
- cover debounce timing, latest-value behavior, aria labelling, and unmount cleanup

## Validation
- npm exec -- vitest run components/transactions/table-searchbar.test.tsx
- npm exec -- prettier --check components/transactions/table-searchbar.tsx components/transactions/table-searchbar.test.tsx
- git diff --check

Note: `npm run type-check` is currently blocked by the existing `vitest.config.ts` PostCSS type mismatch (`css.postcss: false`). `npm exec -- eslint ...` is also blocked because this ESLint 9 project still exposes only legacy `.eslintrc` config and no flat `eslint.config.*`.