### PR TITLE
refactor(transactions): type sort comparators by huazhuang80-star

### DIFF
--- a/utils/transactionUtils.ts
+++ b/utils/transactionUtils.ts
@@ -6,6 +6,9 @@ import type {
 import { formatCurrency } from "./formatUtils";
 import { formatDate } from "./dateUtils";
 
+type SortableTransactionField = Extract<keyof Transaction, SortField>;
+type TransactionSortValue = Date | number | string;
+
 /**
  * Formats transaction amount with proper currency formatting
  * @param amount - The amount to format
@@ -72,6 +75,24 @@ export const filterTransactions = (
   return filtered;
 };
 
+const getTransactionSortValue = (
+  transaction: Transaction,
+  sortField: SortableTransactionField,
+): TransactionSortValue | null => {
+  switch (sortField) {
+    case "date":
+      return new Date(transaction.date);
+    case "amount":
+      return Math.abs(transaction.amount);
+    case "type":
+      return transaction.type;
+    case "status":
+      return transaction.status;
+    default:
+      return null;
+  }
+};
+
 /**
  * Sorts transactions by specified field and direction
  * @param transactions - Array of transactions to sort
@@ -85,29 +106,10 @@ export const sortTransactions = (
   sortDirection: SortDirection,
 ): Transaction[] => {
   return [...transactions].sort((a, b) => {
-    let aValue: any;
-    let bValue: any;
+    const aValue = getTransactionSortValue(a, sortField);
+    const bValue = getTransactionSortValue(b, sortField);
 
-    switch (sortField) {
-      case "date":
-        aValue = new Date(a.date);
-        bValue = new Date(b.date);
-        break;
-      case "amount":
-        aValue = Math.abs(a.amount);
-        bValue = Math.abs(b.amount);
-        break;
-      case "type":
-        aValue = a.type;
-        bValue = b.type;
-        break;
-      case "status":
-        aValue = a.status;
-        bValue = b.status;
-        break;
-      default:
-        return 0;
-    }
+    if (aValue === null || bValue === null) return 0;
 
     if (aValue < bValue) return sortDirection === "asc" ? -1 : 1;
     if (aValue > bValue) return sortDirection === "asc" ? 1 : -1;


### PR DESCRIPTION
## Summary
- Replace `any` comparator values in `sortTransactions` with a typed `Date | number | string` union.
- Derive supported sort fields from the `Transaction` model and keep unsupported cast behavior stable.
- Preserve existing ascending/descending behavior for date, amount, type, and status sorting.

Closes #332

## Validation
- PASS: `node node_modules/vitest/vitest.mjs run utils/transactionUtils.test.ts` (15 tests passed)
- PASS: `rg -n "any|let aValue|let bValue" utils/transactionUtils.ts` returned no matches
- PASS: `git diff --check`

## Security
No data access behavior changed. This tightens type safety around transaction ordering logic.