### PR TITLE
perf(transactions): debounce table search input by huazhuang80-star

### DIFF
--- a/components/transactions/table-searchbar.test.tsx
+++ b/components/transactions/table-searchbar.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import TableSearchbar from "./table-searchbar";
+
+describe("TableSearchbar", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("debounces search changes and labels the search input", () => {
+    vi.useFakeTimers();
+    const onSearch = vi.fn();
+
+    render(<TableSearchbar onSearch={onSearch} debounceMs={250} />);
+
+    const input = screen.getByRole("searchbox", {
+      name: /search transactions/i,
+    });
+
+    fireEvent.change(input, { target: { value: "x" } });
+    fireEvent.change(input, { target: { value: "xl" } });
+    fireEvent.change(input, { target: { value: "xlm" } });
+
+    vi.advanceTimersByTime(249);
+    expect(onSearch).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledWith("xlm");
+  });
+
+  it("cancels pending searches on unmount", () => {
+    vi.useFakeTimers();
+    const onSearch = vi.fn();
+
+    const { unmount } = render(
+      <TableSearchbar onSearch={onSearch} debounceMs={250} />,
+    );
+
+    fireEvent.change(screen.getByRole("searchbox"), {
+      target: { value: "pending" },
+    });
+
+    unmount();
+    vi.advanceTimersByTime(250);
+
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+});

--- a/components/transactions/table-searchbar.tsx
+++ b/components/transactions/table-searchbar.tsx
@@ -1,20 +1,47 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Search } from "lucide-react";
 
 interface TableSearchbarProps {
   onSearch: (value: string) => void;
+  value?: string;
+  debounceMs?: number;
+  ariaLabel?: string;
 }
 
-const TableSearchbar = ({ onSearch }: TableSearchbarProps) => {
+/**
+ * Debounced transaction search input for table-level filtering.
+ */
+const TableSearchbar = ({
+  onSearch,
+  value = "",
+  debounceMs = 250,
+  ariaLabel = "Search transactions",
+}: TableSearchbarProps) => {
+  const [searchValue, setSearchValue] = useState(value);
+
+  useEffect(() => {
+    setSearchValue(value);
+  }, [value]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      onSearch(searchValue);
+    }, debounceMs);
+
+    return () => window.clearTimeout(timer);
+  }, [debounceMs, onSearch, searchValue]);
+
   return (
     <div className="flex items-center bg-transparent rounded-[6.25rem]   ">
       <Search className="w-5 h-5 text-gray-600 " />
 
       <Input
-        type="text"
+        type="search"
+        aria-label={ariaLabel}
         placeholder="Search"
-        onChange={(e) => onSearch(e.target.value)}
+        value={searchValue}
+        onChange={(e) => setSearchValue(e.target.value)}
         className="border-none py-1 focus-visible:ring-0 text-[13px] p-1 sm:text-[14px]"
       />
     </div>


### PR DESCRIPTION
Closes #323.

## Summary
- add a configurable debounce to `TableSearchbar`, defaulting to 250ms
- keep the input controlled locally while syncing external `value` updates
- switch the field to `type="search"` and add a descriptive accessible label
- add fake-timer coverage for debounced callbacks and cleanup on unmount

## Validation
- `node node_modules/vitest/vitest.mjs run components/transactions/table-searchbar.test.tsx` -> passed (2 tests)
- `git diff --check` -> passed (line-ending warning only)

## Existing local blocker
- `tsc --noEmit --pretty false` still fails on the existing `vitest.config.ts(10,5)` type mismatch, unrelated to this change