### PR TITLE
fix(a11y): expose toggle card state by huazhuang80-star

### DIFF
--- a/components/common/toggle-card.test.tsx
+++ b/components/common/toggle-card.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ToggleCard from "./toggle-card";
+
+function renderControlledToggle(initialEnabled = false) {
+  const onToggle = vi.fn();
+  const view = render(
+    <ToggleCard
+      title="Security notifications"
+      description="Receive account protection alerts."
+      enabled={initialEnabled}
+      onToggle={onToggle}
+    />,
+  );
+
+  return { onToggle, ...view };
+}
+
+describe("ToggleCard", () => {
+  it("exposes matching switch and pressed states", () => {
+    renderControlledToggle(true);
+
+    const toggle = screen.getByRole("switch", {
+      name: "Security notifications is on. Turn off.",
+    });
+
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("requests the next state on click and keyboard activation", () => {
+    const { onToggle, rerender } = renderControlledToggle(false);
+
+    const toggle = screen.getByRole("switch", {
+      name: "Security notifications is off. Turn on.",
+    });
+    fireEvent.click(toggle);
+    expect(onToggle).toHaveBeenLastCalledWith(true);
+
+    rerender(
+      <ToggleCard
+        title="Security notifications"
+        enabled
+        onToggle={onToggle}
+      />,
+    );
+
+    const enabledToggle = screen.getByRole("switch", {
+      name: "Security notifications is on. Turn off.",
+    });
+    fireEvent.keyDown(enabledToggle, { key: " " });
+    fireEvent.keyUp(enabledToggle, { key: " " });
+    expect(onToggle).toHaveBeenLastCalledWith(false);
+
+    fireEvent.keyDown(enabledToggle, { key: "Enter" });
+    fireEvent.keyUp(enabledToggle, { key: "Enter" });
+    expect(onToggle).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/components/common/toggle-card.tsx
+++ b/components/common/toggle-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { KeyboardEvent } from "react";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/utils/commonUtils";
 import { ToggleCardProps } from "@/types/ui";
@@ -12,6 +13,15 @@ export default function ToggleCard({
   disabled = false,
   onToggle,
 }: ToggleCardProps) {
+  const nextState = enabled ? "off" : "on";
+  const currentState = enabled ? "on" : "off";
+  const toggle = () => onToggle(!enabled);
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== " " && event.key !== "Enter") return;
+    event.preventDefault();
+    toggle();
+  };
+
   return (
     <div className="flex items-center justify-between gap-4 rounded-2xl border border-zinc-200/80 bg-white p-4 text-zinc-900 shadow-sm transition-all dark:border-white/10 dark:bg-white/5 dark:text-white">
       <div className="space-y-1">
@@ -36,11 +46,13 @@ export default function ToggleCard({
         type="button"
         role="switch"
         aria-checked={enabled}
-        aria-label={title}
+        aria-pressed={enabled}
+        aria-label={`${title} is ${currentState}. Turn ${nextState}.`}
         disabled={disabled}
-        onClick={() => onToggle(!enabled)}
+        onClick={toggle}
+        onKeyDown={handleKeyDown}
         className={cn(
-          "flex h-8 w-14 items-center rounded-full p-1 duration-300 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-white dark:focus-visible:ring-offset-[#09090B]",
+          "flex h-8 w-14 items-center rounded-full p-1 duration-300 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:ring-offset-4 disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-white dark:focus-visible:ring-offset-[#09090B]",
           enabled
             ? "bg-zinc-900 dark:bg-white"
             : "bg-zinc-300 dark:bg-zinc-700",


### PR DESCRIPTION
Closes #345

## Summary
- add `aria-pressed` alongside the existing switch `aria-checked` state
- make the toggle aria-label announce the setting, current state, and next action
- add explicit Space/Enter keyboard handling with `preventDefault()` to avoid duplicate activation
- strengthen the visible focus ring offset
- add RTL coverage for state attributes, click, Space, and Enter activation

## Validation
- `node node_modules/vitest/vitest.mjs run components/common/toggle-card.test.tsx`
- `git diff --check`
- `node node_modules/typescript/bin/tsc --noEmit --pretty false` still fails on the existing `vitest.config.ts(10,5)` type mismatch (`false` is not assignable...)

## Security notes
- ARIA and visual states are both driven from the controlled `enabled` prop so preference state is not misrepresented.