### PR TITLE
chore(eslint): enforce no-console and explicit return types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,35 @@
           }
         ]
       }
-    ]
-  }
+    ],
+    "no-console": ["error", { "allow": ["warn", "error"] }]
+  },
+  "overrides": [
+    {
+      "files": ["**/*.ts"],
+      "excludedFiles": [
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/*.d.ts",
+        "*.config.ts"
+      ],
+      "rules": {
+        "@typescript-eslint/explicit-module-boundary-types": "error"
+      }
+    },
+    {
+      "files": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.spec.tsx",
+        "e2e/**",
+        "tests/**"
+      ],
+      "rules": {
+        "no-console": "off",
+        "@typescript-eslint/explicit-module-boundary-types": "off"
+      }
+    }
+  ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,55 @@ We enforce a strict separation of concerns for data access.
 
 All data access must be routed through the established `lib/api` layer to ensure consistency and future-proof our backend integrations.
 
+## Linting Rules
+
+We treat lint as the cheapest quality gate, so a few rules are enforced beyond
+the Next.js defaults (`next/core-web-vitals` + `next/typescript`). Run them with:
+
+```bash
+npm run lint
+```
+
+### `no-console`
+
+`console.log`, `console.info`, `console.debug`, etc. are **errors**. Only
+`console.warn` and `console.error` are allowed, and only for genuine,
+user-impacting diagnostics.
+
+> **Why:** stray logging can leak sensitive data — emails, verification codes,
+> or wallet addresses — into the browser console. Removing it keeps that data
+> out of client logs. Use a real handler (or a `// TODO` marker) instead of a
+> placeholder `console.log`.
+
+### Explicit return types on module boundaries
+
+`@typescript-eslint/explicit-module-boundary-types` is enabled for non-component
+TypeScript modules (`**/*.ts` — e.g. `lib/`, `utils/`, `hooks/`). Exported
+functions must declare an explicit return type:
+
+```ts
+// ❌ ambiguous public signature
+export function getTransactions(params) { ... }
+
+// ✅ explicit, self-documenting
+export async function getTransactions(
+  params: GetTransactionsParams = {},
+): Promise<PaginatedTransactions> { ... }
+```
+
+> **Why:** explicit return types document the public contract of our data and
+> utility layers and catch accidental type widening before it ships.
+
+**Scope:** React components (`.tsx`) are intentionally exempt — their return
+type (JSX) is self-evident. Test files (`*.test.*`, `*.spec.*`, `e2e/`,
+`tests/`) are also exempt from `no-console` and the return-type rule so mocks
+and debugging stay frictionless.
+
+### Icon imports
+
+`react-icons` and `@hugeicons/*` are restricted — always import icons from
+`lucide-react`.
+
 ## Testing Expectations
 
 We expect all new utility functions and business logic to have **minimum 95% test coverage**.

--- a/components/analytics/analytics-view.test.tsx
+++ b/components/analytics/analytics-view.test.tsx
@@ -29,7 +29,11 @@ vi.mock("recharts", () => {
       <div data-testid="x-axis" data-key={dataKey} />
     ),
     YAxis: () => <div data-testid="y-axis" />,
-    Tooltip: ({ content }: { content: React.ReactElement<any> }) => (
+    Tooltip: ({
+      content,
+    }: {
+      content: React.ReactElement<Record<string, unknown>>;
+    }) => (
       <div data-testid="tooltip">
         {React.cloneElement(content, {
           active: true,

--- a/components/auth/auth-social-buttons.tsx
+++ b/components/auth/auth-social-buttons.tsx
@@ -5,13 +5,11 @@ import Image from "next/image";
 
 export function AuthSocialButtons() {
   const handleGoogleLogin = () => {
-    console.log("Authenticating with Google...");
-    // Add your actual Google auth logic here
+    // TODO: integrate Google authentication.
   };
 
   const handleAppleLogin = () => {
-    console.log("Authenticating with Apple...");
-    // Add your actual Apple auth logic here
+    // TODO: integrate Apple authentication.
   };
 
   return (

--- a/components/auth/sign-up/sign-up-email-modal.tsx
+++ b/components/auth/sign-up/sign-up-email-modal.tsx
@@ -24,8 +24,7 @@ export function SignUpEmailModal({
   const handleResend = async () => {
     setIsResending(true);
     setResendStatus("");
-    // Add your resend logic here
-    console.log("Resending verification email to:", email);
+    // TODO: trigger the resend-verification-email request for `email`.
     setTimeout(() => {
       setIsResending(false);
       setResendStatus("Verification email resent successfully.");

--- a/components/common/support-tabs.tsx
+++ b/components/common/support-tabs.tsx
@@ -44,7 +44,7 @@ export default function SupportTabs({
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!isButtonDisabled) {
-      console.log("Submitted");
+      // TODO: submit the contact-support request.
     }
   };
 

--- a/components/landing/get-started-cta.tsx
+++ b/components/landing/get-started-cta.tsx
@@ -10,8 +10,7 @@ export default function GetStartedCTA() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    console.log("Submitted email:", email);
-    // Add logic to submit email or redirect
+    // TODO: submit `email` to the waitlist endpoint or redirect to sign-up.
   };
 
   return (

--- a/components/landing/navbar.tsx
+++ b/components/landing/navbar.tsx
@@ -21,9 +21,7 @@ export default function Navbar() {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const handleConnect = () => {
-    // placeholder connect wallet handler
-    // Integrate wallet modal/connector here
-    console.log("Connect Wallet clicked");
+    // TODO: integrate wallet modal/connector here.
     alert("Connect Wallet clicked (stub)");
   };
 


### PR DESCRIPTION
## Close #339 

### Summary
`.eslintrc.json` only extended `next/core-web-vitals` + `next/typescript` plus an
icon-import restriction. It lacked a project-wide `no-console` rule and any
enforcement of explicit return types on exported functions, so stray
`console.log` calls (leaking emails/wallet actions) and ambiguous public
function signatures passed lint cleanly.
---

### Root cause
No lint rules existed to catch (a) accidental console logging or (b) untyped
exported functions. Lint was therefore not a meaningful gate for either class of
issue.
---

### Solution implemented
- **`no-console`** → `["error", { "allow": ["warn", "error"] }]`. Intentional
  `warn`/`error` diagnostics remain allowed; everything else is an error.
- **`@typescript-eslint/explicit-module-boundary-types`** enabled for
  non-component TypeScript modules (`**/*.ts`), excluding tests, `*.d.ts`, and
  `*.config.ts`. React components (`.tsx`) are intentionally exempt — their JSX
  return type is self-evident — which keeps the rule targeted at the
  `lib/`/`utils/`/`hooks/` public contracts that benefit from it.
- A **test-file override** disables both new rules for `*.test.*`, `*.spec.*`,
  `e2e/`, and `tests/` so mocks and debugging stay frictionless.
- **Icon-import restriction preserved** unchanged.
---
### Key changes made
- `.eslintrc.json`: added the two rules + `overrides` for scoping.
- Removed stray `console.log` placeholders in:
  `auth-social-buttons.tsx`, `sign-up/sign-up-email-modal.tsx`,
  `landing/get-started-cta.tsx`, `common/support-tabs.tsx`, `landing/navbar.tsx`
  (each replaced with a `// TODO` so intent is preserved).
- Fixed a pre-existing `no-explicit-any` error in
  `components/analytics/analytics-view.test.tsx` that was already failing lint.
- `CONTRIBUTING.md`: new **Linting Rules** section documenting both rules,
  their rationale, and the scoping/exemptions.
---
### Trade-offs / considerations
- The explicit-return-type rule is scoped to `.ts` (not `.tsx`) so JSX
  components aren't forced to annotate `JSX.Element` returns — a deliberate
  "scoped sensibly" choice. The rule was verified to fire via a temporary probe.
- `console.warn`/`console.error` are intentionally allowed for legitimate
  diagnostics (e.g. the clipboard error handler).
- Out of scope: `npm run build` currently fails on a **pre-existing**,
  unrelated type error in `vitest.config.ts` (`postcss: false`) that is not part
  of this PR.
---
### Testing steps
1. `npm run lint` → expect **✔ No ESLint warnings or errors**.
2. Add a temporary `console.log(...)` to any component and re-run lint → expect a
   `no-console` error.
3. Add a temporary untyped exported function to a `lib/*.ts` file → expect a
   `Missing return type on function` error.
4. Confirm `lucide-react` is still enforced (importing `react-icons` errors).
---
### Security notes
`no-console` removes a real data-leak vector: the deleted logs were printing
user emails and wallet interactions to the browser console. Disallowing `log`
keeps emails, verification codes, and wallet data out of client-side logs.
---
please kindly notify if there is any further correction to be made if there is!! thank you very much!!