### PR TITLE
feat(app): add root error boundary by huazhuang80-star

### DIFF
--- a/app/error.test.tsx
+++ b/app/error.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import RootError from "./error";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeError() {
+  const error = new Error("database connection leaked");
+  return Object.assign(error, {
+    digest: "route-digest-123",
+    stack: "secret stack trace",
+  });
+}
+
+describe("RootError", () => {
+  it("renders an accessible route error boundary", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(<RootError error={makeError()} reset={vi.fn()} />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /we could not load this page/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /go to dashboard/i }),
+    ).toHaveAttribute("href", "/dashboard");
+  });
+
+  it("calls reset when the retry button is clicked", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const reset = vi.fn();
+
+    render(<RootError error={makeError()} reset={reset} />);
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs only the digest and does not render raw error details", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(<RootError error={makeError()} reset={vi.fn()} />);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "Route error digest:",
+      "route-digest-123",
+    );
+    expect(screen.queryByText(/database connection leaked/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/secret stack trace/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+
+import { Button } from "@/components/ui/button";
+
+interface RootErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * App Router segment error boundary for recoverable route failures.
+ *
+ * Security: user-facing copy stays generic so runtime messages, stack traces,
+ * and internal paths are not exposed in production.
+ */
+export default function RootError({ error, reset }: RootErrorProps) {
+  useEffect(() => {
+    if (error.digest) {
+      console.error("Route error digest:", error.digest);
+    }
+  }, [error.digest]);
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <section
+        role="alert"
+        aria-labelledby="root-error-title"
+        className="mx-auto flex min-h-screen w-full max-w-3xl flex-col items-center justify-center px-6 py-20 text-center"
+      >
+        <p className="mb-4 text-sm font-medium text-destructive">
+          Something went wrong
+        </p>
+        <h1
+          id="root-error-title"
+          className="text-4xl font-semibold text-foreground sm:text-5xl"
+        >
+          We could not load this page
+        </h1>
+        <p className="mt-5 max-w-xl text-base leading-7 text-muted-foreground sm:text-lg">
+          Try again from here, or continue from your dashboard while we recover
+          the route.
+        </p>
+        <div className="mt-8 flex w-full flex-col items-center justify-center gap-3 sm:w-auto sm:flex-row">
+          <Button
+            type="button"
+            size="lg"
+            onClick={reset}
+            className="w-full sm:w-auto"
+          >
+            Try again
+          </Button>
+          <Button
+            asChild
+            size="lg"
+            variant="outline"
+            className="w-full sm:w-auto"
+          >
+            <Link href="/dashboard">Go to dashboard</Link>
+          </Button>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
Closes #280

## Summary
- add a client `app/error.tsx` route error boundary with an accessible alert region
- wire the Next.js `reset()` callback to a Try again button and provide a dashboard escape hatch
- keep rendered copy generic while logging only `error.digest`
- add RTL coverage for rendering, retry, digest logging, and non-disclosure of raw error details

## Validation
- `node node_modules/vitest/vitest.mjs run app/error.test.tsx`
- `git diff --check`
- `node node_modules/typescript/bin/tsc --noEmit --pretty false` still fails on the existing `vitest.config.ts(10,5)` type mismatch (`false` is not assignable...)

## Security notes
- Does not render `error.message` or `error.stack` to users.
- Logs only the digest value intended for future observability correlation.