### PR TITLE
feat(wallets): validate Stellar addresses by huazhuang80-star

### DIFF
--- a/app/settings/preferences/components/wallets-section.tsx
+++ b/app/settings/preferences/components/wallets-section.tsx
@@ -14,8 +14,14 @@ import ToggleCard from "@/components/common/toggle-card";
 import DestructiveActionDialog from "./destructive-action-dialog";
 import { DEMO_WALLETS } from "@/lib/demo-data";
 import { Loader2 } from "lucide-react";
+import { stellarAddressSchema } from "@/utils/stellarAddress";
 
-const connectedWallets = DEMO_WALLETS;
+interface ConnectedWallet {
+  name: string;
+  network: string;
+  address: string;
+  status: string;
+}
 
 interface WalletSettingsState {
   transferApprovals: boolean;
@@ -41,6 +47,11 @@ export default function WalletsSection() {
   });
   const [status, setStatus] = useState<StatusState>({ message: "", type: null });
   const [isSaving, setIsSaving] = useState(false);
+  const [connectedWallets, setConnectedWallets] =
+    useState<ConnectedWallet[]>(() => [...DEMO_WALLETS]);
+  const [walletName, setWalletName] = useState("");
+  const [walletAddress, setWalletAddress] = useState("");
+  const [walletAddressError, setWalletAddressError] = useState("");
 
   const updateSetting = (field: keyof WalletSettingsState, value: boolean) => {
     setSettings((currentSettings) => ({
@@ -75,6 +86,49 @@ export default function WalletsSection() {
     }
   };
 
+  const handleAddWallet = () => {
+    setWalletAddressError("");
+
+    try {
+      const result = stellarAddressSchema.safeParse(walletAddress);
+
+      if (!result.success) {
+        setWalletAddressError(
+          result.error.issues[0]?.message ?? "Enter a valid Stellar public address.",
+        );
+        return;
+      }
+
+      const normalizedAddress = result.data;
+      const isDuplicate = connectedWallets.some(
+        (wallet) => wallet.address.toUpperCase() === normalizedAddress,
+      );
+
+      if (isDuplicate) {
+        setWalletAddressError("This Stellar address is already connected.");
+        return;
+      }
+
+      setConnectedWallets((currentWallets) => [
+        ...currentWallets,
+        {
+          name: walletName.trim() || "New Stellar wallet",
+          network: normalizedAddress.startsWith("M") ? "Stellar Muxed" : "Stellar",
+          address: normalizedAddress,
+          status: "Pending review",
+        },
+      ]);
+      setWalletName("");
+      setWalletAddress("");
+      setStatus({
+        message: "Wallet address added for review.",
+        type: "success",
+      });
+    } catch {
+      setWalletAddressError("Enter a valid Stellar public address.");
+    }
+  };
+
   return (
     <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
       <Card className="border-zinc-200 bg-white/90 shadow-sm dark:border-white/10 dark:bg-white/5">
@@ -91,6 +145,60 @@ export default function WalletsSection() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4 pt-6">
+          <div className="rounded-3xl border border-zinc-200 bg-zinc-50 p-5 dark:border-white/10 dark:bg-white/5">
+            <div className="grid gap-4 md:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)_auto] md:items-end">
+              <div className="space-y-2">
+                <label
+                  htmlFor="wallet-name"
+                  className="text-sm font-medium text-zinc-900 dark:text-white"
+                >
+                  Wallet label
+                </label>
+                <input
+                  id="wallet-name"
+                  value={walletName}
+                  onChange={(event) => setWalletName(event.target.value)}
+                  className="h-10 w-full rounded-md border border-zinc-200 bg-white px-3 text-sm text-zinc-900 outline-none transition focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900/10 dark:border-white/10 dark:bg-white/5 dark:text-white dark:focus:border-white"
+                  placeholder="Payroll wallet"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  htmlFor="wallet-address"
+                  className="text-sm font-medium text-zinc-900 dark:text-white"
+                >
+                  Stellar address
+                </label>
+                <input
+                  id="wallet-address"
+                  value={walletAddress}
+                  onChange={(event) => {
+                    setWalletAddress(event.target.value);
+                    setWalletAddressError("");
+                  }}
+                  aria-invalid={walletAddressError ? "true" : undefined}
+                  aria-describedby={walletAddressError ? "wallet-address-error" : undefined}
+                  className="h-10 w-full rounded-md border border-zinc-200 bg-white px-3 text-sm text-zinc-900 outline-none transition focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900/10 dark:border-white/10 dark:bg-white/5 dark:text-white dark:focus:border-white"
+                  placeholder="G... or M..."
+                />
+                {walletAddressError && (
+                  <p
+                    id="wallet-address-error"
+                    role="alert"
+                    className="text-sm text-destructive"
+                  >
+                    {walletAddressError}
+                  </p>
+                )}
+              </div>
+
+              <Button type="button" onClick={handleAddWallet}>
+                Add wallet
+              </Button>
+            </div>
+          </div>
+
           {connectedWallets.map((wallet) => (
             <div
               key={wallet.name}

--- a/utils/stellarAddress.test.ts
+++ b/utils/stellarAddress.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isStellarAddress,
+  parseStellarAddress,
+  stellarAddressSchema,
+} from "./stellarAddress";
+
+const validG = `G${"A".repeat(55)}`;
+const validM = `M${"B".repeat(68)}`;
+
+describe("stellarAddressSchema", () => {
+  it("accepts uppercase G public keys", () => {
+    expect(parseStellarAddress(validG)).toBe(validG);
+    expect(isStellarAddress(validG)).toBe(true);
+  });
+
+  it("accepts muxed M addresses", () => {
+    expect(parseStellarAddress(validM)).toBe(validM);
+  });
+
+  it("trims whitespace and normalizes lowercase input", () => {
+    expect(parseStellarAddress(`  ${validG.toLowerCase()}  `)).toBe(validG);
+  });
+
+  it("rejects Stellar secret seeds", () => {
+    const result = stellarAddressSchema.safeParse(`S${"A".repeat(55)}`);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toMatch(/secret seed/i);
+  });
+
+  it("rejects wrong prefixes", () => {
+    expect(isStellarAddress(`T${"A".repeat(55)}`)).toBe(false);
+  });
+
+  it("rejects wrong length", () => {
+    expect(isStellarAddress(`G${"A".repeat(54)}`)).toBe(false);
+    expect(isStellarAddress(`M${"A".repeat(67)}`)).toBe(false);
+  });
+
+  it("rejects non-base32 characters", () => {
+    expect(isStellarAddress(`G${"A".repeat(54)}0`)).toBe(false);
+  });
+});

--- a/utils/stellarAddress.ts
+++ b/utils/stellarAddress.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+const STELLAR_PUBLIC_KEY_LENGTH = 56;
+const STELLAR_MUXED_ADDRESS_LENGTH = 69;
+const STELLAR_BASE32 = /^[A-Z2-7]+$/;
+
+/**
+ * Validates public Stellar recipient addresses only.
+ * G-addresses are Ed25519 public keys; M-addresses are muxed public accounts.
+ * Secret seeds start with S and must never be accepted in wallet address forms.
+ */
+export const stellarAddressSchema = z
+  .string()
+  .trim()
+  .transform((address) => address.toUpperCase())
+  .superRefine((address, ctx) => {
+    if (address.startsWith("S")) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Enter a public Stellar address, not a secret seed.",
+      });
+      return;
+    }
+
+    const hasPublicPrefix = address.startsWith("G") || address.startsWith("M");
+    if (!hasPublicPrefix) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Address must start with G or M.",
+      });
+      return;
+    }
+
+    const expectedLength = address.startsWith("G")
+      ? STELLAR_PUBLIC_KEY_LENGTH
+      : STELLAR_MUXED_ADDRESS_LENGTH;
+
+    if (address.length !== expectedLength) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Address must be ${expectedLength} characters long.`,
+      });
+      return;
+    }
+
+    if (!STELLAR_BASE32.test(address)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Address may only contain uppercase base32 characters A-Z and 2-7.",
+      });
+    }
+  });
+
+export const parseStellarAddress = (address: string): string =>
+  stellarAddressSchema.parse(address);
+
+export const isStellarAddress = (address: string): boolean =>
+  stellarAddressSchema.safeParse(address).success;


### PR DESCRIPTION
## Summary
- Add a zod-backed Stellar address schema for public G-addresses and muxed M-addresses.
- Explicitly reject S-prefixed secret seeds, invalid prefixes, invalid length, and non-base32 characters.
- Add an Add wallet form in WalletsSection with inline address errors, duplicate detection, trimming, and uppercase normalization.
- Add focused Vitest coverage for valid, invalid, lowercase, whitespace, secret seed, and muxed address cases.

Closes #294

## Validation
- PASS: `node node_modules/vitest/vitest.mjs run utils/stellarAddress.test.ts` (7 tests passed)
- PASS: `git diff --check`
- BLOCKED: `node node_modules/typescript/bin/tsc --noEmit --pretty false` is blocked by an existing `vitest.config.ts` type error: `Type 'false' is not assignable to type ...`

## Security
The form only accepts public Stellar G/M addresses. S-prefixed secret seeds are rejected before storage/display, and entered addresses are rendered as React text only.