### PR TITLE
fix(a11y): label network switch dialog by huazhuang80-star

### DIFF
--- a/components/common/network-switcher.tsx
+++ b/components/common/network-switcher.tsx
@@ -87,6 +87,8 @@ export default function NetworkSwitcher({
   const [pendingNetwork, setPendingNetwork] = useState<Network | null>(null);
 
   const isDashboard = variant === "dashboard";
+  const dialogTitleId = "network-switcher-confirm-title";
+  const dialogDescriptionId = "network-switcher-confirm-description";
 
   const handleNetworkSelect = (network: Network) => {
     if (network.id === currentNetwork.id) return;
@@ -188,14 +190,26 @@ export default function NetworkSwitcher({
         <DialogContent
           className="bg-[#1A1A1A] border-[#242428] text-white max-w-sm"
           showCloseButton={false}
+          aria-labelledby={dialogTitleId}
+          aria-describedby={dialogDescriptionId}
         >
           <DialogHeader>
-            <DialogTitle className="text-white">Switch network?</DialogTitle>
-            <DialogDescription className="text-[#9CA3AF]">
+            <DialogTitle id={dialogTitleId} className="text-white">
+              Switch network?
+            </DialogTitle>
+            <DialogDescription
+              id={dialogDescriptionId}
+              className="text-[#9CA3AF]"
+            >
               You are switching from{" "}
-              <span className="font-semibold text-white">{currentNetwork.name}</span>{" "}
+              <strong className="font-semibold text-white">
+                {currentNetwork.name}
+              </strong>{" "}
               to{" "}
-              <span className="font-semibold text-white">{pendingNetwork?.name}</span>.
+              <strong className="font-semibold text-white">
+                {pendingNetwork?.name}
+              </strong>
+              .
               <br />
               <br />
               Your displayed balances and transaction history will reflect the

--- a/tests/network-switcher.spec.ts
+++ b/tests/network-switcher.spec.ts
@@ -94,6 +94,15 @@ test.describe("NetworkSwitcher — confirmation dialog", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog).toContainText("Stellar");
     await expect(dialog).toContainText("Polygon");
+    await expect(dialog).toHaveAttribute(
+      "aria-labelledby",
+      "network-switcher-confirm-title",
+    );
+    await expect(dialog).toHaveAttribute(
+      "aria-describedby",
+      "network-switcher-confirm-description",
+    );
+    await expect(dialog.locator("strong", { hasText: "Polygon" })).toBeVisible();
   });
 
   test("dialog warns about balance/transaction context change", async ({ page }) => {


### PR DESCRIPTION
Closes #343

## Summary
- add explicit `aria-labelledby` and `aria-describedby` wiring to the NetworkSwitcher confirmation dialog
- give the dialog title and body stable IDs
- semantically emphasize source and target network names with `<strong>` while keeping escaped text rendering
- extend the NetworkSwitcher Playwright spec to assert dialog labeling and target-network emphasis

## Validation
- `git diff --check`
- `node node_modules/typescript/bin/tsc --noEmit --pretty false` still fails on the existing `vitest.config.ts(10,5)` type mismatch (`false` is not assignable...)
- `node node_modules/@playwright/test/cli.js test tests/network-switcher.spec.ts --project=chromium --grep "dialog describes"` is blocked by the existing config webServer command using `npx` in this Windows shell (`npx` is not recognized)

## Security notes
- Network names are rendered as React text only; no HTML injection path is introduced.