### PR TITLE
refactor(clipboard): replace alert with callback by huazhuang80-star

### DIFF
--- a/utils/clipboardUtils.test.ts
+++ b/utils/clipboardUtils.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  copyToClipboard,
+  copyToClipboardWithFeedback,
+  copyToClipboardWithTimeout,
+} from "./clipboardUtils";
+
+const writeText = vi.fn();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  Object.defineProperty(globalThis.navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+  writeText.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  writeText.mockReset();
+});
+
+describe("clipboardUtils", () => {
+  it("copies text to clipboard", async () => {
+    await expect(copyToClipboard("stellar")).resolves.toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith("stellar");
+  });
+
+  it("keeps feedback callbacks unchanged", async () => {
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    await copyToClipboardWithFeedback("ok", onSuccess, onError);
+
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("sets copied true and resets after a valid timeout", async () => {
+    const setCopied = vi.fn();
+
+    await copyToClipboardWithTimeout("address", setCopied, 500);
+
+    expect(setCopied).toHaveBeenCalledWith(true);
+    expect(setCopied).not.toHaveBeenCalledWith(false);
+
+    vi.advanceTimersByTime(500);
+
+    expect(setCopied).toHaveBeenLastCalledWith(false);
+  });
+
+  it("defaults invalid timeout values to 2000ms", async () => {
+    const setCopied = vi.fn();
+
+    await copyToClipboardWithTimeout("address", setCopied, Number.POSITIVE_INFINITY);
+
+    vi.advanceTimersByTime(1999);
+    expect(setCopied).not.toHaveBeenCalledWith(false);
+
+    vi.advanceTimersByTime(1);
+    expect(setCopied).toHaveBeenLastCalledWith(false);
+  });
+
+  it("returns cleanup that cancels the pending reset timer", async () => {
+    const setCopied = vi.fn();
+
+    const cleanup = await copyToClipboardWithTimeout("address", setCopied, 500);
+    cleanup();
+    vi.advanceTimersByTime(500);
+
+    expect(setCopied).toHaveBeenCalledTimes(1);
+    expect(setCopied).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onError instead of alerting when clipboard write fails", async () => {
+    const setCopied = vi.fn();
+    const onError = vi.fn();
+    const alertSpy = vi.spyOn(globalThis, "alert").mockImplementation(() => {});
+    writeText.mockRejectedValueOnce(new Error("permission denied"));
+
+    await copyToClipboardWithTimeout("address", setCopied, 500, onError);
+
+    expect(setCopied).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith("Failed to copy text. Please try again.");
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+});

--- a/utils/clipboardUtils.ts
+++ b/utils/clipboardUtils.ts
@@ -42,18 +42,31 @@ export const copyToClipboardWithFeedback = async (
  * @param text - The text to copy
  * @param setCopied - State setter function for copied status
  * @param timeout - Timeout duration in milliseconds (default: 2000)
+ * @param onError - Callback function to call on error
+ * @returns Cleanup function that clears the pending reset timer
  */
 export const copyToClipboardWithTimeout = async (
   text: string,
   setCopied: (value: boolean) => void,
   timeout: number = 2000,
-): Promise<void> => {
+  onError?: (error: string) => void,
+): Promise<() => void> => {
   const success = await copyToClipboard(text);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
   if (success) {
+    const safeTimeout =
+      Number.isFinite(timeout) && timeout > 0 ? timeout : 2000;
+
     setCopied(true);
-    setTimeout(() => setCopied(false), timeout);
+    timeoutId = setTimeout(() => setCopied(false), safeTimeout);
   } else {
-    alert("Failed to copy text. Please try again.");
+    onError?.("Failed to copy text. Please try again.");
   }
+
+  return () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  };
 };


### PR DESCRIPTION
## Summary
- Replace the blocking `alert()` in `copyToClipboardWithTimeout` with an optional `onError` callback.
- Return a cleanup function so callers can cancel the pending copied-state reset timer.
- Default invalid timeout values to 2000ms while keeping existing call sites compatible.
- Add Vitest coverage for success, feedback callbacks, error callback, invalid timeout, and timer cleanup.

Closes #330

## Validation
- PASS: `node node_modules/vitest/vitest.mjs run utils/clipboardUtils.test.ts` (6 tests passed)
- PASS: `git diff --check`

## Security
Clipboard errors are surfaced through callbacks as escaped strings. No secrets or raw HTML are introduced.