### PR TITLE
fix(a11y): focus management and aria-invalid for destructive confirmation dialog

### DIFF
--- a/app/settings/preferences/components/destructive-action-dialog.test.tsx
+++ b/app/settings/preferences/components/destructive-action-dialog.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import DestructiveActionDialog from "./destructive-action-dialog";
+
+/**
+ * Renders the dialog with sensible defaults and immediately opens it, returning
+ * the `onConfirm` spy so individual tests can assert whether it fired.
+ */
+function renderOpenDialog(onConfirm = vi.fn()) {
+  render(
+    <DestructiveActionDialog
+      triggerLabel="Deactivate account"
+      title="Deactivate this account"
+      description="This pauses sign-in."
+      impactItems={["Wallet operations would be blocked."]}
+      confirmationToken="DEACTIVATE"
+      confirmationLabel='Type "DEACTIVATE" to confirm'
+      confirmLabel="Confirm deactivation"
+      onConfirm={onConfirm}
+    />,
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: "Deactivate account" }));
+  return { onConfirm };
+}
+
+const getInput = () => screen.getByLabelText('Type "DEACTIVATE" to confirm');
+const getConfirmButton = () =>
+  screen.getByRole("button", { name: "Confirm deactivation" });
+
+describe("DestructiveActionDialog", () => {
+  it("auto-focuses the confirmation input and exposes its requirements", () => {
+    renderOpenDialog();
+
+    const input = getInput();
+    expect(input).toHaveFocus();
+    expect(input).toHaveAttribute("aria-required", "true");
+    expect(input).toHaveAttribute("aria-invalid", "false");
+    expect(input).toHaveAccessibleDescription(/type "DEACTIVATE" exactly/i);
+    expect(getConfirmButton()).toBeDisabled();
+  });
+
+  it("hints at invisible whitespace when only spaces differ", () => {
+    const { onConfirm } = renderOpenDialog();
+    const input = getInput();
+
+    fireEvent.change(input, { target: { value: "DEACTIVATE " } });
+
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/extra spaces/i);
+    expect(getConfirmButton()).toBeDisabled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("hints at capitalization when only the casing differs", () => {
+    renderOpenDialog();
+
+    fireEvent.change(getInput(), { target: { value: "deactivate" } });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/capitalization/i);
+    expect(getConfirmButton()).toBeDisabled();
+  });
+
+  it("shows a generic mismatch error for unrelated input", () => {
+    renderOpenDialog();
+
+    fireEvent.change(getInput(), { target: { value: "nope" } });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/doesn't match/i);
+    expect(getConfirmButton()).toBeDisabled();
+  });
+
+  it("confirms only on an exact, case-correct token", () => {
+    const { onConfirm } = renderOpenDialog();
+
+    fireEvent.change(getInput(), { target: { value: "DEACTIVATE" } });
+
+    const input = getInput();
+    expect(input).toHaveAttribute("aria-invalid", "false");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    const confirmButton = getConfirmButton();
+    expect(confirmButton).toBeEnabled();
+
+    fireEvent.click(confirmButton);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/settings/preferences/components/destructive-action-dialog.tsx
+++ b/app/settings/preferences/components/destructive-action-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -25,6 +25,60 @@ interface DestructiveActionDialogProps {
   onConfirm: () => void;
 }
 
+/**
+ * Inspects the typed confirmation against the required token and returns a
+ * human-readable hint describing *why* it does not match.
+ *
+ * The comparison the dialog acts on is intentionally **exact** (see
+ * {@link DestructiveActionDialog}); this helper only exists to explain a
+ * mismatch to the user so a silent failure — most importantly an invisible
+ * trailing space — becomes obvious.
+ *
+ * @param value - The raw text the user typed (never trimmed before matching).
+ * @param token - The exact token the user must reproduce to confirm.
+ * @returns A guidance string when the value does not exactly match the token,
+ *   or `null` when the field is empty or the value matches exactly.
+ */
+function getConfirmationError(value: string, token: string): string | null {
+  if (value.length === 0) {
+    return null;
+  }
+
+  if (value === token) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  // Same characters, but surrounded by whitespace the user cannot see.
+  if (trimmed === token) {
+    return `Remove the extra spaces — type exactly "${token}".`;
+  }
+
+  // Right letters, wrong capitalization. The match is case-sensitive on purpose.
+  if (trimmed.toLowerCase() === token.toLowerCase()) {
+    return `Check the capitalization — type exactly "${token}".`;
+  }
+
+  return `The text doesn't match. Type exactly "${token}" to confirm.`;
+}
+
+/**
+ * A confirmation dialog for irreversible, high-impact actions (e.g. account
+ * deactivation, wallet removal).
+ *
+ * Accessibility & safety behaviour:
+ * - The confirmation input is auto-focused when the dialog opens
+ *   (`onOpenAutoFocus`), and focus returns to the trigger button on close —
+ *   focus trapping and restoration are provided by Radix's `Dialog`.
+ * - The input is wired with `aria-required`, `aria-invalid`, and
+ *   `aria-describedby` (instruction text + error) via the shared `Input`
+ *   component.
+ * - The confirm action requires an **exact** token match — the value is *not*
+ *   trimmed or lower-cased — so accidental whitespace or wrong casing can never
+ *   bypass the user's intent. Any mismatch is surfaced inline (including a
+ *   whitespace-specific hint) instead of failing silently.
+ */
 export default function DestructiveActionDialog({
   triggerLabel,
   title,
@@ -37,9 +91,19 @@ export default function DestructiveActionDialog({
 }: DestructiveActionDialogProps) {
   const [open, setOpen] = useState(false);
   const [confirmationText, setConfirmationText] = useState("");
-  const inputId = `confirmation-${confirmationToken.toLowerCase()}`;
 
-  const isConfirmed = confirmationText.trim() === confirmationToken;
+  const inputId = `confirmation-${confirmationToken.toLowerCase()}`;
+  const labelId = `${inputId}-label`;
+  const instructionId = `${inputId}-instruction`;
+  const errorId = `${inputId}-error`;
+
+  // Strict, exact comparison: whitespace and casing must match the token.
+  const isConfirmed = confirmationText === confirmationToken;
+
+  const validationError = useMemo(
+    () => getConfirmationError(confirmationText, confirmationToken),
+    [confirmationText, confirmationToken],
+  );
 
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
@@ -64,7 +128,15 @@ export default function DestructiveActionDialog({
         <Button variant="destructive">{triggerLabel}</Button>
       </DialogTrigger>
 
-      <DialogContent className="border-zinc-200 bg-white text-zinc-900 dark:border-white/10 dark:bg-[#09090B] dark:text-white">
+      <DialogContent
+        className="border-zinc-200 bg-white text-zinc-900 dark:border-white/10 dark:bg-[#09090B] dark:text-white"
+        onOpenAutoFocus={(event) => {
+          // Override Radix's default (focus the content/close button) so the
+          // user lands directly on the field they must fill in.
+          event.preventDefault();
+          document.getElementById(inputId)?.focus();
+        }}
+      >
         <DialogHeader className="space-y-3 text-left">
           <div className="flex items-center gap-3">
             <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-red-500/10 text-red-500">
@@ -96,18 +168,41 @@ export default function DestructiveActionDialog({
 
           <div className="space-y-2">
             <label
+              id={labelId}
               htmlFor={inputId}
               className="text-sm font-medium text-zinc-900 dark:text-white"
             >
               {confirmationLabel}
             </label>
+            <p
+              id={instructionId}
+              className="text-xs text-zinc-600 dark:text-zinc-400"
+            >
+              {`Type "${confirmationToken}" exactly to confirm.`}
+            </p>
             <Input
               id={inputId}
               value={confirmationText}
               onChange={(event) => setConfirmationText(event.target.value)}
               placeholder={confirmationToken}
               className="border-zinc-200 bg-white dark:border-white/10 dark:bg-white/5"
+              required
+              aria-required
+              error={Boolean(validationError)}
+              labelId={labelId}
+              descriptionId={instructionId}
+              errorId={errorId}
             />
+            {validationError && (
+              <p
+                id={errorId}
+                role="alert"
+                aria-live="polite"
+                className="text-xs font-medium text-red-500"
+              >
+                {validationError}
+              </p>
+            )}
           </div>
         </div>
 

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -44,6 +44,66 @@ test("desktop settings navigation and destructive confirmation stay clear", asyn
   });
 });
 
+test("destructive confirmation dialog is labeled and focus-managed", async ({
+  page,
+}) => {
+  await page.goto("/settings/preferences?section=account");
+
+  const trigger = page.getByRole("button", { name: "Deactivate account" });
+  await trigger.click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+
+  const input = page.getByLabel('Type "DEACTIVATE" to confirm');
+  const confirmButton = page.getByRole("button", {
+    name: "Confirm deactivation",
+  });
+
+  // Auto-focus: the field the user must fill is focused on open.
+  await expect(input).toBeFocused();
+
+  // ARIA wiring is present and starts in a valid, required state.
+  await expect(input).toHaveAttribute("aria-required", "true");
+  await expect(input).toHaveAttribute("aria-invalid", "false");
+  await expect(confirmButton).toBeDisabled();
+
+  // Wrong token -> inline error, aria-invalid flips, error is described.
+  await input.fill("nope");
+  await expect(confirmButton).toBeDisabled();
+  await expect(input).toHaveAttribute("aria-invalid", "true");
+  const errorMessage = dialog.getByRole("alert");
+  await expect(errorMessage).toBeVisible();
+  await expect(errorMessage).toContainText("doesn't match");
+  const errorId = await errorMessage.getAttribute("id");
+  expect(errorId).toBeTruthy();
+  await expect(input).toHaveAttribute(
+    "aria-describedby",
+    new RegExp(errorId as string),
+  );
+
+  // Trailing-space token -> still rejected, with a whitespace-specific hint.
+  await input.fill("DEACTIVATE ");
+  await expect(confirmButton).toBeDisabled();
+  await expect(dialog.getByRole("alert")).toContainText("extra spaces");
+
+  // Wrong casing -> rejected, with a capitalization hint (case-sensitive match).
+  await input.fill("deactivate");
+  await expect(confirmButton).toBeDisabled();
+  await expect(dialog.getByRole("alert")).toContainText("capitalization");
+
+  // Exact token -> valid: error clears and confirm is enabled.
+  await input.fill("DEACTIVATE");
+  await expect(input).toHaveAttribute("aria-invalid", "false");
+  await expect(dialog.getByRole("alert")).toHaveCount(0);
+  await expect(confirmButton).toBeEnabled();
+
+  // Escape cancels the dialog and restores focus to the trigger.
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+  await expect(trigger).toBeFocused();
+});
+
 test("mobile settings nav remains reachable", async ({ page }) => {
   ensureScreenshotDirectory();
 


### PR DESCRIPTION
Closes #344

## 📌 Summary

Closes accessibility & security gaps in `app/settings/preferences/components/destructive-action-dialog.tsx` (issue #344). The confirmation input now auto-focuses, is fully ARIA-wired, shows inline validation feedback, and matches the confirmation token **exactly** so accidental whitespace can no longer silently bypass intent.

## ✅ Changes

**`app/settings/preferences/components/destructive-action-dialog.tsx`**
- **Auto-focus** the confirmation input on open via `onOpenAutoFocus`.
- **ARIA wiring**: `aria-required`, `aria-invalid` (flips on mismatch), and `aria-describedby` linking the instruction text **and** the inline error (via the shared `Input` component's `labelId` / `descriptionId` / `errorId` props).
- **Inline error** in a `role="alert"` live region with specific guidance: a whitespace hint ("Remove the extra spaces"), a casing hint ("Check the capitalization"), or a generic mismatch — instead of failing silently.
- **Security hardening**: the confirm check changed from `confirmationText.trim() === token` to an **exact** `confirmationText === token` (case-sensitive, no trimming).
- **TSDoc** documenting the accessibility/security guarantees.

> Focus *trapping* and *focus restoration to the trigger* on close are already provided by Radix `Dialog`; the Playwright test asserts both.

**Tests**
- `tests/settings.spec.ts` — new Playwright test `destructive confirmation dialog is labeled and focus-managed`: auto-focus, `aria-required` / `aria-invalid` / `aria-describedby`, wrong token, trailing-space token, wrong casing, exact match, and Escape-to-cancel with focus restored to the trigger.
- `app/settings/preferences/components/destructive-action-dialog.test.tsx` — new RTL/Vitest unit suite covering auto-focus, accessible description, whitespace/casing/generic mismatch states, and exact-token confirmation (so the component is covered by `npm run test`).

## 🧪 Test results

`node node_modules/vitest/vitest.mjs run app/settings/preferences/components/destructive-action-dialog.test.tsx`
```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

`npx playwright test tests/settings.spec.ts`
- ✅ `destructive confirmation dialog is labeled and focus-managed` — **passed**
- ✅ `mobile settings nav remains reachable` — **passed**
- ⚠️ `desktop settings navigation and destructive confirmation stay clear` — fails on an **unrelated, pre-existing** assertion (`getByText("Connected wallets")`) before the dialog is opened. Verified it fails identically on untouched `main`, so it is **not** introduced by this PR.

`npx tsc --noEmit` — clean on the changed files.

## 🔒 Security notes

The confirmation comparison is intentionally **exact**: the typed value is neither trimmed nor lower-cased. A trailing space or wrong capitalization keeps the destructive action disabled, and the reason is surfaced inline to the user. This removes the previous `.trim()` path where `"DEACTIVATE "` (trailing space) was silently accepted.
