### PR TITLE
fix(account-summary): use wallet context address instead of hardcoded literal

### DIFF
--- a/app/account-summary/page.test.tsx
+++ b/app/account-summary/page.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import React from "react";
+
+import Page from "./page";
+import { WalletProvider } from "@/context/wallet-context";
+
+// copyToClipboardWithTimeout is a side-effectful utility; stub it so tests
+// don't touch the clipboard API.
+vi.mock("@/utils/clipboardUtils", () => ({
+  copyToClipboardWithTimeout: vi.fn(),
+}));
+
+// next/image requires a DOM environment that jsdom approximates well enough,
+// but it emits warnings about the host config. Silence those for tests.
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img {...props} alt={props.alt ?? ""} />
+  ),
+}));
+
+const PUBLIC_ADDRESS = "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPF123";
+
+function renderWithWallet(initialAddress: string | null) {
+  return render(
+    <WalletProvider initialAddress={initialAddress}>
+      <Page />
+    </WalletProvider>,
+  );
+}
+
+describe("AccountSummaryPage — connected wallet", () => {
+  it("shows the truncated Stellar address", () => {
+    renderWithWallet(PUBLIC_ADDRESS);
+    // formatAddress produces "GABC...F123" for a 56-char address
+    expect(screen.getByText("GABC...F123")).toBeInTheDocument();
+  });
+
+  it("shows the copy affordance when connected", () => {
+    renderWithWallet(PUBLIC_ADDRESS);
+    expect(screen.getByText("Copy Address:")).toBeInTheDocument();
+  });
+
+  it("does not show the no-wallet message when connected", () => {
+    renderWithWallet(PUBLIC_ADDRESS);
+    expect(screen.queryByTestId("no-wallet-message")).not.toBeInTheDocument();
+  });
+});
+
+describe("AccountSummaryPage — disconnected wallet", () => {
+  it("shows the no-wallet message", () => {
+    renderWithWallet(null);
+    expect(screen.getByTestId("no-wallet-message")).toHaveTextContent(
+      "No wallet connected",
+    );
+  });
+
+  it("does not show the copy affordance when disconnected", () => {
+    renderWithWallet(null);
+    expect(screen.queryByText("Copy Address:")).not.toBeInTheDocument();
+  });
+});

--- a/app/account-summary/page.tsx
+++ b/app/account-summary/page.tsx
@@ -6,14 +6,19 @@ import Image from "next/image";
 import Icon from "@/public/Icon.png";
 import Piggy from "@/public/piggy-bank.png";
 import { copyToClipboardWithTimeout } from "@/utils/clipboardUtils";
+import { useWallet, formatAddress } from "@/context/wallet-context";
 
-
+/**
+ * Renders the account summary card, sourcing the wallet address from the
+ * WalletProvider context. Shows a "no wallet connected" message when the
+ * user is disconnected. Only the truncated public address is ever displayed.
+ */
 function AccountSummaryView({ isLoading: _isLoading = false }: { isLoading?: boolean }) {
   const [copied, setCopied] = useState(false);
-  const address = "0x8dE1243U45...67800UZ";
+  const { address, isConnected } = useWallet();
 
   const handleCopy = () => {
-    copyToClipboardWithTimeout(address, setCopied);
+    if (address) copyToClipboardWithTimeout(address, setCopied);
   };
 
   return (
@@ -34,10 +39,16 @@ function AccountSummaryView({ isLoading: _isLoading = false }: { isLoading?: boo
             $2,432 <span className="text-base">USDC</span>
           </div>
           <div className="flex items-center text-xs text-gray-400 space-x-2">
-            <span>Copy Address:</span>
-            <span className="truncate text-white">{address}</span>
-            <Copy size={14} className="cursor-pointer" onClick={handleCopy} />
-            {copied && <span className="text-green-400 ml-2">Copied!</span>}
+            {isConnected ? (
+              <>
+                <span>Copy Address:</span>
+                <span className="truncate text-white">{formatAddress(address)}</span>
+                <Copy size={14} className="cursor-pointer" onClick={handleCopy} />
+                {copied && <span className="text-green-400 ml-2">Copied!</span>}
+              </>
+            ) : (
+              <span data-testid="no-wallet-message">No wallet connected</span>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

`app/account-summary/page.tsx` was hardcoding an EVM-style address literal (`"0x8dE1243U45...67800UZ"`) instead of reading the connected wallet from context. The account summary therefore showed the same fake address regardless of which wallet was connected.

## Changes

- **`app/account-summary/page.tsx`**: Import `useWallet` and `formatAddress` from `context/wallet-context`. Replace the hardcoded literal with `const { address, isConnected } = useWallet()`. Use `formatAddress(address)` for Stellar-format truncation (`GABC...F123`). Render a "No wallet connected" message when disconnected, and guard the copy handler so it only fires when an address is present. Added TSDoc comment.

- **`app/account-summary/page.test.tsx`** *(new)*: Vitest tests for connected wallet (truncated address displayed, copy affordance visible) and disconnected wallet (no-wallet message shown, copy affordance absent). Uses `WalletProvider`'s `initialAddress` prop — no mocking of the context module needed.

## Test output

```
✓ app/account-summary/page.test.tsx > AccountSummaryPage — connected wallet > shows the truncated Stellar address
✓ app/account-summary/page.test.tsx > AccountSummaryPage — connected wallet > shows the copy affordance when connected
✓ app/account-summary/page.test.tsx > AccountSummaryPage — connected wallet > does not show the no-wallet message when connected
✓ app/account-summary/page.test.tsx > AccountSummaryPage — disconnected wallet > shows the no-wallet message
✓ app/account-summary/page.test.tsx > AccountSummaryPage — disconnected wallet > does not show the copy affordance when disconnected

Tests  178 passed (178)
```

The pre-existing `app/metadata.test.ts` failure is a PostCSS config issue unrelated to this PR.

## Security notes

- Only the truncated public G-address is ever rendered. Private keys are rejected by `WalletProvider.connect()` before they reach any component.
- The full address is only written to the clipboard via `copyToClipboardWithTimeout`, never logged or displayed in full.

Closes #347