### PR TITLE
feat(verify-email): add resend countdown hook by huazhuang80-star

### DIFF
--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -3,8 +3,10 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { X, Loader2 } from "lucide-react";
+import { useCountdown } from "@/hooks/useCountdown";
 
 type StatusType = "idle" | "loading" | "success" | "error";
+const RESEND_COOLDOWN_SECONDS = 30;
 
 export default function VerifyEmail() {
   const [code, setCode] = useState("");
@@ -12,6 +14,9 @@ export default function VerifyEmail() {
   const [status, setStatus] = useState<StatusType>("idle");
   const [message, setMessage] = useState("");
   const [resendStatus, setResendStatus] = useState<StatusType>("idle");
+  const resendCooldown = useCountdown({
+    initialSeconds: RESEND_COOLDOWN_SECONDS,
+  });
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.replace(/[^0-9a-zA-Z]/g, "");
@@ -19,6 +24,8 @@ export default function VerifyEmail() {
   };
 
   const handleResend = async () => {
+    if (resendCooldown.isActive || resendStatus === "loading") return;
+
     setResendStatus("loading");
     setMessage("");
     try {
@@ -26,6 +33,7 @@ export default function VerifyEmail() {
       await new Promise((resolve) => setTimeout(resolve, 1500));
       setResendStatus("success");
       setMessage("Verification code resent to your email.");
+      resendCooldown.start();
     } catch {
       setResendStatus("error");
       setMessage("Failed to resend code. Please try again.");
@@ -76,7 +84,7 @@ export default function VerifyEmail() {
           Didn&apos;t get code?{" "}
           <button
             onClick={handleResend}
-            disabled={resendStatus === "loading"}
+            disabled={resendStatus === "loading" || resendCooldown.isActive}
             className="text-white font-semibold underline cursor-pointer disabled:opacity-50"
           >
             {resendStatus === "loading" ? (
@@ -84,6 +92,8 @@ export default function VerifyEmail() {
                 <Loader2 className="inline h-4 w-4 mr-1 animate-spin" />
                 Sending...
               </>
+            ) : resendCooldown.isActive ? (
+              `Resend in ${resendCooldown.secondsLeft}s`
             ) : "Resend"}
           </button>
         </p>

--- a/hooks/useCountdown.test.ts
+++ b/hooks/useCountdown.test.ts
@@ -1,0 +1,85 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCountdown } from "./useCountdown";
+
+describe("useCountdown", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("starts from the requested number of seconds", () => {
+    const { result } = renderHook(() => useCountdown());
+
+    act(() => result.current.start(3));
+
+    expect(result.current.secondsLeft).toBe(3);
+    expect(result.current.isActive).toBe(true);
+  });
+
+  it("ticks down to zero and calls onComplete once", () => {
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useCountdown({ onComplete }));
+
+    act(() => result.current.start(2));
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current.secondsLeft).toBe(1);
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current.secondsLeft).toBe(0);
+    expect(result.current.isActive).toBe(false);
+    expect(onComplete).toHaveBeenCalledOnce();
+
+    act(() => vi.advanceTimersByTime(2000));
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+
+  it("reset cancels the active interval", () => {
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useCountdown({ onComplete }));
+
+    act(() => result.current.start(5));
+    act(() => result.current.reset());
+    act(() => vi.advanceTimersByTime(5000));
+
+    expect(result.current.secondsLeft).toBe(0);
+    expect(result.current.isActive).toBe(false);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("starting again replaces the existing interval", () => {
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useCountdown({ onComplete }));
+
+    act(() => result.current.start(5));
+    act(() => vi.advanceTimersByTime(1000));
+    act(() => result.current.start(2));
+    act(() => vi.advanceTimersByTime(2000));
+
+    expect(result.current.secondsLeft).toBe(0);
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+
+  it("uses initialSeconds when start receives no argument", () => {
+    const { result } = renderHook(() => useCountdown({ initialSeconds: 4 }));
+
+    act(() => result.current.start());
+
+    expect(result.current.secondsLeft).toBe(4);
+  });
+
+  it("cleans up the interval on unmount", () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+    const { result, unmount } = renderHook(() => useCountdown());
+
+    act(() => result.current.start(5));
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+  });
+});

--- a/hooks/useCountdown.ts
+++ b/hooks/useCountdown.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseCountdownOptions {
+  initialSeconds?: number;
+  onComplete?: () => void;
+}
+
+/**
+ * Reusable countdown timer for rate-limited UI actions.
+ * Keeps a single interval alive, cleans it up on unmount, and fires
+ * `onComplete` exactly when the timer reaches zero.
+ */
+export function useCountdown({
+  initialSeconds = 0,
+  onComplete,
+}: UseCountdownOptions = {}) {
+  const [secondsLeft, setSecondsLeft] = useState(() =>
+    Math.max(0, Math.floor(initialSeconds)),
+  );
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const onCompleteRef = useRef(onComplete);
+
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  const clearCountdown = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(
+    (nextSeconds = 0) => {
+      clearCountdown();
+      setSecondsLeft(Math.max(0, Math.floor(nextSeconds)));
+    },
+    [clearCountdown],
+  );
+
+  const start = useCallback(
+    (nextSeconds = initialSeconds) => {
+      const duration = Math.max(0, Math.floor(nextSeconds));
+      clearCountdown();
+      setSecondsLeft(duration);
+
+      if (duration === 0) {
+        onCompleteRef.current?.();
+        return;
+      }
+
+      intervalRef.current = setInterval(() => {
+        setSecondsLeft((current) => {
+          if (current <= 1) {
+            clearCountdown();
+            onCompleteRef.current?.();
+            return 0;
+          }
+
+          return current - 1;
+        });
+      }, 1000);
+    },
+    [clearCountdown, initialSeconds],
+  );
+
+  useEffect(() => clearCountdown, [clearCountdown]);
+
+  return {
+    secondsLeft,
+    isActive: secondsLeft > 0,
+    start,
+    reset,
+  };
+}


### PR DESCRIPTION
## Summary
- Add a reusable `useCountdown` hook with secondsLeft, isActive, start, reset, completion callback, and interval cleanup.
- Refactor verify-email resend to use the hook, disable during cooldown, and show remaining seconds.
- Guard rapid resend clicks while loading or cooling down.
- Add fake-timer Vitest coverage for start, ticking, completion, reset, restart, initialSeconds, and unmount cleanup.

Closes #305

## Validation
- PASS: `node node_modules/vitest/vitest.mjs run hooks/useCountdown.test.ts` (6 tests passed)
- PASS: `git diff --check`
- NOTE: `node node_modules/@playwright/test/cli.js test --list --config=playwright.config.ts verify-email` found no matching Playwright spec in the current repo

## Security
This cooldown is a UX guard only; server-side rate limits are still required. The hook prevents duplicate client intervals and cleans up on unmount.