### PR TITLE
fix(theme): set theme before hydration by huazhuang80-star

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,6 +25,17 @@ const generalSans = localFont({
   display: "swap",
 });
 
+const themeInitScript = `
+(function () {
+  try {
+    var storedTheme = window.localStorage.getItem("theme");
+    var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    var useDark = storedTheme === "dark" || (!storedTheme && prefersDark);
+    document.documentElement.classList.toggle("dark", useDark);
+  } catch (_) {}
+})();
+`;
+
 /**
  * Global metadata configuration for the StelloPay application.
  * Sets the default title templates and default OpenGraph and Twitter preview parameters.
@@ -66,12 +77,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${inter.variable} ${clashDisplay.variable} ${generalSans.variable} antialiased`}
       >
         {/* Skip navigation link — first focusable element on every page.
             Allows keyboard/screen-reader users to bypass repeated nav. */}
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[9999] focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:rounded focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-black"

--- a/context/theme-context.tsx
+++ b/context/theme-context.tsx
@@ -12,10 +12,18 @@ type ThemeContextValue = {
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
+const getInitialTheme = (): Theme => {
+  if (typeof document !== "undefined") {
+    return document.documentElement.classList.contains("dark") ? "dark" : "light";
+  }
+
+  return "light";
+};
+
 export const ThemeProvider: React.FC<React.PropsWithChildren<{}>> = ({
   children,
 }) => {
-  const [theme, setThemeState] = useState<Theme>("light");
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
 
   useEffect(() => {
     try {


### PR DESCRIPTION
Closes #272.

## Summary
- add a small pre-hydration script that applies the `dark` class from stored preference or system preference before React mounts
- add `suppressHydrationWarning` to the root `<html>` element because the script can update its class before hydration
- initialize `ThemeProvider` from the pre-hydrated document class so it does not briefly overwrite dark mode with the default light state

## Validation
- `git diff --check` -> passed (line-ending warnings only)

## Existing local blocker
- `tsc --noEmit --pretty false` still fails on the existing `vitest.config.ts(10,5)` type mismatch, unrelated to this change