### PR TITLE
fix: Centralize transaction status color hex value (#333)

### DIFF
--- a/src/utils/transactionUtils.ts
+++ b/src/utils/transactionUtils.ts
@@ -1,0 +1,16 @@
+import type { TransactionStatus } from '@/types/transaction';
+
+// Define a centralized, typed color palette for transaction statuses
+export const TRANSACTION_STATUS_COLORS: Record<TransactionStatus, string> = {
+  pending: 'bg-[#FFA500] text-[#000000]',
+  confirmed: 'bg-[#4CAF50] text-[#FFFFFF]',
+  failed: 'bg-[#F44336] text-[#FFFFFF]',
+  refunded: 'bg-[#2196F3] text-[#FFFFFF]',
+  settled: 'bg-[#9C27B0] text-[#FFFFFF]',
+  // Default/unknown status with a distinct visual style
+  unknown: 'bg-[#757575] text-[#FFFFFF]',
+};
+
+export function getStatusColor(status: TransactionStatus): string {
+  return TRANSACTION_STATUS_COLORS[status] ?? TRANSACTION_STATUS_COLORS.unknown;
+}


### PR DESCRIPTION
Fixes #333

*Automated by REAPR*