### PR TITLE
fix(network): replace EVM networks with Stellar networks by huazhuang80-star

### DIFF
--- a/components/common/network-switcher.tsx
+++ b/components/common/network-switcher.tsx
@@ -6,7 +6,7 @@
  * Improvements over the original (issue #238):
  * - Active-network badge: green dot + "Active" label on the current network
  * - Confirmation dialog: shown before committing a switch, warns that
- *   balances and transaction history will reflect the new network
+ *   Stellar balances and operations will reflect the selected network
  * - Keyboard accessibility: Radix DropdownMenu already handles arrow-key
  *   navigation; trigger now has an explicit aria-label describing the
  *   current network so screen readers announce it correctly
@@ -34,6 +34,7 @@ import { cn } from "@/utils/commonUtils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { SUPPORTED_NETWORKS, useWallet } from "@/context/wallet-context";
 import type { Network } from "@/types/wallet";
+import { StellarIcon } from "@/public/svg/svg";
 
 export type { Network };
 
@@ -49,21 +50,6 @@ interface NetworkSwitcherProps {
   variant?: "dashboard" | "landing";
   isLoading?: boolean;
 }
-
-/** Minimal Ethereum diamond icon — no external asset dependency */
-const EthereumIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-  >
-    <path d="M12 0L5.5 12.5L12 16L18.5 12.5L12 0Z" fill="currentColor" />
-    <path d="M12 17.5L5.5 13.5L12 24L18.5 13.5L12 17.5Z" fill="currentColor" />
-  </svg>
-);
 
 export default function NetworkSwitcher({
   networks,
@@ -130,7 +116,7 @@ export default function NetworkSwitcher({
             className="w-2 h-2 rounded-full bg-green-500 shrink-0"
             aria-hidden="true"
           />
-          {currentNetwork.icon || <EthereumIcon />}
+          {currentNetwork.icon || <StellarIcon />}
           <span className="text-sm font-medium" style={{ fontFamily: "General Sans, sans-serif" }}>
             {currentNetwork.name}
           </span>
@@ -162,7 +148,7 @@ export default function NetworkSwitcher({
                 )}
               >
                 <div className="flex items-center gap-2 w-full">
-                  {network.icon || <EthereumIcon />}
+                  {network.icon || <StellarIcon />}
                   <span className="text-sm" style={{ fontFamily: "General Sans, sans-serif" }}>
                     {network.name}
                   </span>
@@ -198,8 +184,8 @@ export default function NetworkSwitcher({
               <span className="font-semibold text-white">{pendingNetwork?.name}</span>.
               <br />
               <br />
-              Your displayed balances and transaction history will reflect the
-              new network. No funds will be moved.
+              Your displayed Stellar balances and operations will reflect the
+              selected network. No funds will be moved.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/context/wallet-context.tsx
+++ b/context/wallet-context.tsx
@@ -22,15 +22,24 @@ import type {
   WalletProviderProps,
 } from "@/types/wallet";
 
-// Networks exposed to the UI. Stellar lives first so first-time visitors see
-// the network the product is actually built on. Synthetic placeholders cover
-// the multichain story until real adapters land.
+// Public Stellar networks exposed to the UI. Passphrases are public network
+// identifiers used by Stellar SDKs; they are not secrets.
 export const SUPPORTED_NETWORKS: Network[] = [
-  { id: "stellar", name: "Stellar" },
-  { id: "eth", name: "ETH" },
-  { id: "polygon", name: "Polygon" },
-  { id: "bsc", name: "BSC" },
-  { id: "arbitrum", name: "Arbitrum" },
+  {
+    id: "public",
+    name: "Mainnet",
+    passphrase: "Public Global Stellar Network ; September 2015",
+  },
+  {
+    id: "testnet",
+    name: "Testnet",
+    passphrase: "Test SDF Network ; September 2015",
+  },
+  {
+    id: "futurenet",
+    name: "Futurenet",
+    passphrase: "Test SDF Future Network ; October 2022",
+  },
 ];
 
 export const DEFAULT_NETWORK: Network = SUPPORTED_NETWORKS[0];

--- a/tests/network-switcher.spec.ts
+++ b/tests/network-switcher.spec.ts
@@ -37,7 +37,7 @@ test.describe("NetworkSwitcher — active badge", () => {
 
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await expect(trigger).toHaveAttribute("aria-label", /current network/i);
-    await expect(trigger).toHaveAttribute("aria-label", /Stellar/i);
+    await expect(trigger).toHaveAttribute("aria-label", /Mainnet/i);
   });
 
   test("active network item shows 'Active' badge in dropdown", async ({ page }) => {
@@ -46,7 +46,7 @@ test.describe("NetworkSwitcher — active badge", () => {
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await trigger.click();
 
-    // The first network (ETH) should show the Active badge
+    // The first network (Mainnet) should show the Active badge
     const activeBadge = page.getByText("Active").first();
     await expect(activeBadge).toBeVisible();
   });
@@ -59,9 +59,9 @@ test.describe("NetworkSwitcher — no-op on active network", () => {
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await trigger.click();
 
-    // Click the currently active network (ETH)
-    const ethItem = page.getByRole("menuitem", { name: /Stellar/i }).first();
-    await ethItem.click();
+    // Click the currently active network (Mainnet)
+    const mainnetItem = page.getByRole("menuitem", { name: /Mainnet/i }).first();
+    await mainnetItem.click();
 
     // Dialog should NOT appear
     const dialog = page.getByRole("dialog");
@@ -76,8 +76,8 @@ test.describe("NetworkSwitcher — confirmation dialog", () => {
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await trigger.click();
 
-    const polygonItem = page.getByRole("menuitem", { name: /Polygon/i }).first();
-    await polygonItem.click();
+    const testnetItem = page.getByRole("menuitem", { name: /Testnet/i }).first();
+    await testnetItem.click();
 
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
@@ -89,11 +89,11 @@ test.describe("NetworkSwitcher — confirmation dialog", () => {
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await trigger.click();
 
-    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+    await page.getByRole("menuitem", { name: /Testnet/i }).first().click();
 
     const dialog = page.getByRole("dialog");
-    await expect(dialog).toContainText("Stellar");
-    await expect(dialog).toContainText("Polygon");
+    await expect(dialog).toContainText("Mainnet");
+    await expect(dialog).toContainText("Testnet");
   });
 
   test("dialog warns about balance/transaction context change", async ({ page }) => {
@@ -102,11 +102,11 @@ test.describe("NetworkSwitcher — confirmation dialog", () => {
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await trigger.click();
 
-    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+    await page.getByRole("menuitem", { name: /Testnet/i }).first().click();
 
     const dialog = page.getByRole("dialog");
     await expect(dialog).toContainText(/balances/i);
-    await expect(dialog).toContainText(/transaction/i);
+    await expect(dialog).toContainText(/operations/i);
     // Confirm no funds are moved
     await expect(dialog).toContainText(/no funds will be moved/i);
   });
@@ -117,16 +117,16 @@ test.describe("NetworkSwitcher — confirmation dialog", () => {
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await trigger.click();
 
-    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+    await page.getByRole("menuitem", { name: /Testnet/i }).first().click();
 
     await page.getByRole("button", { name: /cancel/i }).click();
 
     // Dialog should be gone
     await expect(page.getByRole("dialog")).not.toBeVisible();
 
-    // Trigger still shows ETH
+    // Trigger still shows Mainnet
     const updatedTrigger = page.locator('[aria-label*="Current network"]').first();
-    await expect(updatedTrigger).toHaveAttribute("aria-label", /Stellar/i);
+    await expect(updatedTrigger).toHaveAttribute("aria-label", /Mainnet/i);
   });
 
   test("confirming the switch updates the displayed network", async ({ page }) => {
@@ -135,16 +135,16 @@ test.describe("NetworkSwitcher — confirmation dialog", () => {
     const trigger = page.locator('[aria-label*="Current network"]').first();
     await trigger.click();
 
-    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+    await page.getByRole("menuitem", { name: /Testnet/i }).first().click();
 
     await page.getByTestId("confirm-network-switch").click();
 
     // Dialog should be gone
     await expect(page.getByRole("dialog")).not.toBeVisible();
 
-    // Trigger now shows Polygon
+    // Trigger now shows Testnet
     const updatedTrigger = page.locator('[aria-label*="Current network"]').first();
-    await expect(updatedTrigger).toHaveAttribute("aria-label", /Polygon/i);
+    await expect(updatedTrigger).toHaveAttribute("aria-label", /Testnet/i);
   });
 });
 
@@ -152,41 +152,41 @@ test.describe("NetworkSwitcher — rapid switching", () => {
   test("switching back and forth quickly ends on the last confirmed network", async ({ page }) => {
     await page.goto(LANDING_URL);
 
-    // Switch ETH → Polygon
+    // Switch Mainnet to Testnet
     await page.locator('[aria-label*="Current network"]').first().click();
-    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+    await page.getByRole("menuitem", { name: /Testnet/i }).first().click();
     await page.getByTestId("confirm-network-switch").click();
 
-    // Switch Polygon → BSC
+    // Switch Testnet to Futurenet
     await page.locator('[aria-label*="Current network"]').first().click();
-    await page.getByRole("menuitem", { name: /BSC/i }).first().click();
+    await page.getByRole("menuitem", { name: /Futurenet/i }).first().click();
     await page.getByTestId("confirm-network-switch").click();
 
-    // Switch BSC → ETH
+    // Switch Futurenet to Mainnet
     await page.locator('[aria-label*="Current network"]').first().click();
-    await page.getByRole("menuitem", { name: /Stellar/i }).first().click();
+    await page.getByRole("menuitem", { name: /Mainnet/i }).first().click();
     await page.getByTestId("confirm-network-switch").click();
 
     const trigger = page.locator('[aria-label*="Current network"]').first();
-    await expect(trigger).toHaveAttribute("aria-label", /Stellar/i);
+    await expect(trigger).toHaveAttribute("aria-label", /Mainnet/i);
   });
 
   test("cancelling mid-sequence preserves the last confirmed network", async ({ page }) => {
     await page.goto(LANDING_URL);
 
-    // Confirm ETH → Polygon
+    // Confirm Mainnet to Testnet
     await page.locator('[aria-label*="Current network"]').first().click();
-    await page.getByRole("menuitem", { name: /Polygon/i }).first().click();
+    await page.getByRole("menuitem", { name: /Testnet/i }).first().click();
     await page.getByTestId("confirm-network-switch").click();
 
-    // Start Polygon → BSC but cancel
+    // Start Testnet to Futurenet but cancel
     await page.locator('[aria-label*="Current network"]').first().click();
-    await page.getByRole("menuitem", { name: /BSC/i }).first().click();
+    await page.getByRole("menuitem", { name: /Futurenet/i }).first().click();
     await page.getByRole("button", { name: /cancel/i }).click();
 
-    // Should still be Polygon
+    // Should still be Testnet
     const trigger = page.locator('[aria-label*="Current network"]').first();
-    await expect(trigger).toHaveAttribute("aria-label", /Polygon/i);
+    await expect(trigger).toHaveAttribute("aria-label", /Testnet/i);
   });
 });
 
@@ -242,7 +242,7 @@ test.describe("NetworkSwitcher — keyboard accessibility", () => {
     await expect(page.locator('[role="menu"]').first()).not.toBeVisible();
 
     // Network unchanged
-    await expect(trigger).toHaveAttribute("aria-label", /Stellar/i);
+    await expect(trigger).toHaveAttribute("aria-label", /Mainnet/i);
   });
 });
 

--- a/types/wallet.ts
+++ b/types/wallet.ts
@@ -5,6 +5,7 @@
 export interface Network {
   id: string;
   name: string;
+  passphrase?: string;
   icon?: React.ReactNode;
 }
 


### PR DESCRIPTION
## Summary
- Replace the EVM placeholder network list with Stellar Mainnet, Testnet, and Futurenet.
- Add public Stellar passphrases to the shared Network model.
- Use the existing Stellar glyph in NetworkSwitcher and update the confirmation copy to mention Stellar balances and operations.
- Update the NetworkSwitcher Playwright spec expectations to cover the Stellar network labels.

Closes #279

## Validation
- PASS: `node node_modules/@playwright/test/cli.js test --list --config=playwright.config.ts network-switcher` (16 tests discovered)
- PASS: `git diff --check`
- BLOCKED: `node node_modules/typescript/bin/tsc --noEmit` is blocked by an existing `vitest.config.ts` type error: `Type 'false' is not assignable to type ...`

## Security
Only public Stellar network passphrases were added. No keys, secrets, or wallet material are introduced.