### PR TITLE
fix(a11y): clarify destructive confirmations by huazhuang80-star

### DIFF
--- a/app/settings/preferences/components/destructive-action-dialog.test.tsx
+++ b/app/settings/preferences/components/destructive-action-dialog.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import DestructiveActionDialog from "./destructive-action-dialog";
+
+function renderDialog(onConfirm = vi.fn()) {
+  render(
+    <DestructiveActionDialog
+      triggerLabel="Deactivate account"
+      title="Deactivate this account"
+      description="This pauses sign-in."
+      impactItems={["Wallet operations would be blocked."]}
+      confirmationToken="DEACTIVATE"
+      confirmationLabel='Type "DEACTIVATE" to confirm'
+      confirmLabel="Confirm deactivation"
+      onConfirm={onConfirm}
+    />,
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: "Deactivate account" }));
+  return { onConfirm };
+}
+
+describe("DestructiveActionDialog", () => {
+  it("focuses and describes the required confirmation input", () => {
+    renderDialog();
+
+    const input = screen.getByLabelText('Type "DEACTIVATE" to confirm');
+    expect(input).toHaveFocus();
+    expect(input).toHaveAttribute("aria-required", "true");
+    expect(input).toHaveAttribute("aria-invalid", "false");
+    expect(input).toHaveAccessibleDescription(/Type DEACTIVATE exactly/i);
+  });
+
+  it("shows an inline mismatch error and blocks confirmation", () => {
+    const { onConfirm } = renderDialog();
+
+    const input = screen.getByLabelText('Type "DEACTIVATE" to confirm');
+    fireEvent.change(input, { target: { value: "DEACTIVATE " } });
+
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(
+      screen.getByText("The confirmation must match DEACTIVATE exactly."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Confirm deactivation" }),
+    ).toBeDisabled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("confirms only the exact token", () => {
+    const { onConfirm } = renderDialog();
+
+    fireEvent.change(screen.getByLabelText('Type "DEACTIVATE" to confirm'), {
+      target: { value: "DEACTIVATE" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Confirm deactivation" }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/settings/preferences/components/destructive-action-dialog.tsx
+++ b/app/settings/preferences/components/destructive-action-dialog.tsx
@@ -38,8 +38,12 @@ export default function DestructiveActionDialog({
   const [open, setOpen] = useState(false);
   const [confirmationText, setConfirmationText] = useState("");
   const inputId = `confirmation-${confirmationToken.toLowerCase()}`;
+  const instructionId = `${inputId}-instruction`;
+  const errorId = `${inputId}-error`;
 
-  const isConfirmed = confirmationText.trim() === confirmationToken;
+  const hasConfirmationText = confirmationText.length > 0;
+  const isConfirmed = confirmationText === confirmationToken;
+  const showMismatch = hasConfirmationText && !isConfirmed;
 
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
@@ -101,13 +105,27 @@ export default function DestructiveActionDialog({
             >
               {confirmationLabel}
             </label>
+            <p id={instructionId} className="text-sm text-zinc-500 dark:text-zinc-400">
+              Type {confirmationToken} exactly. Extra spaces and different
+              casing will not match.
+            </p>
             <Input
               id={inputId}
               value={confirmationText}
               onChange={(event) => setConfirmationText(event.target.value)}
               placeholder={confirmationToken}
+              autoFocus
+              aria-required="true"
+              error={showMismatch}
+              errorId={errorId}
+              descriptionId={instructionId}
               className="border-zinc-200 bg-white dark:border-white/10 dark:bg-white/5"
             />
+            {showMismatch ? (
+              <p id={errorId} className="text-sm text-destructive">
+                The confirmation must match {confirmationToken} exactly.
+              </p>
+            ) : null}
           </div>
         </div>
 


### PR DESCRIPTION
Closes #344

## Summary
- autofocus the destructive confirmation input when the dialog opens
- wire `aria-required`, `aria-invalid`, and `aria-describedby` to the confirmation input
- make token matching exact instead of trimming whitespace silently
- show inline guidance when the typed token does not match exactly
- add RTL coverage for focus, described-by text, mismatch state, and exact-token confirmation

## Validation
- `node node_modules/vitest/vitest.mjs run app/settings/preferences/components/destructive-action-dialog.test.tsx`
- `git diff --check`
- `node node_modules/typescript/bin/tsc --noEmit --pretty false` still fails on the existing `vitest.config.ts(10,5)` type mismatch (`false` is not assignable...)

## Security notes
- Destructive actions still require an exact, case-correct token. Whitespace no longer silently passes.