### PR TITLE
test(transactions): cover date range filtering by huazhuang80-star

### DIFF
--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -73,6 +73,10 @@ const Transactions = () => {
         endDate={endDate}
         onStartDateChange={setStartDate}
         onEndDateChange={setEndDate}
+        onClearDateRange={() => {
+          setStartDate(undefined);
+          setEndDate(undefined);
+        }}
       />
 
       <div className="container mx-auto py-8 px-8">

--- a/components/dashboard/transaction-header.tsx
+++ b/components/dashboard/transaction-header.tsx
@@ -6,6 +6,7 @@ interface TransactionHeaderProps {
   endDate: Date | undefined;
   onStartDateChange: (date: Date | undefined) => void;
   onEndDateChange: (date: Date | undefined) => void;
+  onClearDateRange?: () => void;
 }
 
 export default function TransactionHeader({
@@ -14,7 +15,10 @@ export default function TransactionHeader({
   endDate,
   onStartDateChange,
   onEndDateChange,
+  onClearDateRange,
 }: TransactionHeaderProps) {
+  const hasDateRange = Boolean(startDate || endDate);
+
   return (
     <div className="w-full px-4 md:px-6 pt-4 border-b border-[#1A1A1A]">
       <div className="max-w-screen-xl mx-auto flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
@@ -31,6 +35,15 @@ export default function TransactionHeader({
             onDateChange={onEndDateChange}
             placeholder="End date"
           />
+          {hasDateRange && onClearDateRange && (
+            <button
+              type="button"
+              onClick={onClearDateRange}
+              className="h-10 rounded-md border border-[#242428] px-3 text-sm font-medium text-[#CBD2EB] transition hover:bg-[#1a1a1a] hover:text-white"
+            >
+              Clear date range
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/tests/transactions-date-filter.spec.ts
+++ b/tests/transactions-date-filter.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TRANSACTIONS_URL = "/transactions";
+
+async function selectApril122023(page: Page, triggerName: RegExp) {
+  await page.getByRole("button", { name: triggerName }).click();
+
+  const previousMonth = page.getByLabel(/previous month/i);
+  for (let i = 0; i < 40; i += 1) {
+    if (await page.getByText(/April 2023/i).isVisible().catch(() => false)) {
+      break;
+    }
+    await previousMonth.click();
+  }
+
+  await expect(page.getByText(/April 2023/i)).toBeVisible();
+  await page.getByRole("button", { name: /12/ }).first().click();
+}
+
+async function visibleTransactionDates(page: Page) {
+  return page
+    .locator("tbody time")
+    .evaluateAll((nodes) =>
+      nodes.map((node) => node.getAttribute("datetime") ?? node.textContent ?? ""),
+    );
+}
+
+test.describe("Transactions date range filter", () => {
+  test("filters rows to a selected date range and clears back to all rows", async ({
+    page,
+  }) => {
+    await page.goto(TRANSACTIONS_URL);
+
+    await expect(page.getByText("All Transactions")).toBeVisible();
+    await expect(page.locator("tbody tr")).toHaveCount(6);
+
+    await selectApril122023(page, /start date/i);
+    await selectApril122023(page, /end date/i);
+
+    await expect(page.getByText("(2 filtered)")).toBeVisible();
+    await expect(page.locator("tbody tr")).toHaveCount(2);
+    await expect
+      .poll(() => visibleTransactionDates(page))
+      .toEqual(["2023-04-12", "2023-04-12"]);
+
+    await page.getByRole("button", { name: /clear date range/i }).click();
+
+    await expect(page.getByText("(2 filtered)")).not.toBeVisible();
+    await expect(page.locator("tbody tr")).toHaveCount(6);
+  });
+});

--- a/utils/dateUtils.test.ts
+++ b/utils/dateUtils.test.ts
@@ -32,6 +32,15 @@ describe("dateUtils", () => {
     expect(parseTransactionDate("not-a-date")).toBeNull();
   });
 
+  it("parses ISO transaction dates used by mock transaction data", () => {
+    const parsed = parseTransactionDate("2023-04-12");
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.getFullYear()).toBe(2023);
+    expect(parsed?.getMonth()).toBe(3);
+    expect(parsed?.getDate()).toBe(12);
+  });
+
   it("checks Date objects inclusively when both range endpoints are provided", () => {
     const start = new Date("2024-01-01T00:00:00.000Z");
     const middle = new Date("2024-01-15T00:00:00.000Z");
@@ -62,6 +71,8 @@ describe("dateUtils", () => {
     expect(isDateInRange("May 01, 2023", undefined, end)).toBe(false);
     expect(isDateInRange("Apr 12, 2023", start, end)).toBe(true);
     expect(isDateInRange("May 01, 2023", start, end)).toBe(false);
+    expect(isDateInRange("2023-04-12", start, end)).toBe(true);
+    expect(isDateInRange("2023-05-01", start, end)).toBe(false);
   });
 
   it("keeps malformed transaction date labels visible instead of filtering them out", () => {

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -1,7 +1,7 @@
 /**
  * Date utility functions
  */
-import { isValid, isWithinInterval, parse } from "date-fns";
+import { isValid, isWithinInterval, parse, parseISO } from "date-fns";
 
 /**
  * Formats a date string to a readable format (e.g., "Jan 15, 2024")
@@ -46,8 +46,11 @@ export const formatDateForDisplay = (date: Date): string => {
  */
 export const parseTransactionDate = (dateString: string): Date | null => {
   try {
-    const parsed = parse(dateString, "MMM dd, yyyy", new Date());
-    return isValid(parsed) ? parsed : null;
+    const isoParsed = parseISO(dateString);
+    if (isValid(isoParsed)) return isoParsed;
+
+    const labelParsed = parse(dateString, "MMM dd, yyyy", new Date());
+    return isValid(labelParsed) ? labelParsed : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Add a Playwright spec for the transactions date-range filter flow.
- Select a known in-range date from the calendar, assert only matching rows remain, then clear the range and assert the full list returns.
- Add a small `Clear date range` control so the range can be reset from the UI.
- Fix ISO transaction date parsing so mock data dates like `2023-04-12` are actually filterable, and add unit coverage.

Closes #297

## Validation
- PASS: `node node_modules/vitest/vitest.mjs run utils/dateUtils.test.ts` (8 tests passed)
- PASS: `node node_modules/@playwright/test/cli.js test --list --config=playwright.config.ts transactions-date-filter` (1 test discovered)
- PASS: `git diff --check`
- BLOCKED: full Playwright execution is blocked locally because `playwright.config.ts` starts the web server with `npx`, which is not available in this Windows shell

## Security
UI-only flow over mock transaction data. No auth, wallet, or secret material is changed.