### PR TITLE
fix(settings): clear account status timers by huazhuang80-star

### DIFF
--- a/app/settings/preferences/components/account-section.test.tsx
+++ b/app/settings/preferences/components/account-section.test.tsx
@@ -1,0 +1,111 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import AccountSection from "@/app/settings/preferences/components/account-section";
+
+vi.mock("next/image", () => ({
+  default: ({
+    alt,
+    priority: _priority,
+    src,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & { priority?: boolean }) => (
+    <img alt={alt} src={String(src)} {...props} />
+  ),
+}));
+
+describe("AccountSection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.1);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("does not update state after unmounting during a pending save", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const { unmount } = render(<AccountSection />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /save account changes/i }),
+      );
+    });
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6500);
+    });
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("clears the status message after five seconds", async () => {
+    render(<AccountSection />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /save account changes/i }),
+      );
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(
+      screen.getByText(/account profile changes are staged/i),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(
+      screen.queryByText(/account profile changes are staged/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("resets the prior status timer on consecutive saves", async () => {
+    render(<AccountSection />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /save account changes/i }),
+      );
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /save account changes/i }),
+      );
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4999);
+    });
+    expect(
+      screen.getByText(/account profile changes are staged/i),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(
+      screen.queryByText(/account profile changes are staged/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/settings/preferences/components/account-section.tsx
+++ b/app/settings/preferences/components/account-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import { Camera, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -14,7 +14,6 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { FormMessage } from "@/components/ui/form";
 import DestructiveActionDialog from "./destructive-action-dialog";
 import { DEMO_PROFILE } from "@/lib/demo-data";
 
@@ -61,6 +60,10 @@ const sectionMap = [
  * Uses placeholder demo data pending full backend API integration.
  */
 export default function AccountSection() {
+  const isMountedRef = useRef(true);
+  const statusTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(
+    null,
+  );
   const [profile, setProfile] = useState<ProfileState>({
     firstName: DEMO_PROFILE.firstName,
     lastName: DEMO_PROFILE.lastName,
@@ -72,6 +75,30 @@ export default function AccountSection() {
   const [status, setStatus] = useState<StatusState>({ message: "", type: null });
   const [isSaving, setIsSaving] = useState(false);
 
+  const clearStatusTimer = useCallback(() => {
+    if (statusTimerRef.current) {
+      window.clearTimeout(statusTimerRef.current);
+      statusTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleStatusClear = useCallback(() => {
+    clearStatusTimer();
+    statusTimerRef.current = window.setTimeout(() => {
+      if (isMountedRef.current) {
+        setStatus({ message: "", type: null });
+      }
+      statusTimerRef.current = null;
+    }, 5000);
+  }, [clearStatusTimer]);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      clearStatusTimer();
+    };
+  }, [clearStatusTimer]);
+
   const updateProfileField = (field: keyof ProfileState, value: string) => {
     setProfile((currentProfile) => ({
       ...currentProfile,
@@ -80,6 +107,7 @@ export default function AccountSection() {
   };
 
   const handleSave = async () => {
+    clearStatusTimer();
     setIsSaving(true);
     setStatus({ message: "", type: null });
     try {
@@ -92,18 +120,24 @@ export default function AccountSection() {
           resolve(null);
         }
       }, 1500));
-      setStatus({
-        message: "Account profile changes are staged and ready for backend save.",
-        type: "success",
-      });
+      if (isMountedRef.current) {
+        setStatus({
+          message: "Account profile changes are staged and ready for backend save.",
+          type: "success",
+        });
+      }
     } catch {
-      setStatus({
-        message: "Failed to save changes. Please try again.",
-        type: "error",
-      });
+      if (isMountedRef.current) {
+        setStatus({
+          message: "Failed to save changes. Please try again.",
+          type: "error",
+        });
+      }
     } finally {
-      setIsSaving(false);
-      setTimeout(() => setStatus({ message: "", type: null }), 5000);
+      if (isMountedRef.current) {
+        setIsSaving(false);
+        scheduleStatusClear();
+      }
     }
   };
 
@@ -222,12 +256,13 @@ export default function AccountSection() {
                   : "border-destructive/20 bg-destructive/10"
               }`}
             >
-              <FormMessage
-                variant={status.type === "success" ? "success" : "error"}
-                className={status.type === "success" ? "text-success" : "text-destructive"}
+              <p
+                className={
+                  status.type === "success" ? "text-success" : "text-destructive"
+                }
               >
                 {status.message}
-              </FormMessage>
+              </p>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- track the status-message timeout and clear it on unmount
- guard async save resolution so state is only updated while the account section is mounted
- reset any prior status-clear timeout before a new save to avoid stacked timers
- replace the out-of-form FormMessage usage with a plain status paragraph so profile save feedback does not throw outside react-hook-form context
- add Vitest coverage for unmount during save, five-second status clearing, and consecutive saves

Closes #328

## Validation
- PASS: node node_modules/vitest/vitest.mjs run app/settings/preferences/components/account-section.test.tsx

## Security
- no profile data is persisted in timers after unmount; cleanup clears pending status timers
- no secrets, credentials, or wallet material are added