### PR TITLE
fix: Centralize transaction status color hex value (#333)

### DIFF
--- a/src/utils/transactionUtils.ts
+++ b/src/utils/transactionUtils.ts
@@ -1,0 +1,15 @@
+import type { TransactionStatus } from '@/types/transaction';
+
+const STATUS_COLOR_PALETTE: Record<TransactionStatus, string> = {
+  pending: 'bg-[#FFA500] text-[#000000]',
+  processing: 'bg-[#4CAF50] text-[#FFFFFF]',
+  completed: 'bg-[#2196F3] text-[#FFFFFF]',
+  failed: 'bg-[#F44336] text-[#FFFFFF]',
+  cancelled: 'bg-[#795548] text-[#FFFFFF]',
+  refunded: 'bg-[#9C27B0] text-[#FFFFFF]',
+  unknown: 'bg-[#616161] text-[#FFFFFF]', // Visually distinct default
+};
+
+export function getStatusColor(status: TransactionStatus): string {
+  return STATUS_COLOR_PALETTE[status] ?? STATUS_COLOR_PALETTE.unknown;
+}


### PR DESCRIPTION
Fixes #333

*Automated by REAPR*