### PR TITLE
feat(app): add accessible root error boundary with reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ The context exposes:
 
 Run the unit suite with `npm test` and the end-to-end suite with `npx playwright test tests/wallet.spec.ts`.
 
+## Error handling
+
+The App Router uses two cooperating client boundaries.
+
+`app/error.tsx` is the route-segment boundary. Any uncaught render or runtime error inside a route segment is caught here. It renders inside the root layout, so it has access to theme tokens and shared UI: a generic "Something went wrong" surface built from `bg-background`, `text-foreground`, and `text-destructive`, plus a "Try again" action wired to the `reset()` callback Next.js passes in, and a "Go to dashboard" escape hatch. The surface uses `role="alert"` and `aria-live="assertive"` so assistive tech announces it. In production, the raw `error.message` and `error.stack` are never rendered; the underlying message is only revealed when `process.env.NODE_ENV !== "production"` to keep debugging cheap locally. The `error.digest` Next.js attaches in production is logged through `console.error` so it can be correlated with server logs, but it is intentionally not surfaced in the UI.
+
+`app/global-error.tsx` is the wider safety net for when the root layout itself or one of its providers throws. It ships its own `<html>/<body>` shell with inline styles because the layout that loads `globals.css` is exactly what failed.
+
+Coverage for `app/error.tsx` is gated by the same 95% thresholds as the rest of the suite via `vitest.config.ts`. See `app/error.test.tsx` for the unit coverage.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/app/error.test.tsx
+++ b/app/error.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import React from "react";
+
+import GlobalError from "@/app/error";
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={typeof href === "string" ? href : "#"} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+function buildError(overrides: { digest?: string; message?: string } = {}) {
+  const err = new Error(overrides.message ?? "boom") as Error & {
+    digest?: string;
+  };
+  if (overrides.digest !== undefined) {
+    err.digest = overrides.digest;
+  }
+  return err;
+}
+
+describe("GlobalError boundary", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it("renders an alert region with an accessible heading", () => {
+    render(<GlobalError error={buildError()} reset={vi.fn()} />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /something went wrong/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('"Try again" invokes the reset handler', () => {
+    const reset = vi.fn();
+    render(<GlobalError error={buildError()} reset={reset} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers an escape hatch back to /dashboard", () => {
+    render(<GlobalError error={buildError()} reset={vi.fn()} />);
+
+    const link = screen.getByRole("link", { name: /go to dashboard/i });
+    expect(link).toHaveAttribute("href", "/dashboard");
+  });
+
+  it("logs the digest and keeps it out of the rendered output", () => {
+    const error = buildError({ digest: "abc123" });
+    render(<GlobalError error={error} reset={vi.fn()} />);
+
+    expect(screen.queryByText(/abc123/)).not.toBeInTheDocument();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[app/error] uncaught route error",
+      { digest: "abc123" },
+    );
+  });
+
+  it("still renders and logs when no digest is provided", () => {
+    render(
+      <GlobalError error={buildError({ digest: undefined })} reset={vi.fn()} />,
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[app/error] uncaught route error",
+      { digest: "no-digest" },
+    );
+  });
+
+  it("shows the underlying error message in non-production environments", () => {
+    vi.stubEnv("NODE_ENV", "development");
+
+    render(
+      <GlobalError
+        error={buildError({ message: "stack-revealing detail" })}
+        reset={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("error-dev-details")).toHaveTextContent(
+      "stack-revealing detail",
+    );
+  });
+
+  it("does not render the underlying error message in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    render(
+      <GlobalError
+        error={buildError({ message: "should-never-render" })}
+        reset={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("error-dev-details")).not.toBeInTheDocument();
+    expect(screen.queryByText(/should-never-render/)).not.toBeInTheDocument();
+  });
+});

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * Props that Next.js passes to a route-segment `error.tsx` boundary.
+ *
+ * - `error.digest` is a server-generated hash for the underlying error and is
+ *   the only identifier we ever surface or log. The raw `message`/`stack` is
+ *   kept off the UI in production.
+ * - `reset()` re-renders the segment that errored.
+ */
+type RouteError = Error & { digest?: string };
+
+type GlobalErrorProps = {
+  error: RouteError;
+  reset: () => void;
+};
+
+/**
+ * Root error boundary for the App Router.
+ *
+ * Renders an accessible recovery surface with a "Try again" action wired to
+ * Next's `reset()` and an escape hatch back to `/dashboard`. In production,
+ * the underlying error message and stack trace are never rendered.
+ */
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    const reference = error?.digest ?? "no-digest";
+    // Routed through console for now; swap in an observability hook later
+    // without changing the boundary's public contract.
+    console.error("[app/error] uncaught route error", { digest: reference });
+  }, [error]);
+
+  const showDevDetails =
+    process.env.NODE_ENV !== "production" && Boolean(error?.message);
+
+  return (
+    <main
+      role="alert"
+      aria-live="assertive"
+      className="min-h-screen flex items-center justify-center bg-background text-foreground px-6"
+    >
+      <div className="w-full max-w-md space-y-6 text-center">
+        <h1 className="text-3xl font-semibold text-destructive">
+          Something went wrong
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          We hit an unexpected error while loading this page. You can retry or
+          head back to your dashboard.
+        </p>
+
+        {showDevDetails ? (
+          <pre
+            data-testid="error-dev-details"
+            className="text-left text-xs text-muted-foreground bg-muted/40 p-3 rounded-md overflow-auto"
+          >
+            {error.message}
+          </pre>
+        ) : null}
+
+        <div className="flex items-center justify-center gap-3">
+          <Button onClick={() => reset()}>Try again</Button>
+          <Button variant="outline" asChild>
+            <Link href="/dashboard">Go to dashboard</Link>
+          </Button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
         'utils/transactionUtils.ts',
         'utils/paginationUtils.ts',
         'types/auth.ts',
+        'app/error.tsx',
         'app/global-error.tsx',
         'context/wallet-context.tsx',
         'components/analytics/analytics-view.tsx',


### PR DESCRIPTION
Closes #280

## What this adds

A new `app/error.tsx` route-segment boundary for the App Router. This sits next to the existing `app/global-error.tsx` (which is the wider layout-level safety net) and catches any uncaught render or runtime error inside a route segment.

Because `error.tsx` renders inside the root layout, it has access to `globals.css`, the theme tokens, and the shared `Button`, so the recovery surface looks like the rest of the product instead of a bare HTML shell.

## How it behaves

UX
- `role="alert"` and `aria-live="assertive"` so assistive tech announces the surface.
- An accessible `h1` "Something went wrong".
- "Try again" is wired to Next's `reset()` callback.
- "Go to dashboard" is the escape hatch, rendered through `Button asChild` + `next/link`.
- Built on `bg-background`, `text-foreground`, and `text-destructive` (plus `text-muted-foreground` for the supporting copy).

Security
- The raw `error.message` and `error.stack` are never rendered in production. Only a generic message is shown.
- In development the underlying `error.message` is revealed in a `<pre>` to keep local debugging cheap, gated on `process.env.NODE_ENV !== "production"`.
- `error.digest` is logged through `console.error` only; it is never surfaced in the UI. The log call site is the single seam where a future observability hook would plug in.

## Tests

`app/error.test.tsx` ships 7 Vitest + RTL cases:

1. Renders an alert region with an accessible heading.
2. "Try again" invokes the reset handler.
3. "Go to dashboard" link has `href="/dashboard"`.
4. Digest is logged via `console.error` but not rendered.
5. Still renders and logs when no digest is provided (`"no-digest"` fallback).
6. Shows the underlying error message in non-production environments.
7. Does not render the underlying error message in production (covers both the dev-only branch and the security note).

`vitest.config.ts` adds `app/error.tsx` to the coverage include list so the 95% threshold applies to the new file. Running the full suite locally with the pre-existing broken `app/metadata.test.ts` excluded gives:

```
Test Files  15 passed (15)
     Tests  180 passed (180)
Statements   : 97.73% ( 216/221 )
Branches     : 97.6%  ( 163/167 )
Functions    : 100%   ( 60/60 )
Lines        : 99%    ( 200/202 )
```

`app/error.tsx` does not appear in the per-file uncovered report, which means v8 measured it at 100% across statements, branches, functions, and lines.

## Notes for reviewers

- The pre-existing `app/metadata.test.ts` failure (PostCSS plugin loader error on `globals.css`) reproduces on a clean checkout of upstream `main` and is unrelated to this change.
- The pre-existing `tsc --noEmit` error at `vitest.config.ts:10` (`postcss: false`) also reproduces on a clean checkout of upstream `main`.
- I deliberately did not surface `error.digest` in the UI, matching the existing `global-error.tsx` convention and the issue requirement that the digest be logged "only".
- I did not introduce an in-app "Report" button. The issue body explicitly scopes the report path to a console log (or future observability hook). The single `console.error` call in the effect is the seam where that hook drops in without touching the boundary's public contract.

## Documentation

Added an "Error handling" section to `README.md` covering the two-boundary setup, the reset behavior, and the production stack-trace policy.