### PR TITLE
refactor(transactions): share date and page defaults by huazhuang80-star

### DIFF
--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -8,6 +8,7 @@ import TableSearchbar from "@/components/transactions/table-searchbar";
 import Filter from "@/components/transactions/filter";
 import Sort from "@/components/transactions/sort";
 import { TransactionTableSkeleton } from "@/components/ui/table-skeleton";
+import { DEFAULT_TRANSACTIONS_PAGE_SIZE } from "@/components/transactions/transactions-config";
 import { useTransactions } from "@/hooks/useTransactions";
 import type { TransactionProps } from "@/types/transaction";
 import { isDateInRange } from "@/utils/dateUtils";
@@ -25,7 +26,6 @@ const Transactions = () => {
   const [searchParams, setSearchParams] = useState("");
   const [startDate, setStartDate] = useState<Date | undefined>(undefined);
   const [endDate, setEndDate] = useState<Date | undefined>(undefined);
-  const itemsPerPage = 6;
 
   // Reset to page 1 whenever filters change
   useEffect(() => {
@@ -61,8 +61,8 @@ const Transactions = () => {
   );
 
   const paginated = useMemo(() => {
-    const start = (currentPage - 1) * itemsPerPage;
-    return dateFiltered.slice(start, start + itemsPerPage);
+    const start = (currentPage - 1) * DEFAULT_TRANSACTIONS_PAGE_SIZE;
+    return dateFiltered.slice(start, start + DEFAULT_TRANSACTIONS_PAGE_SIZE);
   }, [dateFiltered, currentPage]);
 
   return (
@@ -102,7 +102,9 @@ const Transactions = () => {
           </div>
 
           {/* Loading state */}
-          {isLoading && <TransactionTableSkeleton rows={itemsPerPage} />}
+          {isLoading && (
+            <TransactionTableSkeleton rows={DEFAULT_TRANSACTIONS_PAGE_SIZE} />
+          )}
 
           {/* Error state */}
           {!isLoading && error && (
@@ -129,7 +131,7 @@ const Transactions = () => {
         <TransactionsPagination
           totalItems={dateFiltered.length}
           currentPage={currentPage}
-          itemsPerPage={itemsPerPage}
+          itemsPerPage={DEFAULT_TRANSACTIONS_PAGE_SIZE}
           onPageChange={setCurrentPage}
         />
       )}

--- a/components/transactions/transactions-config.test.ts
+++ b/components/transactions/transactions-config.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_TRANSACTION_DATE_RANGE,
+  DEFAULT_TRANSACTIONS_PAGE_SIZE,
+} from "./transactions-config";
+
+describe("transactions config", () => {
+  it("keeps the shared page size in sync with skeleton row expectations", () => {
+    expect(DEFAULT_TRANSACTIONS_PAGE_SIZE).toBe(6);
+  });
+
+  it("does not pin the default transaction range to a stale fixed window", () => {
+    expect(DEFAULT_TRANSACTION_DATE_RANGE).toEqual({
+      fromDate: "",
+      toDate: "",
+    });
+  });
+});

--- a/components/transactions/transactions-config.ts
+++ b/components/transactions/transactions-config.ts
@@ -1,0 +1,13 @@
+/**
+ * Default page size shared by transactions pagination and loading skeletons.
+ */
+export const DEFAULT_TRANSACTIONS_PAGE_SIZE = 6;
+
+/**
+ * Empty defaults mean the initial transactions view is not pinned to a stale
+ * historical date window; users can opt into date filtering from the header.
+ */
+export const DEFAULT_TRANSACTION_DATE_RANGE = {
+  fromDate: "",
+  toDate: "",
+} as const;

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -8,6 +8,10 @@ import TransactionsHeader from "./transactions-header";
 import TransactionsFilters from "./transactions-filters";
 import { TransactionsTable } from "./transactions-table";
 import TransactionsPagination from "./transactions-pagination";
+import {
+  DEFAULT_TRANSACTION_DATE_RANGE,
+  DEFAULT_TRANSACTIONS_PAGE_SIZE,
+} from "./transactions-config";
 
 /** Map token symbol → icon path */
 const getTokenIcon = (token: string): string => {
@@ -37,19 +41,17 @@ const toTransactionProps = (t: Transaction): TransactionProps => ({
 export default function TransactionsContent() {
   const [filters, setFilters] = useState<TransactionFilters>({
     searchQuery: "",
-    fromDate: "2023-03-26",
-    toDate: "2023-04-15",
+    ...DEFAULT_TRANSACTION_DATE_RANGE,
     selectedFilter: "All Transactions",
     sortField: "date",
     sortDirection: "desc",
   });
   const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 6;
 
   const { data, isLoading, error } = useTransactions({
     filters,
     page: currentPage,
-    pageSize: itemsPerPage,
+    pageSize: DEFAULT_TRANSACTIONS_PAGE_SIZE,
   });
 
   const paginatedTransactions: TransactionProps[] = useMemo(
@@ -98,7 +100,11 @@ export default function TransactionsContent() {
 
           <div className="py-4">
             {/* Loading state */}
-            {isLoading && <TransactionTableSkeleton rows={itemsPerPage} />}
+            {isLoading && (
+              <TransactionTableSkeleton
+                rows={DEFAULT_TRANSACTIONS_PAGE_SIZE}
+              />
+            )}
 
             {/* Error state */}
             {!isLoading && error && (
@@ -117,7 +123,7 @@ export default function TransactionsContent() {
                 <TransactionsPagination
                   totalItems={data?.total ?? 0}
                   currentPage={currentPage}
-                  itemsPerPage={itemsPerPage}
+                  itemsPerPage={DEFAULT_TRANSACTIONS_PAGE_SIZE}
                   onPageChange={setCurrentPage}
                 />
               </>

--- a/components/transactions/transactions-table.tsx
+++ b/components/transactions/transactions-table.tsx
@@ -12,6 +12,7 @@ import { TransactionsTableProps } from "@/types/transaction";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
 import { Skeleton } from "@/components/ui/skeleton";
+import { DEFAULT_TRANSACTIONS_PAGE_SIZE } from "./transactions-config";
 
 interface TransactionsTablePropsExtended extends TransactionsTableProps {
   isLoading?: boolean;
@@ -51,7 +52,7 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
           </TableHeader>
           <TableBody>
             {isLoading ? (
-              Array.from({ length: 6 }).map((_, index) => (
+              Array.from({ length: DEFAULT_TRANSACTIONS_PAGE_SIZE }).map((_, index) => (
                 <TableRow key={`skeleton-${index}`} className="border border-[#2D2D2D]">
                   <TableCell className="font-medium border border-[#2D2D2D] py-4 px-6">
                     <Skeleton className="h-4 w-20 mb-1" />
@@ -128,7 +129,7 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
       {/* Mobile Cards */}
       <div className="md:hidden space-y-4">
         {isLoading ? (
-          Array.from({ length: 6 }).map((_, index) => (
+          Array.from({ length: DEFAULT_TRANSACTIONS_PAGE_SIZE }).map((_, index) => (
             <div key={`skeleton-mobile-${index}`} className="p-4 border rounded-lg border-[#2D2D2D]">
               <div className="flex justify-between items-start">
                 <div className="space-y-2">


### PR DESCRIPTION
Closes #346

## Summary
- add a shared `transactions-config.ts` for the default page size and default date range
- remove the fixed 2023 default date window from `transactions-content.tsx`
- reuse `DEFAULT_TRANSACTIONS_PAGE_SIZE` for content pagination, route pagination, and table loading skeletons
- add a small config test that locks the shared page-size and empty default range expectations

## Validation
- `node node_modules/vitest/vitest.mjs run components/transactions/transactions-config.test.ts`
- `git diff --check`
- `rg "2023-03-26|2023-04-15|itemsPerPage = 6|length: 6" components/transactions app/transactions -g "*.tsx" -g "*.ts"`
- `node node_modules/typescript/bin/tsc --noEmit --pretty false` still fails on the existing `vitest.config.ts(10,5)` type mismatch (`false` is not assignable...)

## Security notes
- The default range stays unset instead of passing invalid dates into filtering by default.