### PR TITLE
feat(settings): persist notification preferences by huazhuang80-star

### DIFF
--- a/app/settings/preferences/components/notifications-section.test.tsx
+++ b/app/settings/preferences/components/notifications-section.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import NotificationsSection from "./notifications-section";
+import {
+  DEFAULT_NOTIFICATION_PREFS,
+  getNotificationPrefs,
+  saveNotificationPrefs,
+} from "@/lib/api/notification-preferences";
+
+vi.mock("@/lib/api/notification-preferences", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/api/notification-preferences")
+  >("@/lib/api/notification-preferences");
+
+  return {
+    ...actual,
+    getNotificationPrefs: vi.fn(),
+    saveNotificationPrefs: vi.fn(),
+  };
+});
+
+const mockedGetNotificationPrefs = vi.mocked(getNotificationPrefs);
+const mockedSaveNotificationPrefs = vi.mocked(saveNotificationPrefs);
+
+describe("NotificationsSection", () => {
+  beforeEach(() => {
+    mockedGetNotificationPrefs.mockResolvedValue(DEFAULT_NOTIFICATION_PREFS);
+    mockedSaveNotificationPrefs.mockResolvedValue({
+      ...DEFAULT_NOTIFICATION_PREFS,
+      marketing: true,
+    });
+  });
+
+  it("disables save until preferences are changed, then persists the draft", async () => {
+    render(<NotificationsSection />);
+
+    const saveButton = await screen.findByRole("button", { name: "Saved" });
+    expect(saveButton).toBeDisabled();
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Marketing and announcements" }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Save notification settings" }),
+    ).toBeEnabled();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save notification settings" }),
+    );
+
+    await waitFor(() =>
+      expect(mockedSaveNotificationPrefs).toHaveBeenCalledWith({
+        ...DEFAULT_NOTIFICATION_PREFS,
+        marketing: true,
+      }),
+    );
+    expect(
+      await screen.findByText("Notification preferences saved."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Saved" })).toBeDisabled();
+  });
+
+  it("reverts optimistic changes when save fails", async () => {
+    mockedSaveNotificationPrefs.mockRejectedValueOnce(new Error("failed"));
+
+    render(<NotificationsSection />);
+
+    await screen.findByRole("button", { name: "Saved" });
+    const marketingSwitch = screen.getByRole("switch", {
+      name: "Marketing and announcements",
+    });
+
+    fireEvent.click(marketingSwitch);
+    expect(marketingSwitch).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save notification settings" }),
+    );
+
+    expect(
+      await screen.findByText(/previous preferences were restored/i),
+    ).toBeInTheDocument();
+    expect(marketingSwitch).toHaveAttribute("aria-checked", "false");
+  });
+});

--- a/app/settings/preferences/components/notifications-section.tsx
+++ b/app/settings/preferences/components/notifications-section.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import ToggleCard from "@/components/common/toggle-card";
 import { Button } from "@/components/ui/button";
