### PR TITLE
fix(auth): share signup password policy by huazhuang80-star

### DIFF
--- a/types/auth.test.ts
+++ b/types/auth.test.ts
@@ -122,6 +122,21 @@ describe("signUpSchema", () => {
     });
   });
 
+  it("rejects lowercase-only passwords that the visual checklist marks invalid", () => {
+    const issues = issuesFor(signUpSchema, {
+      ...validSignUp,
+      password: "password1",
+      confirmPassword: "password1",
+    });
+
+    expect(issues.map((issue) => issue.message)).toEqual(
+      expect.arrayContaining([
+        "Password must include at least one uppercase letter.",
+        "Password must include at least one special character.",
+      ]),
+    );
+  });
+
   it("rejects mismatched confirmation passwords on confirmPassword", () => {
     expect(
       issueFor(
@@ -245,6 +260,16 @@ describe("loginSchema", () => {
       path: ["password"],
       message: "Password must be at least 8 characters.",
     });
+  });
+
+  it("keeps login validation compatible with existing length-only passwords", () => {
+    expect(
+      loginSchema.safeParse({
+        ...validLogin,
+        password: "password1",
+        rememberMe: false,
+      }).success,
+    ).toBe(true);
   });
 
   it.each([

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { checkPasswordRequirements } from "@/utils/authUtils";
 
 // Auth component props
 export interface SignUpEmailModalProps {
@@ -30,17 +31,30 @@ export const signUpSchema = z
     email: z.string().email({
       message: "Please enter a valid email address.",
     }),
-    password: z
-      .string()
-      .min(8, {
-        message: "Password must be at least 8 characters.",
-      })
-      .regex(/[A-Z]/, {
-        message: "Password must include at least one uppercase letter.",
-      })
-      .regex(/[@!#%$^&*()_+\-=[\]{};':"\\|,.<>/?]/, {
-        message: "Password must include at least one special character.",
-      }),
+    password: z.string().superRefine((password, context) => {
+      const requirements = checkPasswordRequirements(password);
+
+      if (!requirements.minLength) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Password must be at least 8 characters.",
+        });
+      }
+
+      if (!requirements.uppercase) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Password must include at least one uppercase letter.",
+        });
+      }
+
+      if (!requirements.specialChar) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Password must include at least one special character.",
+        });
+      }
+    }),
     confirmPassword: z.string(),
     agreeToTerms: z.boolean().refine((val) => val === true, {
       message: "You must agree to the terms and conditions.",
@@ -53,7 +67,8 @@ export const signUpSchema = z
 
 /**
  * Validates login form values: valid email, an 8+ character password, and
- * remember-me preference.
+ * remember-me preference. Login intentionally keeps a length-only password
+ * check because existing credentials may predate the current signup policy.
  */
 export const loginSchema = z.object({
   email: z.string().email({


### PR DESCRIPTION
Closes #253

## Summary
- make `signUpSchema` reuse `checkPasswordRequirements()` so schema and UI checklist share one password policy
- keep confirm-password matching intact
- document why `loginSchema` remains length-only for existing credential compatibility
- add schema coverage for lowercase-only weak passwords and length-only login compatibility

## Validation
- `node node_modules/vitest/vitest.mjs run types/auth.test.ts utils/authUtils.test.ts`
- `git diff --check`
- `node node_modules/typescript/bin/tsc --noEmit --pretty false` still fails on the existing `vitest.config.ts(10,5)` type mismatch (`false` is not assignable...)

## Security notes
- Centralizing signup password policy prevents schema/UI drift and keeps client validation consistent as defense-in-depth.