### PR TITLE
feat(app): add route loading skeletons by huazhuang80-star

### DIFF
--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,0 +1,30 @@
+import { AccountSummaryCardSkeleton, CardSkeleton } from "@/components/ui/card-skeleton";
+
+export default function DashboardLoading() {
+  return (
+    <main
+      role="status"
+      aria-busy="true"
+      aria-label="Loading dashboard"
+      className="min-h-screen p-4 text-white sm:p-6"
+    >
+      <span className="sr-only">Loading dashboard...</span>
+      <div className="space-y-6">
+        <div className="rounded-xl border border-[#2D2D2D] bg-[#0D0D0D80] p-4">
+          <div className="mb-4 flex items-center gap-3">
+            <CardSkeleton showHeader={false} lines={1} className="w-48 border-0 p-0" />
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            <AccountSummaryCardSkeleton />
+            <AccountSummaryCardSkeleton />
+            <AccountSummaryCardSkeleton />
+          </div>
+        </div>
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
+          <CardSkeleton lines={6} className="min-h-[22rem] bg-[#0D0D0D80]" />
+          <CardSkeleton lines={4} className="min-h-[22rem] bg-[#0D0D0D80]" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/route-loading.test.tsx
+++ b/app/route-loading.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import DashboardLoading from "@/app/dashboard/loading";
+import TransactionsLoading from "@/app/transactions/loading";
+import SettingsPreferencesLoading from "@/app/settings/preferences/loading";
+
+describe("route segment loading states", () => {
+  it("renders an accessible dashboard loading skeleton", () => {
+    render(<DashboardLoading />);
+
+    const status = screen.getByRole("status", { name: /loading dashboard/i });
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByText("Loading dashboard...")).toBeInTheDocument();
+  });
+
+  it("renders an accessible transactions loading skeleton", () => {
+    render(<TransactionsLoading />);
+
+    const status = screen.getByRole("status", {
+      name: /loading transactions/i,
+    });
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByText("Loading transactions...")).toBeInTheDocument();
+  });
+
+  it("renders an accessible settings loading skeleton", () => {
+    render(<SettingsPreferencesLoading />);
+
+    const status = screen.getByRole("status", {
+      name: /loading settings preferences/i,
+    });
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(
+      screen.getByText("Loading settings preferences..."),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/settings/preferences/loading.tsx
+++ b/app/settings/preferences/loading.tsx
@@ -1,0 +1,30 @@
+import { CardSkeleton } from "@/components/ui/card-skeleton";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function SettingsPreferencesLoading() {
+  return (
+    <main
+      role="status"
+      aria-busy="true"
+      aria-label="Loading settings preferences"
+      className="min-h-screen p-4 text-white sm:p-6"
+    >
+      <span className="sr-only">Loading settings preferences...</span>
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-56" />
+          <Skeleton className="h-4 w-full max-w-xl" />
+        </div>
+        <div className="grid gap-4 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <CardSkeleton key={index} lines={2} className="min-h-28 bg-white/5" />
+          ))}
+        </div>
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+          <CardSkeleton lines={8} className="min-h-[32rem] bg-white/5" />
+          <CardSkeleton lines={6} className="min-h-[32rem] bg-white/5" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/transactions/loading.tsx
+++ b/app/transactions/loading.tsx
@@ -1,0 +1,27 @@
+import { TransactionTableSkeleton } from "@/components/ui/table-skeleton";
+import { CardSkeleton } from "@/components/ui/card-skeleton";
+
+export default function TransactionsLoading() {
+  return (
+    <main
+      role="status"
+      aria-busy="true"
+      aria-label="Loading transactions"
+      className="min-h-screen text-white"
+    >
+      <span className="sr-only">Loading transactions...</span>
+      <div className="container mx-auto px-8 py-8">
+        <div className="mb-6 grid gap-4 md:grid-cols-[1fr_auto]">
+          <CardSkeleton showHeader={false} lines={2} className="border-0 p-0" />
+          <div className="flex gap-2">
+            <CardSkeleton showHeader={false} lines={1} className="h-10 w-40 border-[#2D2D2D]" />
+            <CardSkeleton showHeader={false} lines={1} className="h-10 w-24 border-[#2D2D2D]" />
+          </div>
+        </div>
+        <div className="rounded-[1.5rem] border border-[#2D2D2D] bg-foreground p-2">
+          <TransactionTableSkeleton rows={6} />
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add segment-level loading.tsx skeletons for /dashboard, /transactions, and /settings/preferences
- reuse existing card and transaction table skeleton components to match route layouts and reduce layout shift
- expose each loading state with role="status", aria-busy, and an sr-only loading label
- add a lightweight Vitest render test for the three loading states

Closes #283

## Validation
- PASS: node node_modules/vitest/vitest.mjs run app/route-loading.test.tsx
- NOT RUN: Playwright browser assertions; this local machine is still missing the Playwright Chromium binary, so the PR uses component-level accessibility assertions instead

## Security
- skeletons render placeholders only and include no PII, payment data, credentials, or wallet material