### PR TITLE
test(e2e): add firefox and webkit projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ stellopay-frontend
 - `npm run test` runs the Vitest unit suite with coverage for auth, transaction, and pagination utils plus auth schemas.
 - `npm run test:watch` runs Vitest in watch mode while developing unit tests.
 - `npm run test:e2e` is the Playwright local/E2E command.
+- Playwright runs Chromium, Firefox, and WebKit projects from `playwright.config.ts`.
+  Run one browser locally with `npx playwright test --project=chromium`,
+  `npx playwright test --project=firefox`, or
+  `npx playwright test --project=webkit`.
+  CI retries failed Playwright tests twice while local runs fail fast.
 
 ## Iconography
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
   // routinely needs more than the previous 60s budget.
   timeout: 180_000,
   fullyParallel: false,
-  workers: 1,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : 1,
   use: {
     baseURL: "http://127.0.0.1:3000",
     trace: "retain-on-failure",
@@ -17,6 +18,14 @@ export default defineConfig({
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
     },
   ],
   webServer: {


### PR DESCRIPTION
## Description
- Adds Firefox and WebKit projects alongside Chromium in `playwright.config.ts`.
- Enables CI-only retries and two CI workers while keeping local runs fail-fast and serial by default.
- Documents how to run a single browser project locally from the README.

## Related Issue
Closes #334

## Checklist
- [x] I have tested the config locally.
- [x] I have added/updated documentation as needed.
- [x] I have reviewed the code and ensured it follows the project guidelines.

## Test plan
- [x] `node node_modules/@playwright/test/cli.js test --list --config=playwright.config.ts` — config loads and lists 147 tests across Chromium, Firefox, and WebKit

## Security notes
No secrets or credentials are committed; base URL remains local and configurable by the Playwright runtime.