### PR TITLE
test(e2e): verify theme persistence by huazhuang80-star

### DIFF
--- a/tests/theme.spec.ts
+++ b/tests/theme.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("theme persistence", () => {
+  test("persists dark and light choices across reloads and routes", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.evaluate(() => localStorage.setItem("theme", "light"));
+    await page.reload();
+
+    await expect(page.locator("html")).not.toHaveClass(/dark/);
+
+    await page.getByRole("button", { name: "Toggle theme" }).click();
+    await expect(page.locator("html")).toHaveClass(/dark/);
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("theme")))
+      .toBe("dark");
+
+    await page.reload();
+    await expect(page.locator("html")).toHaveClass(/dark/);
+    expect(await page.evaluate(() => localStorage.getItem("theme"))).toBe(
+      "dark",
+    );
+
+    await page.goto("/dashboard");
+    await expect(page.locator("html")).toHaveClass(/dark/);
+    expect(await page.evaluate(() => localStorage.getItem("theme"))).toBe(
+      "dark",
+    );
+
+    await page.getByRole("button", { name: "Toggle theme" }).click();
+    await expect(page.locator("html")).not.toHaveClass(/dark/);
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("theme")))
+      .toBe("light");
+  });
+});


### PR DESCRIPTION
## Summary
- add a Playwright spec for theme persistence across reloads and route changes
- verify the html dark class and localStorage theme value after toggling dark
- verify the persisted dark choice after reload and navigation to /dashboard
- verify toggling back to light updates both DOM class and storage

Closes #296

## Validation
- PASS: node node_modules/@playwright/test/cli.js test --list --config=playwright.config.ts tests/theme.spec.ts
- BLOCKED locally: full Playwright run cannot start because this Windows environment does not expose npx to the Playwright webServer command; CI/npm environments should run the existing config normally

## Security
- test only reads/writes the non-sensitive theme localStorage key
- no secrets, credentials, or wallet material are added