### PR TITLE
refactor(transactions): centralize status color palette

### DIFF
--- a/utils/transactionUtils.test.ts
+++ b/utils/transactionUtils.test.ts
@@ -9,6 +9,7 @@ import {
   formatTransactionDate,
   getStatusColor,
   sortTransactions,
+  TRANSACTION_STATUS_COLOR_CLASSES,
 } from "@/utils/transactionUtils";
 
 const fixtureStartDate = "2023-03-26";
@@ -392,17 +393,24 @@ describe("sortTransactions", () => {
 describe("getStatusColor", () => {
   it("returns exact classes for known statuses, unknown statuses, and mixed case", () => {
     const statusCases = [
-      ["completed", "bg-[#102B19] text-[#04842E]"],
-      ["pending", "bg-[#191919] text-[#9F6603]"],
-      ["failed", "bg-[#1A1A1A] text-[#B70B05]"],
-      ["unknown", "bg-[#1A1A1A] text-[#E5E5E5]"],
-      ["CoMpLeTeD", "bg-[#102B19] text-[#04842E]"],
-      ["PeNdInG", "bg-[#191919] text-[#9F6603]"],
-      ["FaIlEd", "bg-[#1A1A1A] text-[#B70B05]"],
+      ["completed", TRANSACTION_STATUS_COLOR_CLASSES.completed],
+      ["pending", TRANSACTION_STATUS_COLOR_CLASSES.pending],
+      ["failed", TRANSACTION_STATUS_COLOR_CLASSES.failed],
+      ["unknown", TRANSACTION_STATUS_COLOR_CLASSES.unknown],
+      ["CoMpLeTeD", TRANSACTION_STATUS_COLOR_CLASSES.completed],
+      ["PeNdInG", TRANSACTION_STATUS_COLOR_CLASSES.pending],
+      ["FaIlEd", TRANSACTION_STATUS_COLOR_CLASSES.failed],
     ] as const;
 
     for (const [status, expectedClassName] of statusCases) {
       expect(getStatusColor(status)).toBe(expectedClassName);
     }
+  });
+
+  it("uses a distinct fallback for unexpected statuses and empty strings", () => {
+    expect(getStatusColor("reversed")).not.toBe(
+      TRANSACTION_STATUS_COLOR_CLASSES.unknown,
+    );
+    expect(getStatusColor("")).not.toBe(TRANSACTION_STATUS_COLOR_CLASSES.unknown);
   });
 });

--- a/utils/transactionUtils.ts
+++ b/utils/transactionUtils.ts
@@ -6,6 +6,22 @@ import type {
 import { formatCurrency } from "./formatUtils";
 import { formatDate } from "./dateUtils";
 
+type TransactionStatusColorKey = "completed" | "pending" | "failed" | "unknown";
+
+/**
+ * Fixed status-to-class palette for transaction badges.
+ * Known status outputs are kept stable while unexpected statuses use
+ * a separate fallback so bad data is visually distinct from "unknown".
+ */
+export const TRANSACTION_STATUS_COLOR_CLASSES = {
+  completed: "bg-[#102B19] text-[#04842E]",
+  pending: "bg-[#191919] text-[#9F6603]",
+  failed: "bg-[#1A1A1A] text-[#B70B05]",
+  unknown: "bg-[#1A1A1A] text-[#E5E5E5]",
+} as const satisfies Record<TransactionStatusColorKey, string>;
+
+const UNEXPECTED_STATUS_COLOR_CLASS = "bg-white text-black";
+
 /**
  * Formats transaction amount with proper currency formatting
  * @param amount - The amount to format
@@ -116,19 +132,19 @@ export const sortTransactions = (
 };
 
 /**
- * Gets the status color for a transaction status
+ * Gets the status color for a transaction status from a fixed palette.
+ * Unexpected statuses never get interpolated into class names.
  * @param status - Transaction status
  * @returns Color class name for the status
  */
 export const getStatusColor = (status: string): string => {
-  switch (status.toLowerCase()) {
-    case "completed":
-      return "bg-[#102B19] text-[#04842E]";
-    case "pending":
-      return "bg-[#191919] text-[#9F6603]";
-    case "failed":
-      return "bg-[#1A1A1A] text-[#B70B05]";
-    default:
-      return "bg-[#1A1A1A] text-[#E5E5E5]";
+  const normalizedStatus = status.toLowerCase();
+
+  if (normalizedStatus in TRANSACTION_STATUS_COLOR_CLASSES) {
+    return TRANSACTION_STATUS_COLOR_CLASSES[
+      normalizedStatus as TransactionStatusColorKey
+    ];
   }
+
+  return UNEXPECTED_STATUS_COLOR_CLASS;
 };


### PR DESCRIPTION
## Description
- Extracts transaction status badge classes into a typed `TRANSACTION_STATUS_COLOR_CLASSES` palette.
- Keeps completed, pending, failed, and unknown status outputs stable.
- Gives truly unexpected statuses a distinct fallback style so bad data does not look like the known `unknown` state.
- Adds tests for known mappings, mixed-case inputs, unknown, empty, and unexpected statuses.

## Related Issue
Closes #333

## Checklist
- [x] I have tested the changes locally.
- [x] I have reviewed the code and ensured it follows the project guidelines.
- [x] I have added necessary tests.

## Test plan
- [x] `node node_modules/vitest/vitest.mjs run utils/transactionUtils.test.ts` — 1 file / 16 tests passed

## Security notes
Status values are mapped through a fixed lookup table, so unexpected values cannot inject arbitrary class names.