### PR TITLE
perf(transactions): debounce search input by huazhuang80-star

### DIFF
--- a/components/transactions/table-searchbar.test.tsx
+++ b/components/transactions/table-searchbar.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import TableSearchbar from "@/components/transactions/table-searchbar";
+
+describe("TableSearchbar", () => {
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("debounces search changes and labels the search field", () => {
+    vi.useFakeTimers();
+    const onSearch = vi.fn();
+
+    render(<TableSearchbar onSearch={onSearch} debounceMs={250} />);
+
+    const input = screen.getByRole("searchbox", {
+      name: /search transactions/i,
+    });
+    expect(input).toHaveAttribute("type", "search");
+
+    fireEvent.change(input, { target: { value: "s" } });
+    fireEvent.change(input, { target: { value: "st" } });
+    fireEvent.change(input, { target: { value: "stellar" } });
+
+    expect(onSearch).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(249);
+    expect(onSearch).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenLastCalledWith("stellar");
+  });
+
+  it("cancels the pending debounce when unmounted", () => {
+    vi.useFakeTimers();
+    const onSearch = vi.fn();
+
+    const { unmount } = render(
+      <TableSearchbar onSearch={onSearch} debounceMs={250} />,
+    );
+
+    fireEvent.change(
+      screen.getByRole("searchbox", { name: /search transactions/i }),
+      { target: { value: "pending" } },
+    );
+    unmount();
+
+    vi.advanceTimersByTime(250);
+
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it("debounces clearing the search field", () => {
+    vi.useFakeTimers();
+    const onSearch = vi.fn();
+
+    render(
+      <TableSearchbar
+        onSearch={onSearch}
+        debounceMs={250}
+        defaultValue="xlm"
+      />,
+    );
+
+    const input = screen.getByRole("searchbox", {
+      name: /search transactions/i,
+    });
+    fireEvent.change(input, { target: { value: "" } });
+
+    vi.advanceTimersByTime(250);
+
+    expect(onSearch).toHaveBeenCalledWith("");
+  });
+});

--- a/components/transactions/table-searchbar.tsx
+++ b/components/transactions/table-searchbar.tsx
@@ -4,17 +4,36 @@ import { Search } from "lucide-react";
 
 interface TableSearchbarProps {
   onSearch: (value: string) => void;
+  debounceMs?: number;
+  defaultValue?: string;
 }
 
-const TableSearchbar = ({ onSearch }: TableSearchbarProps) => {
+/** Debounces client-side transaction filtering while keeping the field controlled locally. */
+const TableSearchbar = ({
+  onSearch,
+  debounceMs = 250,
+  defaultValue = "",
+}: TableSearchbarProps) => {
+  const [searchValue, setSearchValue] = React.useState(defaultValue);
+
+  React.useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      onSearch(searchValue);
+    }, debounceMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [debounceMs, onSearch, searchValue]);
+
   return (
     <div className="flex items-center bg-transparent rounded-[6.25rem]   ">
       <Search className="w-5 h-5 text-gray-600 " />
 
       <Input
-        type="text"
+        type="search"
+        aria-label="Search transactions"
         placeholder="Search"
-        onChange={(e) => onSearch(e.target.value)}
+        value={searchValue}
+        onChange={(e) => setSearchValue(e.target.value)}
         className="border-none py-1 focus-visible:ring-0 text-[13px] p-1 sm:text-[14px]"
       />
     </div>


### PR DESCRIPTION
## Summary
- debounce transaction search input updates with a configurable 250ms default
- keep the search field locally controlled while cancelling pending timers on rapid input and unmount
- switch the field to type="search" with an accessible aria-label
- add Vitest fake-timer coverage for rapid typing, clear, and unmount cleanup

Closes #323

## Validation
- PASS: node node_modules/vitest/vitest.mjs run components/transactions/table-searchbar.test.tsx

## Security
- search text remains plain client-side filter input and is not interpolated into dynamic selectors or regexes
- no secrets, credentials, or wallet material are added