### PR TITLE
fix(transactions): render token icon fallback by huazhuang80-star

### DIFF
--- a/components/transactions/token-icon.test.tsx
+++ b/components/transactions/token-icon.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import TokenIcon from "./token-icon";
+
+vi.mock("next/image", () => ({
+  default: ({
+    alt,
+    src,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img alt={alt} src={String(src)} {...props} />
+  ),
+}));
+
+describe("TokenIcon", () => {
+  it("keeps the USDC image branch unchanged", () => {
+    render(<TokenIcon token="USDC" />);
+
+    const icon = screen.getByAltText("USDC");
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute("src", "/usdc-logo.png");
+  });
+
+  it("keeps the XLM image branch unchanged", () => {
+    render(<TokenIcon token="XLM" />);
+
+    const icon = screen.getByAltText("XLM");
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute("src", "/stellar-xlm-logo.png");
+  });
+
+  it("renders a labeled fallback badge for an unsupported token", () => {
+    render(<TokenIcon token="EURC" />);
+
+    const fallback = screen.getByLabelText("EURC token icon");
+    expect(fallback).toBeInTheDocument();
+    expect(fallback).toHaveTextContent("EUR");
+    expect(fallback).toHaveClass("w-5", "h-5", "rounded-full");
+  });
+
+  it("renders a safe unknown-token fallback for an empty token", () => {
+    render(<TokenIcon token="  " />);
+
+    const fallback = screen.getByLabelText("Unknown token token icon");
+    expect(fallback).toBeInTheDocument();
+    expect(fallback).toHaveTextContent("?");
+  });
+
+  it("normalizes lowercase unsupported token initials", () => {
+    render(<TokenIcon token="brl" />);
+
+    expect(screen.getByLabelText("brl token icon")).toHaveTextContent("BRL");
+  });
+});

--- a/components/transactions/token-icon.tsx
+++ b/components/transactions/token-icon.tsx
@@ -1,6 +1,10 @@
 import Image from "next/image";
 import { TokenIconProps } from "@/types/transaction";
 
+/**
+ * Render a known token image or a stable fallback badge for unsupported
+ * symbols. Fallback text is escaped by React and never injected as HTML.
+ */
 export default function TokenIcon({ token }: TokenIconProps) {
   if (token === "USDC") {
     return (
@@ -28,4 +32,20 @@ export default function TokenIcon({ token }: TokenIconProps) {
       </div>
     );
   }
+
+  const normalizedToken = token.trim();
+  const fallbackLabel = normalizedToken || "Unknown token";
+  const initials = (normalizedToken.match(/[a-z0-9]/gi)?.join("") || "?")
+    .slice(0, 3)
+    .toUpperCase();
+
+  return (
+    <span
+      aria-label={`${fallbackLabel} token icon`}
+      className="w-5 h-5 rounded-full bg-[#2D2D2D] text-[8px] font-semibold text-[#D7E0EF] flex items-center justify-center uppercase shrink-0"
+      title={`${fallbackLabel} token`}
+    >
+      {initials}
+    </span>
+  );
 }


### PR DESCRIPTION
## Summary
- Add an explicit fallback badge for unsupported transaction token symbols.
- Keep the existing USDC and XLM image branches unchanged.
- Preserve the same `w-5 h-5` sizing and add an accessible label/title for fallback tokens.
- Add Vitest coverage for USDC, XLM, unknown, empty, and lowercase token cases.

Closes #320

## Validation
- PASS: `node node_modules/vitest/vitest.mjs run components/transactions/token-icon.test.tsx` (5 tests passed)
- PASS: `git diff --check`

## Security
Fallback token symbols are rendered as escaped React text only. No raw HTML or secret material is introduced.