### PR TITLE
perf(analytics): memoize chart and transaction rows by huazhuang80-star

### DIFF
--- a/components/analytics/analytics-view.test.tsx
+++ b/components/analytics/analytics-view.test.tsx
@@ -5,6 +5,8 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import AnalyticsViews, { AnalyticsDataPoint } from "./analytics-view";
 import ClientAnalyticsView from "./client-analytics-view";
 
+let barChartRenderCount = 0;
+
 // Mock recharts
 vi.mock("recharts", () => {
   return {
@@ -18,9 +20,14 @@ vi.mock("recharts", () => {
       children: React.ReactNode;
       data: unknown;
     }) => (
-      <div data-testid="bar-chart" data-data={JSON.stringify(data)}>
-        {children}
-      </div>
+      (() => {
+        barChartRenderCount += 1;
+        return (
+          <div data-testid="bar-chart" data-data={JSON.stringify(data)}>
+            {children}
+          </div>
+        );
+      })()
     ),
     Bar: ({ dataKey }: { dataKey: string }) => (
       <div data-testid="bar" data-key={dataKey} />
@@ -54,6 +61,7 @@ vi.mock("@/hooks/usePaymentHistory", () => ({
 describe("AnalyticsViews Component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    barChartRenderCount = 0;
     mockUsePaymentHistory.mockReturnValue({
       data: [
         {
@@ -124,6 +132,16 @@ describe("AnalyticsViews Component", () => {
     fireEvent.click(screen.getByText("2024"));
     expect(screen.getByText("2024")).toBeInTheDocument();
     expect(screen.queryByText("2023")).not.toBeInTheDocument();
+  });
+
+  it("does not re-render the bar chart for unrelated dropdown state changes", () => {
+    render(<AnalyticsViews showDropdown={true} />);
+    expect(barChartRenderCount).toBe(1);
+
+    fireEvent.click(screen.getByText("This Year"));
+    fireEvent.click(screen.getByText("2024"));
+
+    expect(barChartRenderCount).toBe(1);
   });
 
   it("renders notifications sidebar when showNotifications is true", () => {

--- a/components/analytics/analytics-view.tsx
+++ b/components/analytics/analytics-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import Image from "next/image";
 import {
   BarChart,
@@ -100,6 +100,48 @@ const defaultData: AnalyticsDataPoint[] = [
   { month: "Dec", views: 54000 },
 ];
 
+interface AnalyticsBarChartProps {
+  chartData: AnalyticsDataPoint[];
+  showNotifications: boolean;
+}
+
+const AnalyticsBarChart = React.memo(function AnalyticsBarChart({
+  chartData,
+  showNotifications,
+}: AnalyticsBarChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={chartData}>
+        <CartesianGrid
+          strokeDasharray="3 3"
+          vertical={false}
+          stroke={showNotifications ? "currentColor" : "#1f1b2e"}
+          className={showNotifications ? "text-zinc-200 dark:text-zinc-800" : ""}
+        />
+        <XAxis
+          dataKey="month"
+          tick={{ fill: "#aaa", fontSize: 10 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          tick={{ fill: "#aaa", fontSize: 10 }}
+          tickFormatter={formatChartValue}
+          tickLine={false}
+          axisLine={false}
+        />
+        <Tooltip content={<CustomTooltip />} />
+        <Bar
+          dataKey="views"
+          fill={showNotifications ? "#3b82f6" : "#2E2E2E"}
+          radius={[4, 4, 0, 0]}
+          barSize={showNotifications ? 20 : 28}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+});
+
 /**
  * The canonical AnalyticsViews component.
  * Renders a recharts bar chart with a clean, responsive design, an optional year-selector dropdown,
@@ -117,14 +159,21 @@ const AnalyticsViews = ({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [selectedYear, setSelectedYear] = useState("This Year");
 
-  const yearOptions = ["This Year", "2024", "2023", "2022", "2021", "2020"];
+  const yearOptions = useMemo(
+    () => ["This Year", "2024", "2023", "2022", "2021", "2020"],
+    [],
+  );
 
-  const handleYearSelect = (year: string) => {
+  const handleYearSelect = useCallback((year: string) => {
     setSelectedYear(year);
     setIsDropdownOpen(false);
-  };
+  }, []);
 
-  const chartData = data || defaultData;
+  /**
+   * Memo key: only the caller-provided data reference changes the chart data.
+   * This keeps dropdown state updates from rebuilding the bar-chart payload.
+   */
+  const chartData = useMemo(() => data ?? defaultData, [data]);
 
   if (isLoading) {
     if (showNotifications) {
@@ -247,35 +296,10 @@ const AnalyticsViews = ({
         </div>
 
         <div className={showNotifications ? "w-full h-56 mt-4 border border-zinc-100 dark:border-zinc-800/50 p-6 rounded-xl bg-zinc-50/30 dark:bg-zinc-900/20" : "w-full h-full aspect-[3/1] rounded-lg border border-[#2D2D2D] p-2 sm:p-4"}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={chartData}>
-              <CartesianGrid
-                strokeDasharray="3 3"
-                vertical={false}
-                stroke={showNotifications ? "currentColor" : "#1f1b2e"}
-                className={showNotifications ? "text-zinc-200 dark:text-zinc-800" : ""}
-              />
-              <XAxis
-                dataKey="month"
-                tick={{ fill: "#aaa", fontSize: 10 }}
-                tickLine={false}
-                axisLine={false}
-              />
-              <YAxis
-                tick={{ fill: "#aaa", fontSize: 10 }}
-                tickFormatter={formatChartValue}
-                tickLine={false}
-                axisLine={false}
-              />
-              <Tooltip content={<CustomTooltip />} />
-              <Bar
-                dataKey="views"
-                fill={showNotifications ? "#3b82f6" : "#2E2E2E"}
-                radius={[4, 4, 0, 0]}
-                barSize={showNotifications ? 20 : 28}
-              />
-            </BarChart>
-          </ResponsiveContainer>
+          <AnalyticsBarChart
+            chartData={chartData}
+            showNotifications={showNotifications}
+          />
         </div>
       </div>
 

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -75,14 +75,35 @@ export default function TransactionsContent() {
     setCurrentPage(1);
   }, []);
 
+  const handleFromDateChange = useCallback(
+    (date: string) => updateFilter("fromDate", date),
+    [updateFilter],
+  );
+
+  const handleToDateChange = useCallback(
+    (date: string) => updateFilter("toDate", date),
+    [updateFilter],
+  );
+
+  const handleSearchChange = useCallback(
+    (query: string) => updateFilter("searchQuery", query),
+    [updateFilter],
+  );
+
+  const handleFilterChange = useCallback(
+    (filter: TransactionFilters["selectedFilter"]) =>
+      updateFilter("selectedFilter", filter),
+    [updateFilter],
+  );
+
   return (
     <div className="min-h-screen text-white mt-4">
       <div className="w-full max-w-7xl mx-auto mb-4">
         <TransactionsHeader
           fromDate={filters.fromDate}
           toDate={filters.toDate}
-          onFromDateChange={(date) => updateFilter("fromDate", date)}
-          onToDateChange={(date) => updateFilter("toDate", date)}
+          onFromDateChange={handleFromDateChange}
+          onToDateChange={handleToDateChange}
         />
 
         <div className="px-4 sm:px-6 lg:px-8 bg-[#160f17] pt-3 border-[#2D2D2D] border rounded-xl">
@@ -91,8 +112,8 @@ export default function TransactionsContent() {
             selectedFilter={filters.selectedFilter}
             sortField={filters.sortField}
             sortDirection={filters.sortDirection}
-            onSearchChange={(q) => updateFilter("searchQuery", q)}
-            onFilterChange={(f) => updateFilter("selectedFilter", f)}
+            onSearchChange={handleSearchChange}
+            onFilterChange={handleFilterChange}
             onSort={handleSort}
           />
 

--- a/components/transactions/transactions-table.tsx
+++ b/components/transactions/transactions-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import {
   Table,
   TableBody,
@@ -16,6 +17,105 @@ import { Skeleton } from "@/components/ui/skeleton";
 interface TransactionsTablePropsExtended extends TransactionsTableProps {
   isLoading?: boolean;
 }
+
+interface TransactionRowProps {
+  transaction: TransactionsTableProps["transactions"][number];
+}
+
+const DesktopTransactionRow = React.memo(function DesktopTransactionRow({
+  transaction,
+}: TransactionRowProps) {
+  return (
+    <TableRow className="border border-[#2D2D2D]">
+      <TableCell className="font-medium border border-[#2D2D2D] py-4 px-6">
+        <span className="text-[#D7E0EF]">{transaction.type}</span>
+        <p>#{transaction.id}</p>
+      </TableCell>
+      <TableCell className="border border-[#2D2D2D] py-4 px-6">
+        {transaction.address}
+      </TableCell>
+      <TableCell className="border border-[#2D2D2D] py-4 px-6">
+        <time dateTime={transaction.date}>
+          {transaction.date} {transaction.time}
+        </time>
+      </TableCell>
+      <TableCell className="flex place-items-center space-x-2 py-8 px-6">
+        <Image
+          src={transaction.tokenIcon}
+          alt={`${transaction.token} token icon`}
+          width={20}
+          height={20}
+        />
+        <span>{transaction.token}</span>
+      </TableCell>
+      <TableCell className="border border-[#2D2D2D] py-4 px-6 ">
+        {transaction.amount}
+      </TableCell>
+      <TableCell className="py-4 px-6">
+        <Badge
+          aria-label={`Status: ${transaction.status}`}
+          className={`${transaction.status === "Completed" ? "bg-[#102B19] text-[#04842E]" : transaction.status === "Pending" ? "bg-[#191919] text-[#9F6603]" : "bg-[#1A1A1A] text-[#B70B05]" }`}
+        >
+          <span className="text-sm">{transaction.status}</span>
+        </Badge>
+      </TableCell>
+    </TableRow>
+  );
+});
+
+const MobileTransactionCard = React.memo(function MobileTransactionCard({
+  transaction,
+}: TransactionRowProps) {
+  return (
+    <div className="p-4 border rounded-lg">
+      <div className="flex justify-between items-start">
+        <div>
+          <p className="font-medium">
+            {transaction.type} #{transaction.id}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {transaction.address}
+          </p>
+        </div>
+        <Badge
+          variant={
+            transaction.status === "Completed"
+              ? "default"
+              : transaction.status === "Pending"
+                ? "secondary"
+                : "destructive"
+          }
+        >
+          {transaction.status}
+        </Badge>
+      </div>
+      <div className="mt-2 grid grid-cols-2 gap-2">
+        <div>
+          <p className="text-sm text-muted-foreground">Date</p>
+          <p>
+            {transaction.date} {transaction.time}
+          </p>
+        </div>
+        <div>
+          <p className="text-sm text-muted-foreground">Token</p>
+          <p>{transaction.token}</p>
+        </div>
+        <div>
+          <p className="text-sm text-muted-foreground">Amount</p>
+          <p
+            className={
+              transaction.amount.startsWith("+")
+                ? "text-green-500"
+                : "text-red-500"
+            }
+          >
+            {transaction.amount}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+});
 
 export function TransactionsTable({ transactions, isLoading = false }: TransactionsTablePropsExtended) {
   const isEmpty = !isLoading && transactions.length === 0;
@@ -84,41 +184,11 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
                 </TableCell>
               </TableRow>
             ) : (
-              transactions.map((transaction, index) => (
-                <TableRow key={transaction.id ?? index} className="border border-[#2D2D2D]">
-                  <TableCell className="font-medium border border-[#2D2D2D] py-4 px-6">
-                    <span className="text-[#D7E0EF]">{transaction.type}</span>
-                    <p>#{transaction.id}</p>
-                  </TableCell>
-                  <TableCell className="border border-[#2D2D2D] py-4 px-6">
-                    {transaction.address}
-                  </TableCell>
-                  <TableCell className="border border-[#2D2D2D] py-4 px-6">
-                    <time dateTime={transaction.date}>
-                      {transaction.date} {transaction.time}
-                    </time>
-                  </TableCell>
-                  <TableCell className="flex place-items-center space-x-2 py-8 px-6">
-                    <Image
-                      src={transaction.tokenIcon}
-                      alt={`${transaction.token} token icon`}
-                      width={20}
-                      height={20}
-                    />
-                    <span>{transaction.token}</span>
-                  </TableCell>
-                  <TableCell className="border border-[#2D2D2D] py-4 px-6 ">
-                    {transaction.amount}
-                  </TableCell>
-                  <TableCell className="py-4 px-6">
-                    <Badge
-                      aria-label={`Status: ${transaction.status}`}
-                      className={`${transaction.status === "Completed" ? "bg-[#102B19] text-[#04842E]" : transaction.status === "Pending" ? "bg-[#191919] text-[#9F6603]" : "bg-[#1A1A1A] text-[#B70B05]" }`}
-                    >
-                      <span className="text-sm">{transaction.status}</span>
-                    </Badge>
-                  </TableCell>
-                </TableRow>
+              transactions.map((transaction) => (
+                <DesktopTransactionRow
+                  key={transaction.id}
+                  transaction={transaction}
+                />
               ))
             )}
           </TableBody>
@@ -156,54 +226,11 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
             </div>
           </div>
         ) : (
-          transactions.map((transaction, index) => (
-            <div key={index} className="p-4 border rounded-lg">
-              <div className="flex justify-between items-start">
-                <div>
-                  <p className="font-medium">
-                    {transaction.type} #{transaction.id}
-                  </p>
-                  <p className="text-sm text-muted-foreground">
-                    {transaction.address}
-                  </p>
-                </div>
-                <Badge
-                  variant={
-                    transaction.status === "Completed"
-                      ? "default"
-                      : transaction.status === "Pending"
-                        ? "secondary"
-                        : "destructive"
-                  }
-                >
-                  {transaction.status}
-                </Badge>
-              </div>
-              <div className="mt-2 grid grid-cols-2 gap-2">
-                <div>
-                  <p className="text-sm text-muted-foreground">Date</p>
-                  <p>
-                    {transaction.date} {transaction.time}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Token</p>
-                  <p>{transaction.token}</p>
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Amount</p>
-                  <p
-                    className={
-                      transaction.amount.startsWith("+")
-                        ? "text-green-500"
-                        : "text-red-500"
-                    }
-                  >
-                    {transaction.amount}
-                  </p>
-                </div>
-              </div>
-            </div>
+          transactions.map((transaction) => (
+            <MobileTransactionCard
+              key={transaction.id}
+              transaction={transaction}
+            />
           ))
         )}
       </div>

--- a/hooks/useTransactions.ts
+++ b/hooks/useTransactions.ts
@@ -5,7 +5,7 @@
 
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { getTransactions, PaginatedTransactions } from "@/lib/api";
 
 import type { TransactionFilters } from "@/types/transaction";
@@ -42,6 +42,36 @@ export function useTransactions(
   const refetch = useCallback(() => setTick((t) => t + 1), []);
 
   /**
+   * Memo key: the scalar filter fields, page, and page size are the complete
+   * query identity. This prevents equivalent caller object literals from
+   * forcing a new transaction derivation.
+   */
+  const query = useMemo(
+    () => ({
+      filters: {
+        searchQuery: filters?.searchQuery,
+        selectedFilter: filters?.selectedFilter,
+        fromDate: filters?.fromDate,
+        toDate: filters?.toDate,
+        sortField: filters?.sortField,
+        sortDirection: filters?.sortDirection,
+      },
+      page,
+      pageSize,
+    }),
+    [
+      filters?.searchQuery,
+      filters?.selectedFilter,
+      filters?.fromDate,
+      filters?.toDate,
+      filters?.sortField,
+      filters?.sortDirection,
+      page,
+      pageSize,
+    ],
+  );
+
+  /**
    * Effect cancellation is critical to prevent stale async responses from
    * overwriting newer filter/page results.
    */
@@ -59,7 +89,7 @@ export function useTransactions(
 
     setError(null);
 
-    getTransactions({ filters, page, pageSize }, controller.signal)
+    getTransactions(query, controller.signal)
 
       .then((result) => {
         if (controller.signal.aborted) return;
@@ -83,15 +113,7 @@ export function useTransactions(
       controller.abort();
     };
   }, [
-    filters?.searchQuery,
-
-    filters?.selectedFilter,
-    filters?.fromDate,
-    filters?.toDate,
-    filters?.sortField,
-    filters?.sortDirection,
-    page,
-    pageSize,
+    query,
     tick,
   ]);
 


### PR DESCRIPTION
## Summary
- Memoize the analytics chart payload and wrap the chart subtree so unrelated dropdown state does not re-render the bar chart.
- Normalize `useTransactions` query inputs with `useMemo` so equivalent filter objects do not re-derive the request identity.
- Wrap desktop/mobile transaction rows in `React.memo`, use stable transaction ids as keys, and stabilize filter callbacks passed to children.
- Add a render-count RTL test that asserts dropdown state changes do not re-render the bar chart.

Closes #298

## Validation
- PASS: `node node_modules/vitest/vitest.mjs run components/analytics/analytics-view.test.tsx` (12 tests passed)
- PASS: `git diff --check`

## Security
No data-access or wallet behavior changed. This only memoizes UI derivations and render boundaries.