### PR TITLE
fix: clear account status timeout on unmount

### DIFF
--- a/app/settings/preferences/components/account-section.test.tsx
+++ b/app/settings/preferences/components/account-section.test.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AccountSection from "./account-section";
+
+vi.mock("next/image", () => ({
+  default: ({
+    alt,
+    priority: _priority,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & { priority?: boolean }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} {...props} />
+  ),
+}));
+
+vi.mock("@/components/ui/form", () => ({
+  FormMessage: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <p className={className}>{children}</p>,
+}));
+
+describe("AccountSection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.1);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("clears the profile-save status message after the queued timeout", async () => {
+    render(<AccountSection />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /save account changes/i }),
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(
+      screen.getByText(
+        "Account profile changes are staged and ready for backend save.",
+      ),
+    ).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(4999);
+    });
+    expect(
+      screen.getByText(
+        "Account profile changes are staged and ready for backend save.",
+      ),
+    ).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(
+      screen.queryByText(
+        "Account profile changes are staged and ready for backend save.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears the queued status timeout when the section unmounts", async () => {
+    const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+    const { unmount } = render(<AccountSection />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /save account changes/i }),
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(
+      screen.getByText(
+        "Account profile changes are staged and ready for backend save.",
+      ),
+    ).toBeInTheDocument();
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+  });
+
+  it("does not schedule a status reset after unmounting during save", async () => {
+    const setTimeoutSpy = vi.spyOn(window, "setTimeout");
+    const { unmount } = render(<AccountSection />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /save account changes/i }),
+    );
+    unmount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    const resetTimers = setTimeoutSpy.mock.calls.filter(
+      ([, delay]) => delay === 5000,
+    );
+    expect(resetTimers).toHaveLength(0);
+  });
+});

--- a/app/settings/preferences/components/account-section.tsx
+++ b/app/settings/preferences/components/account-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import { Camera, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -69,8 +69,41 @@ export default function AccountSection() {
     timezone: DEMO_PROFILE.timezone,
     currency: DEMO_PROFILE.currency,
   });
-  const [status, setStatus] = useState<StatusState>({ message: "", type: null });
+  const [status, setStatus] = useState<StatusState>({
+    message: "",
+    type: null,
+  });
   const [isSaving, setIsSaving] = useState(false);
+  const statusTimeoutRef = useRef<ReturnType<typeof window.setTimeout> | null>(
+    null,
+  );
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      if (statusTimeoutRef.current) {
+        window.clearTimeout(statusTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const clearQueuedStatusReset = () => {
+    if (statusTimeoutRef.current) {
+      window.clearTimeout(statusTimeoutRef.current);
+      statusTimeoutRef.current = null;
+    }
+  };
+
+  const queueStatusReset = () => {
+    clearQueuedStatusReset();
+    statusTimeoutRef.current = window.setTimeout(() => {
+      if (isMountedRef.current) {
+        setStatus({ message: "", type: null });
+      }
+      statusTimeoutRef.current = null;
+    }, 5000);
+  };
 
   const updateProfileField = (field: keyof ProfileState, value: string) => {
     setProfile((currentProfile) => ({
@@ -82,28 +115,38 @@ export default function AccountSection() {
   const handleSave = async () => {
     setIsSaving(true);
     setStatus({ message: "", type: null });
+    clearQueuedStatusReset();
     try {
       // Simulate async API call
-      await new Promise((resolve, reject) => setTimeout(() => {
-        // Simulate occasional failure for testing
-        if (Math.random() > 0.8) {
-          reject(new Error("Failed to save"));
-        } else {
-          resolve(null);
-        }
-      }, 1500));
-      setStatus({
-        message: "Account profile changes are staged and ready for backend save.",
-        type: "success",
-      });
+      await new Promise((resolve, reject) =>
+        setTimeout(() => {
+          // Simulate occasional failure for testing
+          if (Math.random() > 0.8) {
+            reject(new Error("Failed to save"));
+          } else {
+            resolve(null);
+          }
+        }, 1500),
+      );
+      if (isMountedRef.current) {
+        setStatus({
+          message:
+            "Account profile changes are staged and ready for backend save.",
+          type: "success",
+        });
+      }
     } catch {
-      setStatus({
-        message: "Failed to save changes. Please try again.",
-        type: "error",
-      });
+      if (isMountedRef.current) {
+        setStatus({
+          message: "Failed to save changes. Please try again.",
+          type: "error",
+        });
+      }
     } finally {
-      setIsSaving(false);
-      setTimeout(() => setStatus({ message: "", type: null }), 5000);
+      if (isMountedRef.current) {
+        setIsSaving(false);
+        queueStatusReset();
+      }
     }
   };
 
@@ -224,7 +267,11 @@ export default function AccountSection() {
             >
               <FormMessage
                 variant={status.type === "success" ? "success" : "error"}
-                className={status.type === "success" ? "text-success" : "text-destructive"}
+                className={
+                  status.type === "success"
+                    ? "text-success"
+                    : "text-destructive"
+                }
               >
                 {status.message}
               </FormMessage>
@@ -320,7 +367,8 @@ export default function AccountSection() {
               confirmLabel="Confirm deactivation"
               onConfirm={() =>
                 setStatus({
-                  message: "Deactivation request captured. Keep this action gated until backend approval exists.",
+                  message:
+                    "Deactivation request captured. Keep this action gated until backend approval exists.",
                   type: "success",
                 })
               }


### PR DESCRIPTION
Closes #328.

## Summary
- track the account status reset timeout in a ref and clear it before rescheduling
- clear the pending status timeout on unmount and guard async save completion with a mounted ref
- add coverage for status reset timing, unmount cleanup, and unmount-during-save behavior

## Validation
- npm exec -- vitest run app/settings/preferences/components/account-section.test.tsx
- npm exec -- prettier --check app/settings/preferences/components/account-section.tsx app/settings/preferences/components/account-section.test.tsx
- git diff --check

Note: `npm run type-check` is currently blocked by the existing `vitest.config.ts` PostCSS type mismatch (`css.postcss: false`). `npm exec -- eslint ...` is also blocked because this ESLint 9 project still exposes only legacy `.eslintrc` config and no flat `eslint.config.*`.