### PR TITLE
perf(analytics): dynamically load recharts chart by huazhuang80-star

### DIFF
--- a/components/analytics/analytics-bar-chart.tsx
+++ b/components/analytics/analytics-bar-chart.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { formatChartValue } from "@/utils/formatUtils";
+import type { AnalyticsDataPoint } from "./analytics-view";
+
+interface AnalyticsBarChartProps {
+  data: AnalyticsDataPoint[];
+  showNotifications: boolean;
+}
+
+interface TooltipPayloadItem {
+  value: number;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+  label?: string;
+}
+
+function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
+  if (active && payload && payload.length) {
+    return (
+      <div className="bg-white text-black p-2 rounded shadow text-sm border border-zinc-200">
+        <p className="font-semibold">{label}</p>
+        <p>{payload[0].value.toLocaleString()} views</p>
+      </div>
+    );
+  }
+  return null;
+}
+
+/**
+ * Recharts-only chart body kept behind a dynamic import boundary so the chart
+ * library does not ride along with the analytics shell's initial client chunk.
+ */
+export default function AnalyticsBarChart({
+  data,
+  showNotifications,
+}: AnalyticsBarChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data}>
+        <CartesianGrid
+          strokeDasharray="3 3"
+          vertical={false}
+          stroke={showNotifications ? "currentColor" : "#1f1b2e"}
+          className={showNotifications ? "text-zinc-200 dark:text-zinc-800" : ""}
+        />
+        <XAxis
+          dataKey="month"
+          tick={{ fill: "#aaa", fontSize: 10 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          tick={{ fill: "#aaa", fontSize: 10 }}
+          tickFormatter={formatChartValue}
+          tickLine={false}
+          axisLine={false}
+        />
+        <Tooltip content={<CustomTooltip />} />
+        <Bar
+          dataKey="views"
+          fill={showNotifications ? "#3b82f6" : "#2E2E2E"}
+          radius={[4, 4, 0, 0]}
+          barSize={showNotifications ? 20 : 28}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/components/analytics/analytics-view.test.tsx
+++ b/components/analytics/analytics-view.test.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
-import AnalyticsViews, { AnalyticsDataPoint } from "./analytics-view";
+import AnalyticsViews, {
+  AnalyticsChartSkeleton,
+  AnalyticsDataPoint,
+} from "./analytics-view";
 import ClientAnalyticsView from "./client-analytics-view";
 
 // Mock recharts
@@ -78,38 +81,44 @@ describe("AnalyticsViews Component", () => {
     expect(screen.getByText("Loading analytics...")).toBeInTheDocument();
   });
 
-  it("renders chart with default data when data prop is not provided", () => {
+  it("renders chart with default data when data prop is not provided", async () => {
     render(<AnalyticsViews />);
     expect(screen.getByText("Analytics views")).toBeInTheDocument();
-    const barChart = screen.getByTestId("bar-chart");
+    const barChart = await screen.findByTestId("bar-chart");
     expect(barChart).toBeInTheDocument();
     const parsedData = JSON.parse(barChart.getAttribute("data-data") || "[]");
     expect(parsedData.length).toBe(12);
     expect(parsedData[0]).toEqual({ month: "Jan", views: 24000 });
   });
 
-  it("renders chart with custom populated data", () => {
+  it("renders chart with custom populated data", async () => {
     const customData: AnalyticsDataPoint[] = [
       { month: "Jan", views: 100 },
       { month: "Feb", views: 200 },
     ];
     render(<AnalyticsViews data={customData} />);
-    const barChart = screen.getByTestId("bar-chart");
+    const barChart = await screen.findByTestId("bar-chart");
     const parsedData = JSON.parse(barChart.getAttribute("data-data") || "[]");
     expect(parsedData).toEqual(customData);
   });
 
-  it("renders chart with empty data", () => {
+  it("renders chart with empty data", async () => {
     render(<AnalyticsViews data={[]} />);
-    const barChart = screen.getByTestId("bar-chart");
+    const barChart = await screen.findByTestId("bar-chart");
     const parsedData = JSON.parse(barChart.getAttribute("data-data") || "[]");
     expect(parsedData).toEqual([]);
   });
 
-  it("renders CustomTooltip content correctly inside Tooltip mock", () => {
+  it("renders CustomTooltip content correctly inside Tooltip mock", async () => {
     render(<AnalyticsViews />);
-    expect(screen.getByText("TestMonth")).toBeInTheDocument();
+    expect(await screen.findByText("TestMonth")).toBeInTheDocument();
     expect(screen.getByText("999 views")).toBeInTheDocument();
+  });
+
+  it("renders a chart skeleton for the dynamic Recharts chunk", () => {
+    render(<AnalyticsChartSkeleton />);
+    expect(screen.getByText("Loading analytics chart...")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true");
   });
 
   it("handles year selector dropdown interactions", () => {

--- a/components/analytics/analytics-view.tsx
+++ b/components/analytics/analytics-view.tsx
@@ -2,19 +2,10 @@
 
 import React, { useState } from "react";
 import Image from "next/image";
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  CartesianGrid,
-} from "recharts";
+import dynamic from "next/dynamic";
 import { ChevronDown, ChevronUp, ChevronRight } from "lucide-react";
 
 import chart from "@/public/chart-up.png";
-import { formatChartValue } from "@/utils/formatUtils";
 import { Skeleton } from "@/components/ui/skeleton";
 import PaymentHistory from "@/components/dashboard/payment-history";
 
@@ -26,39 +17,10 @@ export interface AnalyticsDataPoint {
   views: number;
 }
 
-/**
- * Interface representing a item payload inside the custom tooltip.
- */
-interface TooltipPayloadItem {
-  value: number;
-}
-
-/**
- * Props for the custom tooltip component.
- */
-interface CustomTooltipProps {
-  active?: boolean;
-  payload?: TooltipPayloadItem[];
-  label?: string;
-}
-
-/**
- * A custom tooltip component rendered when hovering over the chart bars.
- * 
- * @param props - CustomTooltipProps containing payload data.
- * @returns A JSX element rendering the tooltip contents, or null.
- */
-const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
-  if (active && payload && payload.length) {
-    return (
-      <div className="bg-white text-black p-2 rounded shadow text-sm border border-zinc-200">
-        <p className="font-semibold">{label}</p>
-        <p>{payload[0].value.toLocaleString()} views</p>
-      </div>
-    );
-  }
-  return null;
-};
+const AnalyticsBarChart = dynamic(() => import("./analytics-bar-chart"), {
+  ssr: false,
+  loading: () => <AnalyticsChartSkeleton />,
+});
 
 /**
  * Props accepted by the canonical AnalyticsViews component.
@@ -247,35 +209,10 @@ const AnalyticsViews = ({
         </div>
 
         <div className={showNotifications ? "w-full h-56 mt-4 border border-zinc-100 dark:border-zinc-800/50 p-6 rounded-xl bg-zinc-50/30 dark:bg-zinc-900/20" : "w-full h-full aspect-[3/1] rounded-lg border border-[#2D2D2D] p-2 sm:p-4"}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={chartData}>
-              <CartesianGrid
-                strokeDasharray="3 3"
-                vertical={false}
-                stroke={showNotifications ? "currentColor" : "#1f1b2e"}
-                className={showNotifications ? "text-zinc-200 dark:text-zinc-800" : ""}
-              />
-              <XAxis
-                dataKey="month"
-                tick={{ fill: "#aaa", fontSize: 10 }}
-                tickLine={false}
-                axisLine={false}
-              />
-              <YAxis
-                tick={{ fill: "#aaa", fontSize: 10 }}
-                tickFormatter={formatChartValue}
-                tickLine={false}
-                axisLine={false}
-              />
-              <Tooltip content={<CustomTooltip />} />
-              <Bar
-                dataKey="views"
-                fill={showNotifications ? "#3b82f6" : "#2E2E2E"}
-                radius={[4, 4, 0, 0]}
-                barSize={showNotifications ? 20 : 28}
-              />
-            </BarChart>
-          </ResponsiveContainer>
+          <AnalyticsBarChart
+            data={chartData}
+            showNotifications={showNotifications}
+          />
         </div>
       </div>
 
@@ -313,4 +250,25 @@ const AnalyticsViews = ({
 };
 
 export default AnalyticsViews;
+
+export function AnalyticsChartSkeleton() {
+  return (
+    <div
+      className="h-full flex items-end gap-2"
+      aria-busy="true"
+      aria-live="polite"
+      role="status"
+    >
+      <span className="sr-only">Loading analytics chart...</span>
+      {Array.from({ length: 12 }).map((_, i) => (
+        <Skeleton
+          key={i}
+          className="flex-1"
+          shade="dark"
+          style={{ height: `${20 + (i % 4) * 15}%` }}
+        />
+      ))}
+    </div>
+  );
+}
 


### PR DESCRIPTION
Closes #300

## Summary
- move the Recharts-only bar chart body into `analytics-bar-chart.tsx`
- dynamically import that chart with `next/dynamic` and `ssr: false`
- keep the analytics shell, headings, filters, and notification sidebar outside the chart chunk
- add an accessible chart skeleton fallback for the dynamic chunk
- update analytics RTL coverage to await the dynamically loaded chart and assert the fallback skeleton

## Validation
- `node node_modules/vitest/vitest.mjs run components/analytics/analytics-view.test.tsx`
- `git diff --check`
- `rg 'from "recharts"|from ''recharts''' components/analytics components/dashboard -g '*.tsx'` returns no static Recharts import outside the new chart chunk
- `node node_modules/next/dist/bin/next build` compiles successfully, then fails during type checking on the existing `vitest.config.ts(10,5)` mismatch (`false` is not assignable...)

## Notes
- The chart remains client-only, so no server-only data is exposed through the dynamic Recharts boundary.