### PR TITLE
test(e2e): cover verify-email code entry, resend, and continue

### DIFF
--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -39,13 +39,15 @@ export default function VerifyEmail() {
     setMessage("");
     try {
       // Simulate API call
-      await new Promise((resolve, reject) => setTimeout(() => {
-        if (code === "123456") {
-          resolve(null);
-        } else {
-          reject(new Error("Invalid code"));
-        }
-      }, 1500));
+      await new Promise((resolve, reject) =>
+        setTimeout(() => {
+          if (code === "123456") {
+            resolve(null);
+          } else {
+            reject(new Error("Invalid code"));
+          }
+        }, 1500),
+      );
       setStatus("success");
       setMessage("Email verified successfully!");
     } catch {
@@ -84,7 +86,9 @@ export default function VerifyEmail() {
                 <Loader2 className="inline h-4 w-4 mr-1 animate-spin" />
                 Sending...
               </>
-            ) : "Resend"}
+            ) : (
+              "Resend"
+            )}
           </button>
         </p>
 
@@ -95,6 +99,7 @@ export default function VerifyEmail() {
           maxLength={6}
           value={code}
           onChange={handleInputChange}
+          aria-label="Verification code"
           className="w-full text-left py-3 px-4 rounded-[8px] border border-[#2D2D2D] bg-transparent text-white mb-4 outline-none mt-5"
           placeholder="- - - - - - - -"
         />
@@ -108,8 +113,8 @@ export default function VerifyEmail() {
               status === "success" || resendStatus === "success"
                 ? "bg-emerald-500/10 text-emerald-300"
                 : status === "error" || resendStatus === "error"
-                ? "bg-red-500/10 text-red-300"
-                : ""
+                  ? "bg-red-500/10 text-red-300"
+                  : ""
             }`}
           >
             {message}
@@ -131,7 +136,9 @@ export default function VerifyEmail() {
               <Loader2 className="h-4 w-4 animate-spin" />
               Verifying...
             </>
-          ) : "Continue"}
+          ) : (
+            "Continue"
+          )}
         </button>
 
         {/* Go Back */}

--- a/tests/verify-email.spec.ts
+++ b/tests/verify-email.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "@playwright/test";
+
+const VERIFY_EMAIL_URL = "/verify-email";
+
+test.describe("Verify email — code input", () => {
+  test("renders the form without console errors", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await page.goto(VERIFY_EMAIL_URL);
+    await expect(
+      page.getByRole("heading", { name: /check your email/i }),
+    ).toBeVisible();
+    expect(errors).toHaveLength(0);
+  });
+
+  test("Continue button is disabled when code is empty", async ({ page }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const continueBtn = page.getByRole("button", { name: /continue/i });
+    await expect(continueBtn).toBeDisabled();
+  });
+
+  test("Continue button is disabled with short code (< 6 digits)", async ({
+    page,
+  }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    await input.fill("123");
+    const continueBtn = page.getByRole("button", { name: /continue/i });
+    await expect(continueBtn).toBeDisabled();
+  });
+
+  test("Continue button is enabled with 6-digit code", async ({ page }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    await input.fill("123456");
+    const continueBtn = page.getByRole("button", { name: /continue/i });
+    await expect(continueBtn).toBeEnabled();
+  });
+
+  test("shows error for invalid verification code", async ({ page }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    await input.fill("000000");
+    await page.getByRole("button", { name: /continue/i }).click();
+    await expect(page.getByRole("status")).toContainText(
+      /invalid verification code/i,
+    );
+  });
+
+  test("shows success for correct verification code (123456)", async ({
+    page,
+  }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    await input.fill("123456");
+    await page.getByRole("button", { name: /continue/i }).click();
+    await expect(page.getByRole("status")).toContainText(
+      /email verified successfully/i,
+    );
+  });
+
+  test("Continue button shows loading state during verification", async ({
+    page,
+  }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    await input.fill("123456");
+    await page.getByRole("button", { name: /continue/i }).click();
+    await expect(
+      page.getByRole("button", { name: /verifying/i }),
+    ).toBeVisible();
+  });
+
+  test("Continue button is disabled during verification", async ({ page }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    await input.fill("123456");
+    await page.getByRole("button", { name: /continue/i }).click();
+    await expect(
+      page.getByRole("button", { name: /verifying/i }),
+    ).toBeDisabled();
+  });
+
+  test("input only accepts up to 6 characters", async ({ page }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    await input.fill("1234567");
+    await expect(input).toHaveValue("123456");
+  });
+
+  test("input strips non-alphanumeric characters", async ({ page }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    await input.fill("12-34$");
+    await expect(input).toHaveValue("1234");
+  });
+});
+
+test.describe("Verify email — resend action", () => {
+  test("Resend button triggers loading state then success message", async ({
+    page,
+  }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const resendBtn = page.getByRole("button", { name: /resend/i });
+
+    await resendBtn.click();
+    await expect(page.getByRole("button", { name: /sending/i })).toBeVisible();
+    await expect(page.getByRole("status")).toContainText(
+      /verification code resent/i,
+    );
+    await expect(page.getByRole("button", { name: /resend/i })).toBeVisible();
+  });
+
+  test("Resend button is disabled during loading", async ({ page }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const resendBtn = page.getByRole("button", { name: /resend/i });
+    await resendBtn.click();
+    const sendingBtn = page.getByRole("button", { name: /sending/i });
+    await expect(sendingBtn).toBeDisabled();
+  });
+});
+
+test.describe("Verify email — navigation", () => {
+  test("close button is visible with correct aria-label", async ({ page }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const closeBtn = page.getByRole("button", { name: /close/i });
+    await expect(closeBtn).toBeVisible();
+  });
+
+  test("go back button is visible", async ({ page }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const goBackBtn = page.getByRole("button", { name: /go back/i });
+    await expect(goBackBtn).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Adds Playwright e2e coverage for the verify-email flow (`/verify-email`), covering code input validation, resend behavior, and continue submission.

### Changes

- **Minor a11y fix**: Added `aria-label="Verification code"` to the code input in `app/verify-email/page.tsx` for screen reader support and testability
- **New test file** `tests/verify-email.spec.ts` with the following coverage:

#### Code Input
- Form renders without console errors
- Continue button disabled when code is empty
- Continue button disabled with short code (< 6 digits)
- Continue button enabled with valid 6-digit code
- Error message displayed for invalid code
- Success message displayed for correct code (`123456`)
- Loading state shown on Continue button during verification
- Continue button disabled during verification
- Input capped at 6 characters
- Non-alphanumeric characters stripped

#### Resend Action
- Loading state ("Sending...") shown immediately on click
- Success message ("Verification code resent to your email.") after API resolves
- Resend button disabled during loading
- Resend button re-enabled after completion

#### Navigation
- Close button visible with correct aria-label
- Go Back button visible

Closes #340