### PR TITLE
fix(notifications): add empty state and stable keys by huazhuang80-star

### DIFF
--- a/components/common/notification-panel.test.tsx
+++ b/components/common/notification-panel.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import NotificationPanel from "@/components/common/notification-panel";
+import { NotificationItem } from "@/types/notification-item";
+
+const notifications: NotificationItem[] = [
+  {
+    id: "payment-received",
+    title: "Payment received",
+    message: "Your USDC payment arrived.",
+    read: false,
+  },
+  {
+    id: "transfer-complete",
+    title: "Transfer complete",
+    message: "Your XLM transfer is complete.",
+    read: true,
+  },
+];
+
+describe("NotificationPanel", () => {
+  it("renders an accessible empty state when there are no notifications", () => {
+    render(<NotificationPanel notifications={[]} />);
+
+    expect(
+      screen.getByRole("button", { name: /open notifications/i }),
+    ).toBeInTheDocument();
+
+    const region = screen.getByRole("region", {
+      name: /notifications list/i,
+    });
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByText("You're all caught up")).toBeInTheDocument();
+    expect(
+      screen.getByText(/new transaction notifications will appear here/i),
+    ).toBeInTheDocument();
+  });
+
+  it("uses notification ids for stable rendered items across reorders", () => {
+    const { rerender } = render(
+      <NotificationPanel notifications={notifications} />,
+    );
+
+    expect(screen.getByTestId("notification-payment-received")).toHaveTextContent(
+      "Payment received",
+    );
+    expect(screen.getByTestId("notification-transfer-complete")).toHaveTextContent(
+      "Transfer complete",
+    );
+
+    rerender(<NotificationPanel notifications={[...notifications].reverse()} />);
+
+    expect(screen.getByTestId("notification-payment-received")).toHaveTextContent(
+      "Payment received",
+    );
+    expect(screen.getByTestId("notification-transfer-complete")).toHaveTextContent(
+      "Transfer complete",
+    );
+  });
+
+  it("keeps loading skeletons separate from the empty state", () => {
+    render(<NotificationPanel notifications={[]} isLoading />);
+
+    expect(screen.queryByText("You're all caught up")).not.toBeInTheDocument();
+  });
+});

--- a/components/common/notification-panel.tsx
+++ b/components/common/notification-panel.tsx
@@ -9,7 +9,11 @@ interface NotificationPanelProps extends NotificationProps {
   isLoading?: boolean;
 }
 
-const NotificationPanel = ({ className: _className, notifications, isLoading = false }: NotificationPanelProps) => {
+const NotificationPanel = ({
+  className: _className,
+  notifications,
+  isLoading = false,
+}: NotificationPanelProps) => {
   if (isLoading) {
     return (
       <div className="bg-[#0D0D0D80] bg-opacity-50 border border-[#2D2D2D] max-w-[400px] rounded-xl p-4 text-[#E5E5E5]">
@@ -44,6 +48,7 @@ const NotificationPanel = ({ className: _className, notifications, isLoading = f
       <div className="flex justify-between items-center mb-4">
         <div className="flex items-center gap-3">
           <Button
+            aria-label="Open notifications"
             className="bg-[#121212] border border-[#2E2E2E] cursor-pointer hover:bg-inherit "
             size="icon"
           >
@@ -58,28 +63,45 @@ const NotificationPanel = ({ className: _className, notifications, isLoading = f
         </Button>
       </div>
 
-      <div className="flex flex-col gap-4">
-        {notifications.map((notification, index) => (
-          <div
-            key={index}
-            className="bg-[#12121266] bg-opacity-40 border border-[#2D2D2D] rounded-lg p-3 px-5 flex justify-between items-center"
-          >
-            <div className="grid gap-1">
-              <p className="font-light text-[#E5E5E5] text-sm">
-                {notification.title}
-              </p>
-              <p className="text-xs text-[#505050] truncate">
-                {notification.message}
-              </p>
-            </div>
-            <div className="relative w-[24px] h-[24px] flex items-center justify-center bg-[#0D0D0D80]/50 border border-[#2E2E2E] rounded-sm">
-              <IconBell />
-              {!notification.read && (
-                <div className=" absolute top-2 right-[7px]  w-1 h-1 bg-[#EB6945] rounded-full" />
-              )}
-            </div>
+      <div
+        role="region"
+        aria-label="Notifications list"
+        aria-live="polite"
+        className="flex flex-col gap-4"
+      >
+        {notifications.length === 0 ? (
+          <div className="bg-[#12121266] bg-opacity-40 border border-[#2D2D2D] rounded-lg p-5 text-center">
+            <p className="font-light text-[#E5E5E5] text-sm">
+              You&apos;re all caught up
+            </p>
+            <p className="mt-1 text-xs text-[#707070]">
+              New transaction notifications will appear here.
+            </p>
           </div>
-        ))}
+        ) : (
+          notifications.map((notification) => (
+            <div
+              key={notification.id}
+              data-testid={`notification-${notification.id}`}
+              className="bg-[#12121266] bg-opacity-40 border border-[#2D2D2D] rounded-lg p-3 px-5 flex justify-between items-center"
+            >
+              <div className="grid gap-1">
+                <p className="font-light text-[#E5E5E5] text-sm">
+                  {notification.title}
+                </p>
+                <p className="text-xs text-[#505050] truncate">
+                  {notification.message}
+                </p>
+              </div>
+              <div className="relative w-[24px] h-[24px] flex items-center justify-center bg-[#0D0D0D80]/50 border border-[#2E2E2E] rounded-sm">
+                <IconBell />
+                {!notification.read && (
+                  <div className=" absolute top-2 right-[7px]  w-1 h-1 bg-[#EB6945] rounded-full" />
+                )}
+              </div>
+            </div>
+          ))
+        )}
       </div>
     </div>
   );

--- a/types/notification-item.ts
+++ b/types/notification-item.ts
@@ -1,4 +1,5 @@
 export type NotificationItem = {
+  id: string;
   title: string;
   message: string;
   read: boolean;


### PR DESCRIPTION
## Summary
- add an accessible empty state for zero notifications
- add notification ids to the item type and render list items with stable id keys
- expose the list as a polite live region and label the bell trigger
- add Vitest coverage for the empty state, loading state, and stable rendered ids across reorders

Closes #322

## Validation
- PASS: node node_modules/vitest/vitest.mjs run components/common/notification-panel.test.tsx

## Security
- notification title and message continue to render as escaped React text nodes
- no secrets, credentials, or wallet material are added