### PR TITLE
feat(ui): add reusable ErrorState/EmptyState components and adopt them

### DIFF
--- a/components/dashboard/payment-history.tsx
+++ b/components/dashboard/payment-history.tsx
@@ -3,6 +3,8 @@
 import Image from "next/image";
 import { usePaymentHistory } from "@/hooks/usePaymentHistory";
 import { CardSkeleton } from "@/components/ui/card-skeleton";
+import { ErrorState } from "@/components/ui/error-state";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export default function PaymentHistory() {
   const { data, isLoading, error } = usePaymentHistory();
@@ -19,9 +21,20 @@ export default function PaymentHistory() {
 
   if (error) {
     return (
-      <div role="alert" className="text-sm text-red-400 text-center py-4">
-        Failed to load payment history.
-      </div>
+      <ErrorState
+        title="Failed to Load"
+        description="Failed to load payment history."
+        onRetry={() => window.location.reload()}
+      />
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <EmptyState
+        title="No History"
+        description="You have no payment history yet."
+      />
     );
   }
 

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -8,6 +8,7 @@ import TransactionsHeader from "./transactions-header";
 import TransactionsFilters from "./transactions-filters";
 import { TransactionsTable } from "./transactions-table";
 import TransactionsPagination from "./transactions-pagination";
+import { ErrorState } from "@/components/ui/error-state";
 
 /** Map token symbol → icon path */
 const getTokenIcon = (token: string): string => {
@@ -102,12 +103,11 @@ export default function TransactionsContent() {
 
             {/* Error state */}
             {!isLoading && error && (
-              <div
-                role="alert"
-                className="py-8 text-center text-red-400 text-sm"
-              >
-                Failed to load transactions. Please try again.
-              </div>
+              <ErrorState
+                title="Failed to Load"
+                description="Failed to load transactions. Please try again."
+                onRetry={() => window.location.reload()}
+              />
             )}
 
             {/* Data state */}

--- a/components/transactions/transactions-table.tsx
+++ b/components/transactions/transactions-table.tsx
@@ -12,6 +12,7 @@ import { TransactionsTableProps } from "@/types/transaction";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
 import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
 
 interface TransactionsTablePropsExtended extends TransactionsTableProps {
   isLoading?: boolean;
@@ -78,9 +79,10 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
             ) : isEmpty ? (
               <TableRow>
                 <TableCell colSpan={6} className="py-12 text-center">
-                  <div role="status" aria-live="polite" className="text-muted-foreground">
-                    No transactions found. Try adjusting your filters.
-                  </div>
+                  <EmptyState
+                    title="No Transactions Found"
+                    description="No transactions found. Try adjusting your filters."
+                  />
                 </TableCell>
               </TableRow>
             ) : (
@@ -150,10 +152,11 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
             </div>
           ))
         ) : isEmpty ? (
-          <div className="p-8 text-center border rounded-lg border-[#2D2D2D]">
-            <div role="status" aria-live="polite" className="text-muted-foreground">
-              No transactions found. Try adjusting your filters.
-            </div>
+          <div className="p-8 border rounded-lg border-[#2D2D2D]">
+            <EmptyState
+              title="No Transactions Found"
+              description="No transactions found. Try adjusting your filters."
+            />
           </div>
         ) : (
           transactions.map((transaction, index) => (

--- a/components/ui/empty-state.test.tsx
+++ b/components/ui/empty-state.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EmptyState } from "./empty-state";
+
+describe("EmptyState Component", () => {
+  it("renders with required props and accessibility roles", () => {
+    render(<EmptyState title="No Data" description="There is no data to show." />);
+    
+    const status = screen.getByRole("status");
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveAttribute("aria-live", "polite");
+    
+    expect(screen.getByText("No Data")).toBeInTheDocument();
+    expect(screen.getByText("There is no data to show.")).toBeInTheDocument();
+    expect(document.querySelector("svg")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders action button and handles click when onRetry is provided", () => {
+    const onRetryMock = vi.fn();
+    render(
+      <EmptyState
+        title="No Results"
+        description="Your search returned no results."
+        onRetry={onRetryMock}
+      />
+    );
+    
+    const button = screen.getByRole("button", { name: /clear filters/i });
+    expect(button).toBeInTheDocument();
+    
+    fireEvent.click(button);
+    expect(onRetryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders custom action label when provided", () => {
+    render(
+      <EmptyState
+        title="No Results"
+        description="Your search returned no results."
+        onRetry={() => {}}
+        actionLabel="Reset Search"
+      />
+    );
+    
+    const button = screen.getByRole("button", { name: /reset search/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("renders custom icon when provided", () => {
+    render(
+      <EmptyState
+        title="Custom Icon"
+        description="Testing custom icon"
+        icon={<div data-testid="custom-icon">Icon</div>}
+      />
+    );
+    
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+});

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React from "react";
+import { Inbox } from "lucide-react";
+
+export interface EmptyStateProps {
+  /** The icon to display. Defaults to an inbox icon. */
+  icon?: React.ReactNode;
+  /** The empty state title. */
+  title: string;
+  /** A user-friendly description of why the state is empty or how to populate it. */
+  description: string;
+  /** Optional callback to trigger an action (like retry or clear filters). */
+  onRetry?: () => void;
+  /** Optional custom action text if onRetry is provided. Defaults to "Clear Filters". */
+  actionLabel?: string;
+}
+
+/**
+ * Reusable EmptyState component.
+ * Displays an empty state with proper accessibility semantics (role="status", aria-live).
+ */
+export function EmptyState({
+  icon,
+  title,
+  description,
+  onRetry,
+  actionLabel = "Clear Filters",
+}: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex flex-col items-center justify-center p-8 text-center border border-[#2D2D2D] bg-[#111111] rounded-xl"
+    >
+      <div className="text-zinc-500 mb-4">
+        {icon || <Inbox className="w-10 h-10" aria-hidden="true" />}
+      </div>
+      <h3 className="text-lg font-semibold text-white mb-2">{title}</h3>
+      <p className="text-sm text-zinc-400 max-w-md mb-6">{description}</p>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="px-4 py-2 bg-[#2D2D2D] hover:bg-[#3A3A3A] transition-colors text-white text-sm font-medium rounded-lg"
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/ui/error-state.test.tsx
+++ b/components/ui/error-state.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ErrorState } from "./error-state";
+
+describe("ErrorState Component", () => {
+  it("renders with required props and accessibility roles", () => {
+    render(<ErrorState title="Error Title" description="Error Description" />);
+    
+    const alert = screen.getByRole("alert");
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveAttribute("aria-live", "assertive");
+    
+    expect(screen.getByText("Error Title")).toBeInTheDocument();
+    expect(screen.getByText("Error Description")).toBeInTheDocument();
+    // Default icon (hidden from screen readers) should be present
+    expect(document.querySelector("svg")).toBeInTheDocument();
+    // Try Again button should NOT be rendered
+    expect(screen.queryByRole("button", { name: /try again/i })).not.toBeInTheDocument();
+  });
+
+  it("renders retry button and handles click when onRetry is provided", () => {
+    const onRetryMock = vi.fn();
+    render(
+      <ErrorState
+        title="Network Error"
+        description="Could not connect to the server."
+        onRetry={onRetryMock}
+      />
+    );
+    
+    const button = screen.getByRole("button", { name: /try again/i });
+    expect(button).toBeInTheDocument();
+    
+    fireEvent.click(button);
+    expect(onRetryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders custom icon when provided", () => {
+    render(
+      <ErrorState
+        title="Custom Icon"
+        description="Testing custom icon"
+        icon={<div data-testid="custom-icon">Icon</div>}
+      />
+    );
+    
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+});

--- a/components/ui/error-state.tsx
+++ b/components/ui/error-state.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React from "react";
+import { AlertCircle } from "lucide-react";
+
+export interface ErrorStateProps {
+  /** The icon to display. Defaults to an alert circle. */
+  icon?: React.ReactNode;
+  /** The error title. */
+  title: string;
+  /** A user-friendly error description. Do not pass raw exceptions here. */
+  description: string;
+  /** Optional callback to trigger a retry action. */
+  onRetry?: () => void;
+}
+
+/**
+ * Reusable ErrorState component.
+ * Displays an error message with proper accessibility semantics (role="alert", aria-live).
+ */
+export function ErrorState({
+  icon,
+  title,
+  description,
+  onRetry,
+}: ErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="flex flex-col items-center justify-center p-8 text-center border border-red-900/20 bg-red-900/10 rounded-xl"
+    >
+      <div className="text-red-500 mb-4">
+        {icon || <AlertCircle className="w-10 h-10" aria-hidden="true" />}
+      </div>
+      <h3 className="text-lg font-semibold text-white mb-2">{title}</h3>
+      <p className="text-sm text-zinc-400 max-w-md mb-6">{description}</p>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="px-4 py-2 bg-[#2D2D2D] hover:bg-[#3A3A3A] transition-colors text-white text-sm font-medium rounded-lg"
+        >
+          Try Again
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Description:
Resolves Issue-#304 by extracting disparate, inline error and empty placeholder markups into a tokenized, highly accessible pair of reusable components (ErrorState and EmptyState) located in components/ui/.

Changes Made:

- Added `ErrorState` and `EmptyState` components to `components/ui/` with full a11y roles and RTL tests.
- Replaced inline error and empty markup in the transactions table and analytics/payment-history views with these new shared components.
- Configured safe retry actions where appropriate.
Security: ErrorState requires a `description` prop that safely displays user-friendly copy without rendering raw exceptions to the DOM.

Closes #304 