### PR TITLE
fix(a11y): label the network-switcher confirmation dialog (#343)

### DIFF
--- a/components/common/network-switcher.tsx
+++ b/components/common/network-switcher.tsx
@@ -11,9 +11,17 @@
  *   navigation; trigger now has an explicit aria-label describing the
  *   current network so screen readers announce it correctly
  * - No secrets or private keys are ever displayed
+ *
+ * Improvements over the original (issue #343):
+ * - Confirmation dialog is associated with its title via `aria-labelledby`
+ *   and with its descriptive body via `aria-describedby` so screen-reader
+ *   users hear the full context when the dialog opens.
+ * - Target network name is wrapped in `<strong>` for semantic emphasis.
+ * - Focus returns to the DropdownMenuTrigger when the dialog closes
+ *   (either Cancel or Escape).
  */
 
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -86,6 +94,25 @@ export default function NetworkSwitcher({
   // app until the user confirms.
   const [pendingNetwork, setPendingNetwork] = useState<Network | null>(null);
 
+  /**
+   * Ref to the DropdownMenuTrigger button so focus can be explicitly returned
+   * to it when the confirmation dialog closes (issue #343).
+   * We attach this to a wrapper <div> because the shadcn DropdownMenuTrigger
+   * wrapper does not forward refs; the wrapping element is used only for
+   * focus-return measurement — the actual trigger button is queried inside it.
+   */
+  const triggerWrapperRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * Returns focus to the DropdownMenuTrigger button after the dialog closes.
+   * Called from `onCloseAutoFocus` on DialogContent (issue #343).
+   */
+  const returnFocusToTrigger = (e: Event) => {
+    e.preventDefault(); // suppress Radix's default focus-return
+    const btn = triggerWrapperRef.current?.querySelector<HTMLElement>('[data-slot="dropdown-menu-trigger"]');
+    btn?.focus();
+  };
+
   const isDashboard = variant === "dashboard";
 
   const handleNetworkSelect = (network: Network) => {
@@ -103,9 +130,17 @@ export default function NetworkSwitcher({
     }
     onNetworkChange?.(pendingNetwork);
     setPendingNetwork(null);
+    // Focus returns to the trigger via onCloseAutoFocus on DialogContent
+    // (issue #343).
   };
 
-  const cancelSwitch = () => setPendingNetwork(null);
+  /**
+   * Cancels the pending switch. Focus returns to the dropdown trigger via
+   * the `onCloseAutoFocus` handler on DialogContent (issue #343).
+   */
+  const cancelSwitch = () => {
+    setPendingNetwork(null);
+  };
 
   if (isLoading) {
     return <Skeleton className={cn("h-9 w-24 rounded-md", className)} />;
@@ -114,6 +149,8 @@ export default function NetworkSwitcher({
   return (
     <>
       {/* ── Dropdown ─────────────────────────────────────────────────── */}
+      {/* ref wrapper lets us locate the trigger button for focus-return (issue #343) */}
+      <div ref={triggerWrapperRef} style={{ display: "contents" }}>
       <DropdownMenu>
         <DropdownMenuTrigger
           aria-label={`Current network: ${currentNetwork.name}. Click to switch network.`}
@@ -182,20 +219,44 @@ export default function NetworkSwitcher({
           })}
         </DropdownMenuContent>
       </DropdownMenu>
+      </div>{/* /triggerWrapperRef */}
 
       {/* ── Confirmation dialog ───────────────────────────────────────── */}
+      {/*
+       * aria-labelledby points to the DialogTitle so screen readers announce
+       * "Switch network?" as the dialog name when it opens (issue #343).
+       *
+       * aria-describedby points to the DialogDescription so the full warning
+       * text — including the target network name — is read after the title.
+       *
+       * Radix Dialog sets role="dialog" and manages focus automatically;
+       * focus moves to the first focusable element (Cancel) when it opens.
+       * onCloseAutoFocus returns focus to the DropdownMenuTrigger button so
+       * keyboard users land back on the control they originally activated.
+       */}
       <Dialog open={!!pendingNetwork} onOpenChange={(open) => { if (!open) cancelSwitch(); }}>
         <DialogContent
           className="bg-[#1A1A1A] border-[#242428] text-white max-w-sm"
           showCloseButton={false}
+          aria-labelledby="network-switcher-dialog-title"
+          aria-describedby="network-switcher-dialog-desc"
+          onCloseAutoFocus={returnFocusToTrigger}
         >
           <DialogHeader>
-            <DialogTitle className="text-white">Switch network?</DialogTitle>
-            <DialogDescription className="text-[#9CA3AF]">
+            <DialogTitle
+              id="network-switcher-dialog-title"
+              className="text-white"
+            >
+              Switch network?
+            </DialogTitle>
+            <DialogDescription
+              id="network-switcher-dialog-desc"
+              className="text-[#9CA3AF]"
+            >
               You are switching from{" "}
-              <span className="font-semibold text-white">{currentNetwork.name}</span>{" "}
+              <strong className="font-semibold text-white">{currentNetwork.name}</strong>{" "}
               to{" "}
-              <span className="font-semibold text-white">{pendingNetwork?.name}</span>.
+              <strong className="font-semibold text-white">{pendingNetwork?.name}</strong>.
               <br />
               <br />
               Your displayed balances and transaction history will reflect the

--- a/tests/network-switcher.spec.ts
+++ b/tests/network-switcher.spec.ts
@@ -246,6 +246,132 @@ test.describe("NetworkSwitcher — keyboard accessibility", () => {
   });
 });
 
+/**
+ * Accessibility assertions for issue #343.
+ *
+ * Verifies that the confirmation dialog:
+ *  - carries aria-labelledby pointing to the DialogTitle
+ *  - carries aria-describedby pointing to the DialogDescription
+ *  - emphasises the target network name with a <strong> element
+ *  - returns focus to the DropdownMenuTrigger after Cancel
+ *  - returns focus to the DropdownMenuTrigger after Confirm
+ */
+test.describe("NetworkSwitcher — dialog ARIA labels (issue #343)", () => {
+  test("confirmation dialog has aria-labelledby referencing its title", async ({ page }) => {
+    await page.goto(LANDING_URL);
+
+    // Open dropdown and pick a different network to show the dialog
+    const trigger = page.locator('[aria-label*="Current network"]').first();
+    await trigger.click();
+    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // The dialog element must carry aria-labelledby
+    const labelledBy = await dialog.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+
+    // The element referenced by aria-labelledby must contain the dialog title text
+    const titleEl = page.locator(`#${labelledBy}`);
+    await expect(titleEl).toContainText(/switch network/i);
+  });
+
+  test("confirmation dialog has aria-describedby referencing its description", async ({ page }) => {
+    await page.goto(LANDING_URL);
+
+    const trigger = page.locator('[aria-label*="Current network"]').first();
+    await trigger.click();
+    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // The dialog element must carry aria-describedby
+    const describedBy = await dialog.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+
+    // The element referenced by aria-describedby must include the warning copy
+    const descEl = page.locator(`#${describedBy}`);
+    await expect(descEl).toContainText(/Polygon/i);
+    await expect(descEl).toContainText(/no funds will be moved/i);
+  });
+
+  test("target network name is wrapped in a <strong> element for semantic emphasis", async ({ page }) => {
+    await page.goto(LANDING_URL);
+
+    const trigger = page.locator('[aria-label*="Current network"]').first();
+    await trigger.click();
+    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // Retrieve the aria-describedby id so we scope the strong search to the description
+    const describedBy = await dialog.getAttribute("aria-describedby");
+    const strongWithNetwork = page.locator(`#${describedBy} strong`).filter({ hasText: /Polygon/i });
+    await expect(strongWithNetwork).toBeVisible();
+  });
+
+  test("focus returns to the trigger after cancelling the dialog", async ({ page }) => {
+    await page.goto(LANDING_URL);
+
+    const trigger = page.locator('[aria-label*="Current network"]').first();
+    await trigger.click();
+    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+
+    // Cancel the dialog
+    await page.getByRole("button", { name: /cancel/i }).click();
+
+    // Dialog should be gone
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+
+    // Focus must have returned to the network-switcher trigger
+    await expect(trigger).toBeFocused();
+  });
+
+  test("focus returns to the trigger after confirming the dialog", async ({ page }) => {
+    await page.goto(LANDING_URL);
+
+    const trigger = page.locator('[aria-label*="Current network"]').first();
+    await trigger.click();
+    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+
+    // Confirm the switch
+    await page.getByTestId("confirm-network-switch").click();
+
+    // Dialog should be gone
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+
+    // Focus must be back on the trigger (now labelled Polygon)
+    const updatedTrigger = page.locator('[aria-label*="Current network"]').first();
+    await expect(updatedTrigger).toBeFocused();
+  });
+
+  test("dialog title and description ids are stable across open/close cycles", async ({ page }) => {
+    await page.goto(LANDING_URL);
+
+    for (let i = 0; i < 2; i++) {
+      const trigger = page.locator('[aria-label*="Current network"]').first();
+      await trigger.click();
+      await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+
+      const dialog = page.getByRole("dialog");
+      await expect(dialog).toBeVisible();
+
+      const labelledBy = await dialog.getAttribute("aria-labelledby");
+      const describedBy = await dialog.getAttribute("aria-describedby");
+
+      expect(labelledBy).toBe("network-switcher-dialog-title");
+      expect(describedBy).toBe("network-switcher-dialog-desc");
+
+      // Cancel and repeat
+      await page.getByRole("button", { name: /cancel/i }).click();
+      await expect(dialog).not.toBeVisible();
+    }
+  });
+});
+
 test.describe("Performance & Trace Validation", () => {
   test("main pages load and have no major layout shift or console errors", async ({ page, context }) => {
     // Start tracing before navigating


### PR DESCRIPTION
## Description

The confirmation dialog in `components/common/network-switcher.tsx` was not associated with its title or description via ARIA attributes, meaning screen-reader users had no reliable way to hear which network they were about to switch to when the dialog opened.

Changes made:

- Added `aria-labelledby="network-switcher-dialog-title"` to `DialogContent`, referencing the `DialogTitle` id, so screen readers announce "Switch network?" as the dialog name on open.
- Added `aria-describedby="network-switcher-dialog-desc"` to `DialogContent`, referencing the `DialogDescription` id, so the full warning copy (including both network names) is read after the title.
- Replaced `<span>` wrappers around the from/to network names with `<strong>` for semantic emphasis, ensuring assistive technologies convey their importance.
- Added `onCloseAutoFocus` on `DialogContent` to return focus to the `DropdownMenuTrigger` when the dialog closes (Cancel, Confirm, or Escape), so keyboard users are not left stranded.
- Extended `tests/network-switcher.spec.ts` with 5 new assertions covering all of the above.

## Related Issue

Closes #343

## Checklist

- [x] I have tested the changes locally.
- [x] I have added/updated documentation as needed.
- [x] I have reviewed the code and ensured it follows the project guidelines.
- [x] I have added necessary tests.

## Screenshots/Recordings

<img width="1092" height="731" alt="aria-label-passed-test" src="https://github.com/user-attachments/assets/aabc5f56-51b8-4822-bd58-cae86999f376" />


No visual changes — this PR only affects ARIA attributes, semantic HTML, and focus management. All changes are verified through the Playwright test suite in `tests/network-switcher.spec.ts`.

## Additional Notes

- Network names are rendered as plain escaped text nodes — no HTML injection is possible.
- The `DialogTitle` and `DialogDescription` ids (`network-switcher-dialog-title` and `network-switcher-dialog-desc`) are hardcoded and stable across open/close cycles, confirmed by a dedicated test.
- The Playwright browser binary must be installed before running the tests locally: `npx playwright install chromium`.
