### PR TITLE
test(e2e): cover help support flows by huazhuang80-star

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ stellopay-frontend
 - `npm run test` runs the Vitest unit suite with coverage for auth, transaction, and pagination utils plus auth schemas.
 - `npm run test:watch` runs Vitest in watch mode while developing unit tests.
 - `npm run test:e2e` is the Playwright local/E2E command.
+- `npx playwright test tests/help-support.spec.ts` covers the Help/Support FAQ categories, account-management detail navigation, keyboard-reachable support tabs, and the support loading state.
 
 ## Iconography
 

--- a/app/help/support/loading.tsx
+++ b/app/help/support/loading.tsx
@@ -1,0 +1,25 @@
+export default function SupportLoading() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading support content"
+      className="min-h-screen p-4 sm:p-6 text-white"
+    >
+      <div className="space-y-4">
+        <div className="h-8 w-48 animate-pulse rounded bg-[#2D2D2D]" />
+        <div className="flex gap-2">
+          <div className="h-11 w-28 animate-pulse rounded-l-lg bg-[#2D2D2D]" />
+          <div className="h-11 w-36 animate-pulse rounded-r-lg bg-[#2D2D2D]" />
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-32 animate-pulse rounded-xl border border-[#2E2E2E] bg-[#121212]"
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/common/email-input.tsx
+++ b/components/common/email-input.tsx
@@ -42,6 +42,7 @@ const EmailInput: React.FC<EnhancedEmailInputProps> = ({
   return (
     <div className={cn("w-full space-y-2", className)}>
       <Label
+        htmlFor={fieldId}
         required={required}
         error={error}
         descriptionId={descriptionId}

--- a/components/common/faq-card.tsx
+++ b/components/common/faq-card.tsx
@@ -1,20 +1,15 @@
 "use client";
 import { SquareArrowOutUpRight } from "lucide-react";
 import React from "react";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { FaqCardProps } from "@/types/ui";
 
 const FaqCard: React.FC<FaqCardProps> = ({ title, subtitle, link }) => {
-  const router = useRouter();
-
-  // Dummy navigation
-  const handleCardClick = () => {
-    router.push(link || "/settings/preferences");
-  };
+  const href = link || "/settings/preferences";
 
   return (
-    <div
-      onClick={handleCardClick}
+    <Link
+      href={href}
       className="w-full bg-[#121212] border border-[#2E2E2E] rounded-xl p-4 sm:p-5 md:p-6 hover:shadow-2xl hover:scale-105 transition-all duration-300 ease-in-out cursor-pointer"
     >
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
@@ -27,7 +22,7 @@ const FaqCard: React.FC<FaqCardProps> = ({ title, subtitle, link }) => {
           <SquareArrowOutUpRight size={18} color="#E5E5E5" />
         </div>
       </div>
-    </div>
+    </Link>
   );
 };
 

--- a/components/common/text-area-input.tsx
+++ b/components/common/text-area-input.tsx
@@ -45,6 +45,7 @@ const TextareaInput: React.FC<EnhancedTextareaInputProps> = ({
     <div className={cn("w-full space-y-2", className)}>
       {label && (
         <Label
+          htmlFor={fieldId}
           required={required}
           error={error}
           descriptionId={descriptionId}

--- a/components/common/text-input.tsx
+++ b/components/common/text-input.tsx
@@ -50,6 +50,7 @@ const TextInput: React.FC<EnhancedTextInputProps> = ({
     <div className={cn("w-full space-y-2", className)}>
       {label && (
         <Label
+          htmlFor={fieldId}
           required={required}
           error={error}
           descriptionId={descriptionId}

--- a/tests/help-support.spec.ts
+++ b/tests/help-support.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "@playwright/test";
+
+const SUPPORT_URL = "/help/support";
+const ACCOUNT_MANAGEMENT_URL = "/help/support/accountManagement";
+
+test.describe("Help/Support FAQ navigation", () => {
+  test("renders FAQ categories and resolves the loading skeleton", async ({
+    page,
+  }) => {
+    await page.goto(SUPPORT_URL);
+
+    await expect(
+      page.getByRole("heading", { name: "Help/Support" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Frequently Asked Questions" }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("link", { name: /Account Management/i }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Transaction Issues/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Security & Privacy/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Payment & Transfers/i }).first(),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("status", { name: /loading support content/i }),
+    ).toHaveCount(0);
+  });
+
+  test("navigates to the account-management FAQ detail view", async ({
+    page,
+  }) => {
+    await page.goto(SUPPORT_URL);
+
+    await page
+      .getByRole("link", { name: /Account Management/i })
+      .first()
+      .click();
+
+    await expect(page).toHaveURL(new RegExp(`${ACCOUNT_MANAGEMENT_URL}$`));
+    await expect(
+      page.getByRole("link", { name: "Help/Support" }),
+    ).toBeVisible();
+    await expect(page.getByText("Account Management").first()).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "How to Reset Your Password" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("tab", { name: "Password & Security" }),
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("support tabs are keyboard reachable and do not reflect form input", async ({
+    page,
+  }) => {
+    await page.goto(SUPPORT_URL);
+
+    const clientFaqTab = page.getByRole("button", { name: "Client FAQ" });
+    const contactSupportTab = page.getByRole("button", {
+      name: "Contact Support",
+    });
+
+    await page.keyboard.press("Tab");
+    await expect(clientFaqTab).toBeFocused();
+    await page.keyboard.press("Tab");
+    await expect(contactSupportTab).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    await expect(
+      page.getByRole("heading", { name: "Contact Info & FAQ Details" }),
+    ).toBeVisible();
+    await page.getByLabel("First Name").fill("<script>alert(1)</script>");
+    await page.getByLabel("Last Name").fill("Sullivan");
+    await page.getByLabel("Email address").fill("maya@example.com");
+    await page
+      .getByLabel("We would like to hear from you")
+      .fill("I need help with a transfer.");
+
+    await expect(
+      page.getByRole("button", { name: "Send Message" }),
+    ).toBeEnabled();
+    await expect(page.locator("script", { hasText: "alert(1)" })).toHaveCount(
+      0,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright coverage for the Help/Support FAQ categories and account-management detail flow
- make FAQ cards real links and connect support form labels to their inputs for resilient role/label selectors
- add an accessible support loading skeleton and document the new e2e command

Closes #341

## Validation
- PASS: node node_modules/@playwright/test/cli.js test --list --config=playwright.config.ts tests/help-support.spec.ts (3 tests discovered)
- BLOCKED locally: node node_modules/@playwright/test/cli.js test --config=playwright.config.ts tests/help-support.spec.ts starts the suite but this machine is missing the Playwright Chromium binary at C:\Users\hua\AppData\Local\ms-playwright\chromium_headless_shell-1228\chrome-headless-shell-win64\chrome-headless-shell.exe

## Security
- support form input remains controlled client state and is not reflected into the DOM as executable markup
- no secrets, credentials, or wallet material are added