### PR TITLE
fix(settings): derive summary cards from live state by huazhuang80-star

### DIFF
--- a/app/settings/preferences/components/account-section.tsx
+++ b/app/settings/preferences/components/account-section.tsx
@@ -18,7 +18,7 @@ import { FormMessage } from "@/components/ui/form";
 import DestructiveActionDialog from "./destructive-action-dialog";
 import { DEMO_PROFILE } from "@/lib/demo-data";
 
-interface ProfileState {
+export interface ProfileState {
   firstName: string;
   lastName: string;
   displayName: string;
@@ -55,28 +55,41 @@ const sectionMap = [
   },
 ];
 
+export const INITIAL_PROFILE_STATE: ProfileState = {
+  firstName: DEMO_PROFILE.firstName,
+  lastName: DEMO_PROFILE.lastName,
+  displayName: DEMO_PROFILE.displayName,
+  email: DEMO_PROFILE.email,
+  timezone: DEMO_PROFILE.timezone,
+  currency: DEMO_PROFILE.currency,
+};
+
+interface AccountSectionProps {
+  onSummaryChange?: (profile: ProfileState) => void;
+}
+
 /**
  * AccountSection component.
  * Renders user profile information, identity details, and regional settings.
  * Uses placeholder demo data pending full backend API integration.
  */
-export default function AccountSection() {
-  const [profile, setProfile] = useState<ProfileState>({
-    firstName: DEMO_PROFILE.firstName,
-    lastName: DEMO_PROFILE.lastName,
-    displayName: DEMO_PROFILE.displayName,
-    email: DEMO_PROFILE.email,
-    timezone: DEMO_PROFILE.timezone,
-    currency: DEMO_PROFILE.currency,
-  });
+export default function AccountSection({
+  onSummaryChange,
+}: AccountSectionProps = {}) {
+  const [profile, setProfile] =
+    useState<ProfileState>(INITIAL_PROFILE_STATE);
   const [status, setStatus] = useState<StatusState>({ message: "", type: null });
   const [isSaving, setIsSaving] = useState(false);
 
   const updateProfileField = (field: keyof ProfileState, value: string) => {
-    setProfile((currentProfile) => ({
-      ...currentProfile,
-      [field]: value,
-    }));
+    setProfile((currentProfile) => {
+      const nextProfile = {
+        ...currentProfile,
+        [field]: value,
+      };
+      onSummaryChange?.(nextProfile);
+      return nextProfile;
+    });
   };
 
   const handleSave = async () => {

--- a/app/settings/preferences/components/notifications-section.tsx
+++ b/app/settings/preferences/components/notifications-section.tsx
@@ -12,7 +12,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-interface NotificationSettingsState {
+export interface NotificationSettingsState {
   transactionAlerts: boolean;
   securityAlerts: boolean;
   productUpdates: boolean;
@@ -22,26 +22,40 @@ interface NotificationSettingsState {
   smsChannel: boolean;
 }
 
-export default function NotificationsSection() {
-  const [settings, setSettings] = useState<NotificationSettingsState>({
-    transactionAlerts: true,
-    securityAlerts: true,
-    productUpdates: true,
-    marketing: false,
-    emailChannel: true,
-    pushChannel: true,
-    smsChannel: false,
-  });
+export const INITIAL_NOTIFICATION_SETTINGS: NotificationSettingsState = {
+  transactionAlerts: true,
+  securityAlerts: true,
+  productUpdates: true,
+  marketing: false,
+  emailChannel: true,
+  pushChannel: true,
+  smsChannel: false,
+};
+
+interface NotificationsSectionProps {
+  onSummaryChange?: (settings: NotificationSettingsState) => void;
+}
+
+export default function NotificationsSection({
+  onSummaryChange,
+}: NotificationsSectionProps = {}) {
+  const [settings, setSettings] = useState<NotificationSettingsState>(
+    INITIAL_NOTIFICATION_SETTINGS,
+  );
   const [statusMessage, setStatusMessage] = useState("");
 
   const updateSetting = (
     field: keyof NotificationSettingsState,
     value: boolean,
   ) => {
-    setSettings((currentSettings) => ({
-      ...currentSettings,
-      [field]: value,
-    }));
+    setSettings((currentSettings) => {
+      const nextSettings = {
+        ...currentSettings,
+        [field]: value,
+      };
+      onSummaryChange?.(nextSettings);
+      return nextSettings;
+    });
   };
 
   return (

--- a/app/settings/preferences/components/security-tab.tsx
+++ b/app/settings/preferences/components/security-tab.tsx
@@ -46,17 +46,33 @@ interface StatusState {
   type: "success" | "error" | null;
 }
 
+export interface SecuritySummaryState {
+  twoFactorEnabled: boolean;
+  loginApprovalEnabled: boolean;
+  transferApprovalEnabled: boolean;
+}
+
+export const INITIAL_SECURITY_SUMMARY: SecuritySummaryState = {
+  twoFactorEnabled: true,
+  loginApprovalEnabled: true,
+  transferApprovalEnabled: true,
+};
+
+interface SecurityTabProps {
+  onSummaryChange?: (settings: SecuritySummaryState) => void;
+}
+
 /**
  * SecurityTab component.
  * Renders security-sensitive forms (password updates, two-factor authentication, active sessions).
  * Uses placeholder demo data pending full backend API integration.
  */
-export default function SecurityTab() {
+export default function SecurityTab({ onSummaryChange }: SecurityTabProps = {}) {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [twoFactorEnabled, setTwoFactorEnabled] = useState(true);
-  const [loginApprovalEnabled, setLoginApprovalEnabled] = useState(true);
-  const [transferApprovalEnabled, setTransferApprovalEnabled] = useState(true);
+  const [summarySettings, setSummarySettings] = useState<SecuritySummaryState>(
+    INITIAL_SECURITY_SUMMARY,
+  );
   const [status, setStatus] = useState<StatusState>({ message: "", type: null });
   const [isSaving, setIsSaving] = useState(false);
 
@@ -65,6 +81,20 @@ export default function SecurityTab() {
     Object.values(passwordRequirements).every(Boolean) &&
     password.length > 0 &&
     password === confirmPassword;
+
+  const updateSummarySetting = (
+    field: keyof SecuritySummaryState,
+    value: boolean,
+  ) => {
+    setSummarySettings((currentSettings) => {
+      const nextSettings = {
+        ...currentSettings,
+        [field]: value,
+      };
+      onSummaryChange?.(nextSettings);
+      return nextSettings;
+    });
+  };
 
   const handleSaveChanges = async () => {
     if (!isPasswordReady) {
@@ -249,20 +279,26 @@ export default function SecurityTab() {
               title="Authenticator app verification"
               description="Require a second factor for password resets and critical profile changes."
               badge="Recommended"
-              enabled={twoFactorEnabled}
-              onToggle={setTwoFactorEnabled}
+              enabled={summarySettings.twoFactorEnabled}
+              onToggle={(value) =>
+                updateSummarySetting("twoFactorEnabled", value)
+              }
             />
             <ToggleCard
               title="New device approval"
               description="Challenge sign-ins from browsers or devices you have not approved yet."
-              enabled={loginApprovalEnabled}
-              onToggle={setLoginApprovalEnabled}
+              enabled={summarySettings.loginApprovalEnabled}
+              onToggle={(value) =>
+                updateSummarySetting("loginApprovalEnabled", value)
+              }
             />
             <ToggleCard
               title="Large transfer approval"
               description="Hold transfers over your threshold for a second confirmation."
-              enabled={transferApprovalEnabled}
-              onToggle={setTransferApprovalEnabled}
+              enabled={summarySettings.transferApprovalEnabled}
+              onToggle={(value) =>
+                updateSummarySetting("transferApprovalEnabled", value)
+              }
             />
           </CardContent>
         </Card>

--- a/app/settings/preferences/components/settings-page-shell.test.tsx
+++ b/app/settings/preferences/components/settings-page-shell.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import SettingsPageShell from "./settings-page-shell";
+
+const replace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/settings/preferences",
+  useRouter: () => ({
+    replace,
+  }),
+}));
+
+describe("SettingsPageShell", () => {
+  it("updates summary cards when section state changes", () => {
+    render(<SettingsPageShell initialSection="notifications" />);
+
+    const alertsSummary = screen
+      .getByText("Alerts enabled")
+      .closest('[data-slot="card"]') as HTMLElement | null;
+    expect(alertsSummary).not.toBeNull();
+    expect(within(alertsSummary!).getByText("5 active")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Marketing and announcements" }),
+    );
+
+    expect(within(alertsSummary!).getByText("6 active")).toBeInTheDocument();
+  });
+});

--- a/app/settings/preferences/components/settings-page-shell.tsx
+++ b/app/settings/preferences/components/settings-page-shell.tsx
@@ -14,10 +14,23 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
-import AccountSection from "./account-section";
-import NotificationsSection from "./notifications-section";
-import SecurityTab from "./security-tab";
-import WalletsSection from "./wallets-section";
+import { DEMO_WALLETS } from "@/lib/demo-data";
+import AccountSection, {
+  INITIAL_PROFILE_STATE,
+  ProfileState,
+} from "./account-section";
+import NotificationsSection, {
+  INITIAL_NOTIFICATION_SETTINGS,
+  NotificationSettingsState,
+} from "./notifications-section";
+import SecurityTab, {
+  INITIAL_SECURITY_SUMMARY,
+  SecuritySummaryState,
+} from "./security-tab";
+import WalletsSection, {
+  INITIAL_WALLET_SETTINGS,
+  WalletSettingsState,
+} from "./wallets-section";
 
 const sections: SettingsHeaderSection[] = [
   {
@@ -61,6 +74,15 @@ export default function SettingsPageShell({
     ? initialSection!
     : "account";
   const [activeSection, setActiveSection] = useState(resolvedInitialSection);
+  const [profileSummary, setProfileSummary] =
+    useState<ProfileState>(INITIAL_PROFILE_STATE);
+  const [notificationSummary, setNotificationSummary] =
+    useState<NotificationSettingsState>(INITIAL_NOTIFICATION_SETTINGS);
+  const [securitySummary, setSecuritySummary] =
+    useState<SecuritySummaryState>(INITIAL_SECURITY_SUMMARY);
+  const [walletSummary, setWalletSummary] = useState<WalletSettingsState>(
+    INITIAL_WALLET_SETTINGS,
+  );
 
   const handleSectionChange = (nextSection: string) => {
     setActiveSection(nextSection);
@@ -68,6 +90,47 @@ export default function SettingsPageShell({
       scroll: false,
     });
   };
+
+  const profileFieldCount = Object.values(profileSummary).filter(
+    (value) => value.trim().length > 0,
+  ).length;
+  const profileTotalFields = Object.keys(profileSummary).length;
+  const profileValue =
+    profileFieldCount === profileTotalFields
+      ? "Complete"
+      : `${profileFieldCount}/${profileTotalFields} ready`;
+  const notificationActiveCount =
+    countEnabledSettings(notificationSummary);
+  const securityActiveCount = countEnabledSettings(securitySummary);
+  const walletSafeguardCount = countEnabledSettings(walletSummary);
+  const walletCount = DEMO_WALLETS.length;
+  const walletCountLabel = formatCount(walletCount, "linked");
+
+  const dynamicSections: SettingsHeaderSection[] = sections.map((section) => {
+    if (section.value === "account") {
+      return { ...section, badge: profileValue };
+    }
+
+    if (section.value === "notifications") {
+      return {
+        ...section,
+        badge: formatCount(notificationActiveCount, "active"),
+      };
+    }
+
+    if (section.value === "security") {
+      return {
+        ...section,
+        badge: formatCount(securityActiveCount, "active"),
+      };
+    }
+
+    if (section.value === "wallets") {
+      return { ...section, badge: walletCountLabel };
+    }
+
+    return section;
+  });
 
   return (
     <Tabs
@@ -78,7 +141,7 @@ export default function SettingsPageShell({
       <SettingsHeader
         pageTitle="Settings that stay easy to scan"
         pageDescription="Grouped sections keep high-frequency work within a couple of taps, while advanced and destructive actions stay clearly separated."
-        sections={sections}
+        sections={dynamicSections}
         activeSection={activeSection}
       />
 
@@ -87,47 +150,55 @@ export default function SettingsPageShell({
           <SummaryCard
             icon={UserRound}
             label="Profile readiness"
-            value="Complete"
+            value={profileValue}
             description="Identity, locale, and billing defaults are grouped together."
           />
           <SummaryCard
             icon={Bell}
             label="Alerts enabled"
-            value="5 active"
+            value={formatCount(notificationActiveCount, "active")}
             description="Critical alerts remain above lower-priority updates."
           />
           <SummaryCard
             icon={Shield}
             label="Security posture"
-            value="2-step on"
+            value={formatCount(securityActiveCount, "active")}
             description="Password, verification, and session controls share one section."
           />
           <SummaryCard
             icon={Wallet}
             label="Wallet coverage"
-            value="2 linked"
-            description="Connected wallets sit next to transfer safeguards."
+            value={walletCountLabel}
+            description={`${formatCount(walletSafeguardCount, "safeguard")} active beside connected wallets.`}
           />
         </section>
 
         <TabsContent value="account" className="mt-0">
-          <AccountSection />
+          <AccountSection onSummaryChange={setProfileSummary} />
         </TabsContent>
 
         <TabsContent value="notifications" className="mt-0">
-          <NotificationsSection />
+          <NotificationsSection onSummaryChange={setNotificationSummary} />
         </TabsContent>
 
         <TabsContent value="security" className="mt-0">
-          <SecurityTab />
+          <SecurityTab onSummaryChange={setSecuritySummary} />
         </TabsContent>
 
         <TabsContent value="wallets" className="mt-0">
-          <WalletsSection />
+          <WalletsSection onSummaryChange={setWalletSummary} />
         </TabsContent>
       </div>
     </Tabs>
   );
+}
+
+function countEnabledSettings(settings: object) {
+  return Object.values(settings).filter(Boolean).length;
+}
+
+function formatCount(count: number, label: string) {
+  return `${count} ${label}`;
 }
 
 function SummaryCard({

--- a/app/settings/preferences/components/wallets-section.tsx
+++ b/app/settings/preferences/components/wallets-section.tsx
@@ -17,7 +17,7 @@ import { Loader2 } from "lucide-react";
 
 const connectedWallets = DEMO_WALLETS;
 
-interface WalletSettingsState {
+export interface WalletSettingsState {
   transferApprovals: boolean;
   addressBookLock: boolean;
   travelRuleChecks: boolean;
@@ -28,25 +28,39 @@ interface StatusState {
   type: "success" | "error" | null;
 }
 
+export const INITIAL_WALLET_SETTINGS: WalletSettingsState = {
+  transferApprovals: true,
+  addressBookLock: true,
+  travelRuleChecks: true,
+};
+
+interface WalletsSectionProps {
+  onSummaryChange?: (settings: WalletSettingsState) => void;
+}
+
 /**
  * WalletsSection component.
  * Renders connected wallet configurations, region settings, and outbound transfer safeguards.
  * Uses placeholder demo data pending full backend API integration.
  */
-export default function WalletsSection() {
-  const [settings, setSettings] = useState<WalletSettingsState>({
-    transferApprovals: true,
-    addressBookLock: true,
-    travelRuleChecks: true,
-  });
+export default function WalletsSection({
+  onSummaryChange,
+}: WalletsSectionProps = {}) {
+  const [settings, setSettings] = useState<WalletSettingsState>(
+    INITIAL_WALLET_SETTINGS,
+  );
   const [status, setStatus] = useState<StatusState>({ message: "", type: null });
   const [isSaving, setIsSaving] = useState(false);
 
   const updateSetting = (field: keyof WalletSettingsState, value: boolean) => {
-    setSettings((currentSettings) => ({
-      ...currentSettings,
-      [field]: value,
-    }));
+    setSettings((currentSettings) => {
+      const nextSettings = {
+        ...currentSettings,
+        [field]: value,
+      };
+      onSummaryChange?.(nextSettings);
+      return nextSettings;
+    });
   };
 
   const handleSave = async () => {


### PR DESCRIPTION
Closes #324

## Summary
- derive the settings summary cards from the account, notification, security, and wallet section state instead of hardcoded labels
- update section badges from the same summary counts, including wallet count from the demo wallet data source
- add optional summary callbacks to section components so edits and toggle changes refresh the shell summary without changing standalone section behavior

## Validation
- `node node_modules/vitest/vitest.mjs run app/settings/preferences/components/settings-page-shell.test.tsx`
- `git diff --check`
- `node node_modules/typescript/bin/tsc --noEmit --pretty false` still fails on the existing `vitest.config.ts(10,5)` type mismatch (`false` is not assignable...), with no new settings-page errors after the test typing fix