### PR TITLE
fix(pagination): guard invalid bounds

### DIFF
--- a/utils/paginationUtils.test.ts
+++ b/utils/paginationUtils.test.ts
@@ -41,12 +41,28 @@ describe("paginationUtils", () => {
       expect(getPageItems(items, 4, itemsPerPage)).toEqual([]);
     });
 
-    it("does not clamp page zero to the first page", () => {
-      expect(getPageItems(items, 0, itemsPerPage)).toEqual([]);
+    it("clamps page zero to the first page", () => {
+      expect(getPageItems(items, 0, itemsPerPage)).toEqual([
+        "alpha",
+        "bravo",
+        "charlie",
+      ]);
     });
 
-    it("returns an empty list for a negative page instead of slicing from the end", () => {
-      expect(getPageItems(items, -1, itemsPerPage)).toEqual([]);
+    it("clamps a negative page to the first page instead of slicing from the end", () => {
+      expect(getPageItems(items, -1, itemsPerPage)).toEqual([
+        "alpha",
+        "bravo",
+        "charlie",
+      ]);
+    });
+
+    it("defaults a zero page size to one item per page", () => {
+      expect(getPageItems(items, 2, 0)).toEqual(["bravo"]);
+    });
+
+    it("returns all items when the page size is larger than the list", () => {
+      expect(getPageItems(items, 1, 100)).toEqual(items);
     });
   });
 
@@ -62,6 +78,17 @@ describe("paginationUtils", () => {
     it("returns zero pages when there are no items", () => {
       expect(getTotalPages(0, 4)).toBe(0);
     });
+
+    it("defaults zero and negative page sizes to one item per page", () => {
+      expect(getTotalPages(7, 0)).toBe(7);
+      expect(getTotalPages(7, -3)).toBe(7);
+    });
+
+    it("never returns Infinity or NaN for invalid inputs", () => {
+      expect(Number.isFinite(getTotalPages(7, 0))).toBe(true);
+      expect(Number.isNaN(getTotalPages(Number.NaN, 10))).toBe(false);
+      expect(getTotalPages(Number.NaN, 10)).toBe(0);
+    });
   });
 
   describe("index helpers", () => {
@@ -73,6 +100,11 @@ describe("paginationUtils", () => {
     it("returns start and end indexes for page 2", () => {
       expect(getStartIndex(2, 10)).toBe(10);
       expect(getEndIndex(2, 10)).toBe(20);
+    });
+
+    it("clamps negative pages and invalid page sizes", () => {
+      expect(getStartIndex(-2, 0)).toBe(0);
+      expect(getEndIndex(-2, 0)).toBe(1);
     });
   });
 
@@ -86,6 +118,11 @@ describe("paginationUtils", () => {
       expect(isValidPage(0, 5)).toBe(false);
       expect(isValidPage(-1, 5)).toBe(false);
       expect(isValidPage(6, 5)).toBe(false);
+    });
+
+    it("rejects non-finite pages", () => {
+      expect(isValidPage(Number.NaN, 5)).toBe(false);
+      expect(isValidPage(Number.POSITIVE_INFINITY, 5)).toBe(false);
     });
   });
 });

--- a/utils/paginationUtils.ts
+++ b/utils/paginationUtils.ts
@@ -2,8 +2,22 @@
  * Pagination utility functions
  */
 
