### PR TITLE
feat(ui): add reusable empty and error states by huazhuang80-star

### DIFF
--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -8,6 +8,8 @@ import TableSearchbar from "@/components/transactions/table-searchbar";
 import Filter from "@/components/transactions/filter";
 import Sort from "@/components/transactions/sort";
 import { TransactionTableSkeleton } from "@/components/ui/table-skeleton";
+import EmptyState from "@/components/ui/empty-state";
+import ErrorState from "@/components/ui/error-state";
 import { useTransactions } from "@/hooks/useTransactions";
 import type { TransactionProps } from "@/types/transaction";
 import { isDateInRange } from "@/utils/dateUtils";
@@ -106,9 +108,11 @@ const Transactions = () => {
 
           {/* Error state */}
           {!isLoading && error && (
-            <div role="alert" className="py-8 text-center text-red-400 text-sm">
-              Failed to load transactions. Please try again.
-            </div>
+            <ErrorState
+              title="Failed to load transactions"
+              description="Refresh the data or try again after checking your connection."
+              className="border-[#2D2D2D] bg-[#1A1A1A] text-white"
+            />
           )}
 
           {/* Data state */}
@@ -116,9 +120,11 @@ const Transactions = () => {
             <>
               <TransactionsTable transactions={paginated} />
               {(searchParams || startDate || endDate) && paginated.length === 0 && (
-                <div role="status" aria-live="polite" className="py-4 text-center text-gray-400">
-                  No Transactions Found
-                </div>
+                <EmptyState
+                  title="No transactions found"
+                  description="Try adjusting your filters."
+                  className="mt-4 border-[#2D2D2D] bg-transparent"
+                />
               )}
             </>
           )}

