### PR TITLE
feat(theme): add live system theme mode by huazhuang80-star

### DIFF
--- a/components/common/nav-link.tsx
+++ b/components/common/nav-link.tsx
@@ -19,7 +19,7 @@ import {
 
 export const NavLink = () => {
   const pathname = usePathname() || "/";
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
   const { isSidebarOpen, isMobile } = useSidebar();
 
   const isExpanded = shouldExpandSidebar(isMobile, isSidebarOpen);
@@ -57,9 +57,9 @@ export const NavLink = () => {
           
           let iconColor = "";
           if (isActive) {
-            iconColor = theme === "dark" ? "#0D0D0D" : "#FFFFFF";
+            iconColor = resolvedTheme === "dark" ? "#0D0D0D" : "#FFFFFF";
           } else {
-            iconColor = theme === "dark" ? "#E5E5E5" : "#71717A"; 
+            iconColor = resolvedTheme === "dark" ? "#E5E5E5" : "#71717A";
           }
 
           if (isExpanded) {

--- a/components/dashboard/dashboard-navbar.tsx
+++ b/components/dashboard/dashboard-navbar.tsx
@@ -9,7 +9,7 @@ import NetworkSwitcher from '@/components/common/network-switcher';
 import { StellOpayLogo } from '@/public/svg/svg';
 
 export default function DashboardNavbar() {
-    const { theme, toggleTheme } = useTheme();
+    const { resolvedTheme, toggleTheme } = useTheme();
     const { address, isConnected, connect, disconnect } = useWallet();
 
     return (
@@ -55,7 +55,7 @@ export default function DashboardNavbar() {
                     onClick={toggleTheme}
                     className="p-2 rounded-lg text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
                 >
-                    {theme === 'dark' ? (
+                    {resolvedTheme === 'dark' ? (
                         <Sun size={20} strokeWidth={2} />
                     ) : (
                         <Moon size={20} strokeWidth={2} />

--- a/components/landing/navbar.tsx
+++ b/components/landing/navbar.tsx
@@ -17,7 +17,7 @@ const navLinks = [
 
 export default function Navbar() {
   const pathname = usePathname() || "/";
-  const { theme, toggleTheme } = useTheme();
+  const { resolvedTheme, toggleTheme } = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const handleConnect = () => {
@@ -36,7 +36,7 @@ export default function Navbar() {
             <div className="flex items-center">
               <Link href="/" className="flex items-center">
                 <Image
-                  src={theme === "dark" ? "/logos/LOGO A/PNG/StelloPay Brand-13.png" : "/logos/LOGO A/PNG/StelloPay Brand-14.png"}
+                  src={resolvedTheme === "dark" ? "/logos/LOGO A/PNG/StelloPay Brand-13.png" : "/logos/LOGO A/PNG/StelloPay Brand-14.png"}
                   alt="StelloPay Logo"
                   width={130}
                   height={32}
@@ -74,7 +74,7 @@ export default function Navbar() {
                 onClick={toggleTheme}
                 className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-white/5 transition-colors"
               >
-                {theme === "light" ? (
+                {resolvedTheme === "light" ? (
                   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" fill="#0F172A" />
                   </svg>
@@ -90,7 +90,7 @@ export default function Navbar() {
               <button
                 onClick={handleConnect}
                 className={`hidden md:inline-flex items-center px-5 py-2 rounded-full font-medium transition-shadow shadow-sm ${
-                  theme === "dark"
+                  resolvedTheme === "dark"
                     ? "bg-white text-black hover:opacity-95"
                     : "bg-black text-white hover:opacity-95"
                 }`}

--- a/context/theme-context.test.tsx
+++ b/context/theme-context.test.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider, useTheme } from "./theme-context";
+
+type Listener = (event: MediaQueryListEvent) => void;
+
+let matches = false;
+let listeners = new Set<Listener>();
+
+const fireSystemThemeChange = (nextMatches: boolean) => {
+  matches = nextMatches;
+  const event = { matches: nextMatches } as MediaQueryListEvent;
+  listeners.forEach((listener) => listener(event));
+};
+
+function ThemeProbe() {
+  const { theme, resolvedTheme, setTheme, toggleTheme } = useTheme();
+
+  return (
+    <div>
+      <p data-testid="theme">{theme}</p>
+      <p data-testid="resolved-theme">{resolvedTheme}</p>
+      <button type="button" onClick={() => setTheme("light")}>
+        light
+      </button>
+      <button type="button" onClick={() => setTheme("dark")}>
+        dark
+      </button>
+      <button type="button" onClick={() => setTheme("system")}>
+        system
+      </button>
+      <button type="button" onClick={toggleTheme}>
+        toggle
+      </button>
+    </div>
+  );
+}
+
+const renderTheme = () =>
+  render(
+    <ThemeProvider>
+      <ThemeProbe />
+    </ThemeProvider>,
+  );
+
+describe("ThemeProvider", () => {
+  beforeEach(() => {
+    matches = false;
+    listeners = new Set();
+    window.localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches,
+        media: query,
+        addEventListener: (_event: "change", listener: Listener) => {
+          listeners.add(listener);
+        },
+        removeEventListener: (_event: "change", listener: Listener) => {
+          listeners.delete(listener);
+        },
+      })),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    document.documentElement.classList.remove("dark");
+  });
+
+  it("defaults to system and resolves the current OS preference", async () => {
+    matches = true;
+
+    renderTheme();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("theme")).toHaveTextContent("system");
+      expect(screen.getByTestId("resolved-theme")).toHaveTextContent("dark");
+      expect(document.documentElement).toHaveClass("dark");
+    });
+    expect(window.localStorage.getItem("theme")).toBe("system");
+  });
+
+  it("hydrates a stored light preference without following system dark", async () => {
+    window.localStorage.setItem("theme", "light");
+    matches = true;
+
+    renderTheme();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("theme")).toHaveTextContent("light");
+      expect(screen.getByTestId("resolved-theme")).toHaveTextContent("light");
+      expect(document.documentElement).not.toHaveClass("dark");
+    });
+  });
+
+  it("rejects unknown stored values and falls back to system", async () => {
+    window.localStorage.setItem("theme", "solarized");
+    matches = false;
+
+    renderTheme();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("theme")).toHaveTextContent("system");
+      expect(screen.getByTestId("resolved-theme")).toHaveTextContent("light");
+    });
+    expect(window.localStorage.getItem("theme")).toBe("system");
+  });
+
+  it("cycles light to dark to system", async () => {
+    window.localStorage.setItem("theme", "light");
+
+    renderTheme();
+
+    await act(async () => screen.getByRole("button", { name: "toggle" }).click());
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+    expect(screen.getByTestId("resolved-theme")).toHaveTextContent("dark");
+
+    await act(async () => screen.getByRole("button", { name: "toggle" }).click());
+    expect(screen.getByTestId("theme")).toHaveTextContent("system");
+    expect(screen.getByTestId("resolved-theme")).toHaveTextContent("light");
+  });
+
+  it("updates resolved theme live while system mode is active", async () => {
+    renderTheme();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("resolved-theme")).toHaveTextContent("light");
+    });
+
+    act(() => fireSystemThemeChange(true));
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("system");
+    expect(screen.getByTestId("resolved-theme")).toHaveTextContent("dark");
+    expect(document.documentElement).toHaveClass("dark");
+  });
+
+  it("cleans up the matchMedia change listener on unmount", () => {
+    const { unmount } = renderTheme();
+
+    expect(listeners.size).toBe(1);
+    unmount();
+    expect(listeners.size).toBe(0);
+  });
+});

--- a/context/theme-context.tsx
+++ b/context/theme-context.tsx
@@ -1,55 +1,88 @@
 "use client";
-import React, { createContext, useContext, useEffect, useState } from "react";
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { safeStorage } from "@/utils/safeStorage";
 
-type Theme = "light" | "dark";
+type ResolvedTheme = "light" | "dark";
+type Theme = ResolvedTheme | "system";
 
 type ThemeContextValue = {
   theme: Theme;
+  resolvedTheme: ResolvedTheme;
   toggleTheme: () => void;
   setTheme: (t: Theme) => void;
 };
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
+const STORAGE_KEY = "theme";
+const THEME_QUERY = "(prefers-color-scheme: dark)";
+
+const isTheme = (value: string | null): value is Theme =>
+  value === "light" || value === "dark" || value === "system";
+
+const getSystemTheme = (): ResolvedTheme => {
+  if (typeof window === "undefined" || !window.matchMedia) return "light";
+  return window.matchMedia(THEME_QUERY).matches ? "dark" : "light";
+};
+
 export const ThemeProvider: React.FC<React.PropsWithChildren<{}>> = ({
   children,
 }) => {
-  const [theme, setThemeState] = useState<Theme>("light");
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const stored = safeStorage.getItem(STORAGE_KEY);
+    return isTheme(stored) ? stored : "system";
+  });
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(getSystemTheme);
 
   useEffect(() => {
-    try {
-      const stored = safeStorage.getItem("theme");
-      if (stored === "dark" || stored === "light") {
-        setThemeState(stored);
-      } else {
-        // prefer system dark
-        const prefersDark =
-          window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-        setThemeState(prefersDark ? "dark" : "light");
-      }
-    } catch (e) {
-      // ignore
-    }
+    if (typeof window === "undefined" || !window.matchMedia) return;
+
+    const mediaQuery = window.matchMedia(THEME_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? "dark" : "light");
+    };
+
+    setSystemTheme(mediaQuery.matches ? "dark" : "light");
+    mediaQuery.addEventListener?.("change", handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener?.("change", handleChange);
+    };
   }, []);
+
+  /**
+   * `theme` is the persisted user preference; `resolvedTheme` is the concrete
+   * class applied to the document.
+   */
+  const resolvedTheme: ResolvedTheme = theme === "system" ? systemTheme : theme;
 
   useEffect(() => {
     try {
       const root = document.documentElement;
-      if (theme === "dark") {
+      if (resolvedTheme === "dark") {
         root.classList.add("dark");
       } else {
         root.classList.remove("dark");
       }
-      safeStorage.setItem("theme", theme);
+      safeStorage.setItem(STORAGE_KEY, theme);
     } catch (e) {}
-  }, [theme]);
+  }, [resolvedTheme, theme]);
 
-  const toggleTheme = () => setThemeState((t) => (t === "dark" ? "light" : "dark"));
-  const setTheme = (t: Theme) => setThemeState(t);
+  const toggleTheme = useCallback(() =>
+    setThemeState((t) => {
+      if (t === "light") return "dark";
+      if (t === "dark") return "system";
+      return "light";
+    }), []);
+  const setTheme = useCallback((t: Theme) => setThemeState(t), []);
+
+  const value = useMemo(
+    () => ({ theme, resolvedTheme, toggleTheme, setTheme }),
+    [theme, resolvedTheme, toggleTheme, setTheme],
+  );
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
+    <ThemeContext.Provider value={value}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Add a `system` theme preference alongside `light` and `dark`.
- Expose `resolvedTheme` as the concrete light/dark mode applied to `<html>`.
- Listen for `prefers-color-scheme` changes and update the applied class live while system mode is active.
- Persist the user preference, reject unknown stored values, and update theme consumers to use `resolvedTheme` for icons/logos.
- Add Vitest coverage for all modes, invalid storage, live OS changes, and listener cleanup.

Closes #286

## Validation
- PASS: `node node_modules/vitest/vitest.mjs run context/theme-context.test.tsx` (6 tests passed)
- PASS: `rg -n "const \\{ theme|theme ===|theme !==" components app context -g "*.tsx" -g "*.ts"` only reports ThemeContext internals/tests
- PASS: `git diff --check`

## Security
Only known theme preference values are accepted from localStorage. Unknown values fall back to `system`; no secrets or raw HTML are introduced.