+const MIN_PAGE = 1;
+const MIN_ITEMS_PER_PAGE = 1;
+
+const normalizePage = (page: number): number => {
+  return Number.isFinite(page) ? Math.max(MIN_PAGE, Math.floor(page)) : MIN_PAGE;
+};
+
+const normalizeItemsPerPage = (itemsPerPage: number): number => {
+  return Number.isFinite(itemsPerPage)
+    ? Math.max(MIN_ITEMS_PER_PAGE, Math.floor(itemsPerPage))
+    : MIN_ITEMS_PER_PAGE;
+};
+
 /**
- * Calculates the start index for pagination
+ * Calculates the start index for pagination.
+ * Guarantees a non-negative finite index by clamping page and page size inputs.
  * @param currentPage - Current page number (1-based)
  * @param itemsPerPage - Number of items per page
  * @returns Start index for the current page
@@ -12,11 +26,15 @@ export const getStartIndex = (
   currentPage: number,
   itemsPerPage: number,
 ): number => {
-  return (currentPage - 1) * itemsPerPage;
+  const safePage = normalizePage(currentPage);
+  const safeItemsPerPage = normalizeItemsPerPage(itemsPerPage);
+
+  return (safePage - 1) * safeItemsPerPage;
 };
 
 /**
- * Calculates the end index for pagination
+ * Calculates the end index for pagination.
+ * Guarantees a positive finite index by clamping page and page size inputs.
  * @param currentPage - Current page number (1-based)
  * @param itemsPerPage - Number of items per page
  * @returns End index for the current page
@@ -25,11 +43,15 @@ export const getEndIndex = (
   currentPage: number,
   itemsPerPage: number,
 ): number => {
-  return currentPage * itemsPerPage;
+  const safePage = normalizePage(currentPage);
+  const safeItemsPerPage = normalizeItemsPerPage(itemsPerPage);
+
+  return safePage * safeItemsPerPage;
 };
 
 /**
- * Calculates the total number of pages
+ * Calculates the total number of pages.
+ * Guarantees a finite page count; invalid page sizes fall back to 1 item per page.
  * @param totalItems - Total number of items
  * @param itemsPerPage - Number of items per page
  * @returns Total number of pages
@@ -38,11 +60,17 @@ export const getTotalPages = (
   totalItems: number,
   itemsPerPage: number,
 ): number => {
-  return Math.ceil(totalItems / itemsPerPage);
+  const safeTotalItems = Number.isFinite(totalItems)
+    ? Math.max(0, Math.floor(totalItems))
+    : 0;
+  const safeItemsPerPage = normalizeItemsPerPage(itemsPerPage);
+
+  return Math.ceil(safeTotalItems / safeItemsPerPage);
 };
 
 /**
- * Gets a slice of items for the current page
+ * Gets a slice of items for the current page.
+ * Clamps invalid page and page-size inputs before slicing.
  * @param items - Array of all items
  * @param currentPage - Current page number (1-based)
  * @param itemsPerPage - Number of items per page
@@ -53,20 +81,17 @@ export const getPageItems = <T>(
   currentPage: number,
   itemsPerPage: number,
 ): T[] => {
-  if (currentPage <= 0) {
-    return [];
-  }
   const startIndex = getStartIndex(currentPage, itemsPerPage);
   const endIndex = getEndIndex(currentPage, itemsPerPage);
   return items.slice(startIndex, endIndex);
 };
 
 /**
- * Checks if a page number is valid
+ * Checks if a page number is valid.
  * @param page - Page number to check
  * @param totalPages - Total number of pages
  * @returns True if page is valid, false otherwise
  */
 export const isValidPage = (page: number, totalPages: number): boolean => {
-  return page >= 1 && page <= totalPages;
+  return Number.isFinite(page) && page >= MIN_PAGE && page <= totalPages;
 };


### PR DESCRIPTION
## Description
- Clamps invalid pagination page numbers to page 1 before calculating indexes.
- Defaults non-finite, zero, or negative `itemsPerPage` values to a safe minimum of 1.
- Ensures `getTotalPages` returns a finite number for zero, negative, or non-finite inputs.
- Documents the guarded invariants in TSDoc and extends unit coverage for edge cases.

## Related Issue
Closes #331

## Checklist
- [x] I have tested the changes locally.
- [x] I have reviewed the code and ensured it follows the project guidelines.
- [x] I have added necessary tests.

## Test plan
- [x] `node node_modules/vitest/vitest.mjs run utils/paginationUtils.test.ts` — 1 file / 20 tests passed

## Security notes
Pagination values may come from query params, so the helpers now sanitize invalid bounds before they can produce `Infinity`, `NaN`, or negative slice indexes.