-import { FormMessage } from "@/components/ui/form";
 import {
   Card,
   CardContent,
@@ -11,37 +10,102 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-
-interface NotificationSettingsState {
-  transactionAlerts: boolean;
-  securityAlerts: boolean;
-  productUpdates: boolean;
-  marketing: boolean;
-  emailChannel: boolean;
-  pushChannel: boolean;
-  smsChannel: boolean;
-}
+import {
+  DEFAULT_NOTIFICATION_PREFS,
+  getNotificationPrefs,
+  NotificationPreferences,
+  saveNotificationPrefs,
+} from "@/lib/api/notification-preferences";
 
 export default function NotificationsSection() {
-  const [settings, setSettings] = useState<NotificationSettingsState>({
-    transactionAlerts: true,
-    securityAlerts: true,
-    productUpdates: true,
-    marketing: false,
-    emailChannel: true,
-    pushChannel: true,
-    smsChannel: false,
-  });
-  const [statusMessage, setStatusMessage] = useState("");
+  const [settings, setSettings] = useState<NotificationPreferences>(
+    DEFAULT_NOTIFICATION_PREFS,
+  );
+  const [savedSettings, setSavedSettings] = useState<NotificationPreferences>(
+    DEFAULT_NOTIFICATION_PREFS,
+  );
+  const [status, setStatus] = useState<{
+    message: string;
+    type: "success" | "error" | null;
+  }>({ message: "", type: null });
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    getNotificationPrefs()
+      .then((preferences) => {
+        if (!isMounted) return;
+        setSettings(preferences);
+        setSavedSettings(preferences);
+        setStatus({ message: "", type: null });
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        setStatus({
+          message:
+            "Notification preferences could not be loaded. Defaults are shown.",
+          type: "error",
+        });
+      })
+      .finally(() => {
+        if (isMounted) setIsLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const hasPendingChanges = useMemo(
+    () => JSON.stringify(settings) !== JSON.stringify(savedSettings),
+    [settings, savedSettings],
+  );
 
   const updateSetting = (
-    field: keyof NotificationSettingsState,
+    field: keyof NotificationPreferences,
     value: boolean,
   ) => {
     setSettings((currentSettings) => ({
       ...currentSettings,
       [field]: value,
     }));
+    setStatus({ message: "", type: null });
+  };
+
+  const handleSave = async () => {
+    if (!hasPendingChanges || isSaving) return;
+
+    const previousSettings = savedSettings;
+    const nextSettings = settings;
+
+    setIsSaving(true);
+    setSavedSettings(nextSettings);
+    setStatus({
+      message: "Saving notification preferences...",
+      type: null,
+    });
+
+    try {
+      const persistedSettings = await saveNotificationPrefs(nextSettings);
+      setSettings(persistedSettings);
+      setSavedSettings(persistedSettings);
+      setStatus({
+        message: "Notification preferences saved.",
+        type: "success",
+      });
+    } catch {
+      setSettings(previousSettings);
+      setSavedSettings(previousSettings);
+      setStatus({
+        message:
+          "Notification preferences could not be saved. Previous preferences were restored.",
+        type: "error",
+      });
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (
@@ -140,19 +204,41 @@ export default function NotificationsSection() {
             </p>
           </div>
           <Button
-            onClick={() =>
-              setStatusMessage(
-                "Notification preferences updated. Critical alerts remain prioritized.",
-              )
-            }
+            onClick={handleSave}
+            disabled={!hasPendingChanges || isLoading || isSaving}
           >
-            Save notification settings
+            {isSaving
+              ? "Saving..."
+              : hasPendingChanges
+                ? "Save notification settings"
+                : "Saved"}
           </Button>
-          {statusMessage ? (
-            <div className="rounded-2xl border border-success/20 bg-success/10 px-4 py-3">
-              <FormMessage variant="success" className="text-success">
-                {statusMessage}
-              </FormMessage>
+          <div role="status" aria-live="polite">
+            {status.message ? (
+              <div
+                className={`rounded-2xl border px-4 py-3 ${
+                  status.type === "error"
+                    ? "border-destructive/20 bg-destructive/10"
+                    : "border-success/20 bg-success/10"
+                }`}
+              >
+                <p
+                  className={
+                    status.type === "error"
+                      ? "text-destructive"
+                      : "text-success"
+                  }
+                >
+                  {status.message}
+                </p>
+              </div>
+            ) : null}
+          </div>
+          {isLoading ? (
+            <div className="rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-white/10 dark:bg-white/5">
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                Loading notification preferences...
+              </p>
             </div>
           ) : null}
         </CardContent>

--- a/lib/api/notification-preferences.ts
+++ b/lib/api/notification-preferences.ts
@@ -1,0 +1,130 @@
+export interface NotificationPreferences {
+  transactionAlerts: boolean;
+  securityAlerts: boolean;
+  productUpdates: boolean;
+  marketing: boolean;
+  emailChannel: boolean;
+  pushChannel: boolean;
+  smsChannel: boolean;
+}
+
+export const DEFAULT_NOTIFICATION_PREFS: NotificationPreferences = {
+  transactionAlerts: true,
+  securityAlerts: true,
+  productUpdates: true,
+  marketing: false,
+  emailChannel: true,
+  pushChannel: true,
+  smsChannel: false,
+};
+
+const STORAGE_KEY = "stellopay-notification-preferences";
+const FAIL_NEXT_SAVE_KEY = "stellopay-notification-preferences-fail-next-save";
+
+/**
+ * Reads notification preferences from the current mock data source.
+ *
+ * The localStorage-backed branch keeps the UI functional while the backend API
+ * is not wired yet. When `NEXT_PUBLIC_API_BASE_URL` is present, this becomes a
+ * fetch-ready adapter without changing component state logic.
+ */
+export async function getNotificationPrefs(): Promise<NotificationPreferences> {
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  if (apiBaseUrl) {
+    const response = await fetch(`${apiBaseUrl}/notification-preferences`, {
+      credentials: "include",
+    });
+
+    if (!response.ok) {
+      throw new Error("Unable to load notification preferences");
+    }
+
+    return validateNotificationPrefs(await response.json());
+  }
+
+  return readStoredPrefs();
+}
+
+/**
+ * Persists notification preferences through the current data source.
+ */
+export async function saveNotificationPrefs(
+  preferences: NotificationPreferences,
+): Promise<NotificationPreferences> {
+  const validatedPreferences = validateNotificationPrefs(preferences);
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  if (apiBaseUrl) {
+    const response = await fetch(`${apiBaseUrl}/notification-preferences`, {
+      method: "PUT",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(validatedPreferences),
+    });
+
+    if (!response.ok) {
+      throw new Error("Unable to save notification preferences");
+    }
+
+    return validateNotificationPrefs(await response.json());
+  }
+
+  if (shouldFailNextMockSave()) {
+    throw new Error("Unable to save notification preferences");
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(validatedPreferences));
+  return validatedPreferences;
+}
+
+function readStoredPrefs() {
+  if (typeof window === "undefined") {
+    return DEFAULT_NOTIFICATION_PREFS;
+  }
+
+  const storedValue = window.localStorage.getItem(STORAGE_KEY);
+  if (!storedValue) {
+    return DEFAULT_NOTIFICATION_PREFS;
+  }
+
+  try {
+    return validateNotificationPrefs(JSON.parse(storedValue));
+  } catch {
+    return DEFAULT_NOTIFICATION_PREFS;
+  }
+}
+
+function shouldFailNextMockSave() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const shouldFail =
+    window.localStorage.getItem(FAIL_NEXT_SAVE_KEY) === "true";
+  if (shouldFail) {
+    window.localStorage.removeItem(FAIL_NEXT_SAVE_KEY);
+  }
+  return shouldFail;
+}
+
+function validateNotificationPrefs(
+  value: unknown,
+): NotificationPreferences {
+  if (!value || typeof value !== "object") {
+    return DEFAULT_NOTIFICATION_PREFS;
+  }
+
+  const candidate = value as Record<keyof NotificationPreferences, unknown>;
+  return {
+    transactionAlerts: candidate.transactionAlerts === true,
+    securityAlerts: candidate.securityAlerts === true,
+    productUpdates: candidate.productUpdates === true,
+    marketing: candidate.marketing === true,
+    emailChannel: candidate.emailChannel === true,
+    pushChannel: candidate.pushChannel === true,
+    smsChannel: candidate.smsChannel === true,
+  };
+}

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -21,6 +21,20 @@ test("desktop settings navigation and destructive confirmation stay clear", asyn
 
   await page.getByRole("tab", { name: /notifications/i }).click();
   await expect(page.getByText("Notification priorities")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Saved" }),
+  ).toBeDisabled();
+
+  await page
+    .getByRole("switch", { name: "Marketing and announcements" })
+    .click();
+  await expect(
+    page.getByRole("button", { name: "Save notification settings" }),
+  ).toBeEnabled();
+  await page
+    .getByRole("button", { name: "Save notification settings" })
+    .click();
+  await expect(page.getByText("Notification preferences saved.")).toBeVisible();
 
   await page.getByRole("tab", { name: /wallets/i }).click();
   await expect(


### PR DESCRIPTION
Closes #293

## Summary
- add a fetch-ready notification preferences data adapter with mock localStorage persistence while the backend is pending
- seed the notifications section from `getNotificationPrefs()` and track dirty state against the saved snapshot
- implement optimistic save, disabled no-op save state, aria-live status updates, and revert-on-error behavior
- replace standalone `FormMessage` usage with safe status copy outside react-hook-form context
- extend settings e2e coverage for the successful save path and add RTL coverage for save + error revert

## Validation
- `node node_modules/vitest/vitest.mjs run app/settings/preferences/components/notifications-section.test.tsx`
- `git diff --check`
- `node node_modules/typescript/bin/tsc --noEmit --pretty false` still fails on the existing `vitest.config.ts(10,5)` type mismatch (`false` is not assignable...)

## Notes
- Local Playwright execution remains blocked in this Windows shell by the existing config webServer path using `npx` (`npx` is not recognized here), but `tests/settings.spec.ts` was extended for the save flow.
- Notification prefs are non-sensitive; no full preference payload is logged.