### PR TITLE
feat(hooks): add dashboard refetch callbacks by huazhuang80-star

### DIFF
--- a/components/dashboard/account-summary.tsx
+++ b/components/dashboard/account-summary.tsx
@@ -9,7 +9,7 @@ import { useAccountSummary } from "@/hooks/useAccountSummary";
 
 export default function AccountSummary() {
   const [copied, setCopied] = useState(false);
-  const { data, isLoading, error } = useAccountSummary();
+  const { data, isLoading, error, refetch } = useAccountSummary();
 
   if (isLoading) {
     return (
@@ -34,6 +34,13 @@ export default function AccountSummary() {
         className="max-w-full p-4 rounded-xl my-6 border-[1px] border-[#2D2D2D] bg-[#0D0D0D80] text-red-400 text-sm text-center"
       >
         Failed to load account summary.
+        <button
+          type="button"
+          onClick={refetch}
+          className="ml-3 rounded-md border border-red-400/40 px-3 py-1 text-xs text-red-200 transition hover:bg-red-400/10"
+        >
+          Retry
+        </button>
       </div>
     );
   }

--- a/components/dashboard/payment-history.tsx
+++ b/components/dashboard/payment-history.tsx
@@ -5,7 +5,7 @@ import { usePaymentHistory } from "@/hooks/usePaymentHistory";
 import { CardSkeleton } from "@/components/ui/card-skeleton";
 
 export default function PaymentHistory() {
-  const { data, isLoading, error } = usePaymentHistory();
+  const { data, isLoading, error, refetch } = usePaymentHistory();
 
   if (isLoading) {
     return (
@@ -21,6 +21,13 @@ export default function PaymentHistory() {
     return (
       <div role="alert" className="text-sm text-red-400 text-center py-4">
         Failed to load payment history.
+        <button
+          type="button"
+          onClick={refetch}
+          className="ml-3 rounded-md border border-red-400/40 px-3 py-1 text-xs text-red-200 transition hover:bg-red-400/10"
+        >
+          Retry
+        </button>
       </div>
     );
   }

--- a/hooks/useAccountSummary.test.ts
+++ b/hooks/useAccountSummary.test.ts
@@ -1,0 +1,59 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAccountSummary } from "@/hooks/useAccountSummary";
+import { getAccountSummary } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  getAccountSummary: vi.fn(),
+}));
+
+const summary = {
+  balance: "$ 2,432 USDC",
+  balanceRaw: 2432,
+  paidThisMonth: "$ 0",
+  paidThisMonthCount: 0,
+  toBePaid: "$ 0",
+  toBePaidCount: 0,
+  walletAddress: "GABC...F123",
+};
+
+describe("useAccountSummary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads account summary data", async () => {
+    vi.mocked(getAccountSummary).mockResolvedValue(summary);
+
+    const { result } = renderHook(() => useAccountSummary());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toEqual(summary);
+    expect(result.current.error).toBeNull();
+    expect(typeof result.current.refetch).toBe("function");
+  });
+
+  it("clears an error before refetching successfully", async () => {
+    vi.mocked(getAccountSummary)
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce(summary);
+
+    const { result } = renderHook(() => useAccountSummary());
+
+    await waitFor(() =>
+      expect(result.current.error).toBe("temporary failure"),
+    );
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.data).toEqual(summary));
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/hooks/useAccountSummary.ts
+++ b/hooks/useAccountSummary.ts
@@ -1,35 +1,47 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { getAccountSummary, AccountSummary } from "@/lib/api";
 
 interface UseAccountSummaryResult {
   data: AccountSummary | null;
   isLoading: boolean;
   error: string | null;
+  refetch: () => void;
 }
 
 /**
  * Hook to fetch account summary data for the dashboard.
+ * Returns a stable refetch callback that clears stale errors before retrying.
  */
 export function useAccountSummary(): UseAccountSummaryResult {
   const [data, setData] = useState<AccountSummary | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const requestIdRef = useRef(0);
+
+  const refetch = useCallback(() => {
+    setReloadKey((key) => key + 1);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+
     setIsLoading(true);
+    setError(null);
 
     getAccountSummary()
       .then((result) => {
-        if (!cancelled) {
+        if (!cancelled && requestId === requestIdRef.current) {
           setData(result);
           setIsLoading(false);
         }
       })
       .catch((err: unknown) => {
-        if (!cancelled) {
+        if (!cancelled && requestId === requestIdRef.current) {
           setError(
             err instanceof Error ? err.message : "Failed to load account summary"
           );
@@ -40,7 +52,7 @@ export function useAccountSummary(): UseAccountSummaryResult {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [reloadKey]);
 
-  return { data, isLoading, error };
+  return { data, isLoading, error, refetch };
 }

--- a/hooks/usePaymentHistory.test.ts
+++ b/hooks/usePaymentHistory.test.ts
@@ -1,0 +1,56 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePaymentHistory } from "@/hooks/usePaymentHistory";
+import { getPaymentHistory } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  getPaymentHistory: vi.fn(),
+}));
+
+const paymentHistory = [
+  {
+    id: "ph-1",
+    paymentDescription: "Payment Sent",
+    paymentId: "#TXN12345",
+    history: "Your payment of 250 XLM",
+  },
+];
+
+describe("usePaymentHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads payment history data", async () => {
+    vi.mocked(getPaymentHistory).mockResolvedValue(paymentHistory);
+
+    const { result } = renderHook(() => usePaymentHistory());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toEqual(paymentHistory);
+    expect(result.current.error).toBeNull();
+    expect(typeof result.current.refetch).toBe("function");
+  });
+
+  it("clears an error before refetching successfully", async () => {
+    vi.mocked(getPaymentHistory)
+      .mockRejectedValueOnce(new Error("history failed"))
+      .mockResolvedValueOnce(paymentHistory);
+
+    const { result } = renderHook(() => usePaymentHistory());
+
+    await waitFor(() => expect(result.current.error).toBe("history failed"));
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.data).toEqual(paymentHistory));
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/hooks/usePaymentHistory.ts
+++ b/hooks/usePaymentHistory.ts
@@ -1,35 +1,47 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { getPaymentHistory, PaymentHistoryItem } from "@/lib/api";
 
 interface UsePaymentHistoryResult {
   data: PaymentHistoryItem[];
   isLoading: boolean;
   error: string | null;
+  refetch: () => void;
 }
 
 /**
  * Hook to fetch payment history items for the dashboard sidebar.
+ * Returns a stable refetch callback that clears stale errors before retrying.
  */
 export function usePaymentHistory(): UsePaymentHistoryResult {
   const [data, setData] = useState<PaymentHistoryItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const requestIdRef = useRef(0);
+
+  const refetch = useCallback(() => {
+    setReloadKey((key) => key + 1);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+
     setIsLoading(true);
+    setError(null);
 
     getPaymentHistory()
       .then((result) => {
-        if (!cancelled) {
+        if (!cancelled && requestId === requestIdRef.current) {
           setData(result);
           setIsLoading(false);
         }
       })
       .catch((err: unknown) => {
-        if (!cancelled) {
+        if (!cancelled && requestId === requestIdRef.current) {
           setError(
             err instanceof Error ? err.message : "Failed to load payment history"
           );
@@ -40,7 +52,7 @@ export function usePaymentHistory(): UsePaymentHistoryResult {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [reloadKey]);
 
-  return { data, isLoading, error };
+  return { data, isLoading, error, refetch };
 }


### PR DESCRIPTION
## Summary
- add stable refetch callbacks to useAccountSummary and usePaymentHistory
- clear stale errors and set loading at the start of every retry
- guard state commits with cancellation and request ids so stale responses cannot clobber newer refetch data
- wire Retry buttons into the dashboard account-summary and payment-history error states
- add hook tests for success and refetch-after-error paths

Closes #321

## Validation
- PASS: node node_modules/vitest/vitest.mjs run hooks/useAccountSummary.test.ts hooks/usePaymentHistory.test.ts

## Security
- retry state is in-memory only and does not log account, payment, credential, or wallet material
- stale/cancelled responses are ignored before state commits