--- a/components/analytics/analytics-view.test.tsx
+++ b/components/analytics/analytics-view.test.tsx
@@ -101,9 +101,8 @@ describe("AnalyticsViews Component", () => {
 
   it("renders chart with empty data", () => {
     render(<AnalyticsViews data={[]} />);
-    const barChart = screen.getByTestId("bar-chart");
-    const parsedData = JSON.parse(barChart.getAttribute("data-data") || "[]");
-    expect(parsedData).toEqual([]);
+    expect(screen.getByText("No analytics data")).toBeInTheDocument();
+    expect(screen.queryByTestId("bar-chart")).not.toBeInTheDocument();
   });
 
   it("renders CustomTooltip content correctly inside Tooltip mock", () => {

--- a/components/analytics/analytics-view.tsx
+++ b/components/analytics/analytics-view.tsx
@@ -16,6 +16,7 @@ import { ChevronDown, ChevronUp, ChevronRight } from "lucide-react";
 import chart from "@/public/chart-up.png";
 import { formatChartValue } from "@/utils/formatUtils";
 import { Skeleton } from "@/components/ui/skeleton";
+import EmptyState from "@/components/ui/empty-state";
 import PaymentHistory from "@/components/dashboard/payment-history";
 
 /**
@@ -125,6 +126,7 @@ const AnalyticsViews = ({
   };
 
   const chartData = data || defaultData;
+  const isChartEmpty = chartData.length === 0;
 
   if (isLoading) {
     if (showNotifications) {
@@ -247,35 +249,43 @@ const AnalyticsViews = ({
         </div>
 
         <div className={showNotifications ? "w-full h-56 mt-4 border border-zinc-100 dark:border-zinc-800/50 p-6 rounded-xl bg-zinc-50/30 dark:bg-zinc-900/20" : "w-full h-full aspect-[3/1] rounded-lg border border-[#2D2D2D] p-2 sm:p-4"}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={chartData}>
-              <CartesianGrid
-                strokeDasharray="3 3"
-                vertical={false}
-                stroke={showNotifications ? "currentColor" : "#1f1b2e"}
-                className={showNotifications ? "text-zinc-200 dark:text-zinc-800" : ""}
-              />
-              <XAxis
-                dataKey="month"
-                tick={{ fill: "#aaa", fontSize: 10 }}
-                tickLine={false}
-                axisLine={false}
-              />
-              <YAxis
-                tick={{ fill: "#aaa", fontSize: 10 }}
-                tickFormatter={formatChartValue}
-                tickLine={false}
-                axisLine={false}
-              />
-              <Tooltip content={<CustomTooltip />} />
-              <Bar
-                dataKey="views"
-                fill={showNotifications ? "#3b82f6" : "#2E2E2E"}
-                radius={[4, 4, 0, 0]}
-                barSize={showNotifications ? 20 : 28}
-              />
-            </BarChart>
-          </ResponsiveContainer>
+          {isChartEmpty ? (
+            <EmptyState
+              title="No analytics data"
+              description="Analytics will appear here once views are available."
+              className="h-full border-[#2D2D2D] bg-transparent"
+            />
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={chartData}>
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  vertical={false}
+                  stroke={showNotifications ? "currentColor" : "#1f1b2e"}
+                  className={showNotifications ? "text-zinc-200 dark:text-zinc-800" : ""}
+                />
+                <XAxis
+                  dataKey="month"
+                  tick={{ fill: "#aaa", fontSize: 10 }}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <YAxis
+                  tick={{ fill: "#aaa", fontSize: 10 }}
+                  tickFormatter={formatChartValue}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <Tooltip content={<CustomTooltip />} />
+                <Bar
+                  dataKey="views"
+                  fill={showNotifications ? "#3b82f6" : "#2E2E2E"}
+                  radius={[4, 4, 0, 0]}
+                  barSize={showNotifications ? 20 : 28}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
         </div>
       </div>
 

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -8,6 +8,7 @@ import TransactionsHeader from "./transactions-header";
 import TransactionsFilters from "./transactions-filters";
 import { TransactionsTable } from "./transactions-table";
 import TransactionsPagination from "./transactions-pagination";
+import ErrorState from "@/components/ui/error-state";
 
 /** Map token symbol → icon path */
 const getTokenIcon = (token: string): string => {
@@ -102,12 +103,11 @@ export default function TransactionsContent() {
 
             {/* Error state */}
             {!isLoading && error && (
-              <div
-                role="alert"
-                className="py-8 text-center text-red-400 text-sm"
-              >
-                Failed to load transactions. Please try again.
-              </div>
+              <ErrorState
+                title="Failed to load transactions"
+                description="Refresh the data or try again after checking your connection."
+                className="border-[#2D2D2D] bg-[#1A1A1A] text-white"
+              />
             )}
 
             {/* Data state */}

--- a/components/transactions/transactions-table.tsx
+++ b/components/transactions/transactions-table.tsx
@@ -12,6 +12,7 @@ import { TransactionsTableProps } from "@/types/transaction";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
 import { Skeleton } from "@/components/ui/skeleton";
+import EmptyState from "@/components/ui/empty-state";
 
 interface TransactionsTablePropsExtended extends TransactionsTableProps {
   isLoading?: boolean;
@@ -78,9 +79,11 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
             ) : isEmpty ? (
               <TableRow>
                 <TableCell colSpan={6} className="py-12 text-center">
-                  <div role="status" aria-live="polite" className="text-muted-foreground">
-                    No transactions found. Try adjusting your filters.
-                  </div>
+                  <EmptyState
+                    title="No transactions found"
+                    description="Try adjusting your filters."
+                    className="border-[#2D2D2D] bg-transparent"
+                  />
                 </TableCell>
               </TableRow>
             ) : (
@@ -151,9 +154,11 @@ export function TransactionsTable({ transactions, isLoading = false }: Transacti
           ))
         ) : isEmpty ? (
           <div className="p-8 text-center border rounded-lg border-[#2D2D2D]">
-            <div role="status" aria-live="polite" className="text-muted-foreground">
-              No transactions found. Try adjusting your filters.
-            </div>
+            <EmptyState
+              title="No transactions found"
+              description="Try adjusting your filters."
+              className="border-[#2D2D2D] bg-transparent"
+            />
           </div>
         ) : (
           transactions.map((transaction, index) => (

--- a/components/ui/empty-state.test.tsx
+++ b/components/ui/empty-state.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import EmptyState from "./empty-state";
+
+describe("EmptyState", () => {
+  it("renders accessible empty copy", () => {
+    render(
+      <EmptyState
+        title="No transactions found"
+        description="Try adjusting your filters."
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByText("No transactions found")).toBeInTheDocument();
+    expect(screen.getByText("Try adjusting your filters.")).toBeInTheDocument();
+  });
+});

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,42 @@
+import type { ComponentType } from "react";
+import { Inbox } from "lucide-react";
+
+import { cn } from "@/utils/commonUtils";
+
+interface StateIconProps {
+  className?: string;
+}
+
+export interface EmptyStateProps {
+  title: string;
+  description: string;
+  icon?: ComponentType<StateIconProps>;
+  className?: string;
+}
+
+/**
+ * Accessible empty state for list, table, and chart surfaces.
+ */
+export default function EmptyState({
+  title,
+  description,
+  icon: Icon = Inbox,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "flex flex-col items-center justify-center rounded-2xl border border-border bg-muted/30 px-6 py-8 text-center",
+        className,
+      )}
+    >
+      <Icon className="mb-3 size-6 text-muted-foreground" aria-hidden="true" />
+      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      <p className="mt-2 max-w-md text-sm text-muted-foreground">
+        {description}
+      </p>
+    </div>
+  );
+}

--- a/components/ui/error-state.test.tsx
+++ b/components/ui/error-state.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ErrorState from "./error-state";
+
+describe("ErrorState", () => {
+  it("renders accessible friendly error copy", () => {
+    render(
+      <ErrorState
+        title="Unable to load transactions"
+        description="Refresh the data and try again."
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveAttribute(
+      "aria-live",
+      "assertive",
+    );
+    expect(screen.getByText("Unable to load transactions")).toBeInTheDocument();
+    expect(screen.queryByText(/stack trace/i)).not.toBeInTheDocument();
+  });
+
+  it("calls the optional retry action", () => {
+    const onRetry = vi.fn();
+
+    render(
+      <ErrorState
+        title="Unable to load transactions"
+        description="Refresh the data and try again."
+        onRetry={onRetry}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/ui/error-state.tsx
+++ b/components/ui/error-state.tsx
@@ -1,0 +1,55 @@
+import type { ComponentType } from "react";
+import { AlertCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/utils/commonUtils";
+
+interface StateIconProps {
+  className?: string;
+}
+
+export interface ErrorStateProps {
+  title: string;
+  description: string;
+  icon?: ComponentType<StateIconProps>;
+  retryLabel?: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+/**
+ * Accessible, tokenized error state for async surfaces.
+ *
+ * Security: pass friendly copy only. Do not render raw exception messages,
+ * stack traces, request bodies, or service responses through this component.
+ */
+export default function ErrorState({
+  title,
+  description,
+  icon: Icon = AlertCircle,
+  retryLabel = "Try again",
+  onRetry,
+  className,
+}: ErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className={cn(
+        "flex flex-col items-center justify-center rounded-2xl border border-destructive/20 bg-destructive/10 px-6 py-8 text-center",
+        className,
+      )}
+    >
+      <Icon className="mb-3 size-6 text-destructive" aria-hidden="true" />
+      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      <p className="mt-2 max-w-md text-sm text-muted-foreground">
+        {description}
+      </p>
+      {onRetry ? (
+        <Button type="button" onClick={onRetry} className="mt-4">
+          {retryLabel}
+        </Button>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #304

## Summary
- add reusable `ErrorState` and `EmptyState` UI components with role/aria-live semantics
- support optional retry actions on ErrorState without exposing raw exception details
- adopt the shared states in transactions content, transactions table, the legacy transactions route, and analytics empty charts
- update analytics coverage for the new empty-state behavior

## Validation
- `node node_modules/vitest/vitest.mjs run components/ui/error-state.test.tsx components/ui/empty-state.test.tsx components/analytics/analytics-view.test.tsx`
- `git diff --check`
- `node node_modules/typescript/bin/tsc --noEmit --pretty false` still fails on the existing `vitest.config.ts(10,5)` type mismatch (`false` is not assignable...)

## Security notes
- ErrorState documentation explicitly calls out friendly-copy-only usage; raw exception messages, stack traces, request bodies, and service responses should not be rendered.