### PR TITLE
refactor(transactions): add fetch-backed adapter by huazhuang80-star

### DIFF
--- a/lib/api/__tests__/transactions.test.ts
+++ b/lib/api/__tests__/transactions.test.ts
@@ -15,6 +15,16 @@ afterAll(() => {
 });
 
 describe("getTransactions", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "");
+  });
+
   it("returns first page with default params", async () => {
     const result = await getTransactions();
     expect(result.page).toBe(1);
@@ -141,6 +151,60 @@ describe("getTransactions", () => {
       expect(typeof t.amount).toBe("number");
       expect(["Completed", "Pending", "Failed"]).toContain(t.status);
     });
+  });
+
+  it("fetches from NEXT_PUBLIC_API_BASE_URL when configured", async () => {
+    vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "https://api.example.test");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: "remote-1",
+            type: "Payment Sent",
+            txId: "#REMOTE",
+            address: "GREMOTE",
+            date: "2024-01-01",
+            time: "10:00AM",
+            token: "XLM",
+            amount: -10,
+            status: "Completed",
+            statusColor: "success",
+          },
+        ],
+        total: 1,
+        page: 2,
+        pageSize: 5,
+        totalPages: 1,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getTransactions({
+      filters: { searchQuery: "xlm" },
+      page: 2,
+      pageSize: 5,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("https://api.example.test/transactions?");
+    expect(String(url)).toContain("page=2");
+    expect(String(url)).toContain("pageSize=5");
+    expect(String(url)).toContain("searchQuery=xlm");
+    expect(result.data[0]?.id).toBe("remote-1");
+  });
+
+  it("throws a useful error when the remote transactions request fails", async () => {
+    vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "https://api.example.test");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503 }),
+    );
+
+    await expect(getTransactions()).rejects.toThrow(
+      "Failed to fetch transactions: 503",
+    );
   });
 });
 

--- a/lib/api/transactions.ts
+++ b/lib/api/transactions.ts
@@ -24,6 +24,10 @@ export interface GetTransactionsParams {
   pageSize?: number;
 }
 
+type RemoteTransactionsResponse = Partial<PaginatedTransactions> & {
+  transactions?: Transaction[];
+};
+
 export const MIN_TRANSACTION_PAGE_SIZE = 1;
 export const MAX_TRANSACTION_PAGE_SIZE = 100;
 export const DEFAULT_TRANSACTION_PAGE_SIZE = 6;
@@ -68,6 +72,76 @@ const normalizeDateFilter = (
   }
 
   return value;
+};
+
+type NormalizedTransactionFilters = {
+  searchQuery: string;
+  selectedFilter: string;
+  fromDate: string;
+  toDate: string;
+  sortField: TransactionFilters["sortField"];
+  sortDirection: TransactionFilters["sortDirection"];
+};
+
+const buildTransactionsUrl = (
+  baseUrl: string,
+  page: number,
+  pageSize: number,
+  filters: NormalizedTransactionFilters,
+) => {
+  const url = new URL("/transactions", baseUrl);
+
+  url.searchParams.set("page", String(page));
+  url.searchParams.set("pageSize", String(pageSize));
+  url.searchParams.set("searchQuery", filters.searchQuery);
+  url.searchParams.set("selectedFilter", filters.selectedFilter);
+  url.searchParams.set("fromDate", filters.fromDate);
+  url.searchParams.set("toDate", filters.toDate);
+  url.searchParams.set("sortField", filters.sortField);
+  url.searchParams.set("sortDirection", filters.sortDirection);
+
+  return url;
+};
+
+const normalizeRemoteTransactions = (
+  response: RemoteTransactionsResponse,
+  fallbackPage: number,
+  fallbackPageSize: number,
+): PaginatedTransactions => {
+  const data = response.data ?? response.transactions ?? [];
+  const total = response.total ?? data.length;
+  const pageSize = response.pageSize ?? fallbackPageSize;
+
+  return {
+    data,
+    total,
+    page: response.page ?? fallbackPage,
+    pageSize,
+    totalPages: response.totalPages ?? Math.max(1, Math.ceil(total / pageSize)),
+  };
+};
+
+const fetchRemoteTransactions = async (
+  baseUrl: string,
+  page: number,
+  pageSize: number,
+  filters: NormalizedTransactionFilters,
+  signal?: AbortSignal,
+): Promise<PaginatedTransactions> => {
+  const response = await fetch(
+    buildTransactionsUrl(baseUrl, page, pageSize, filters),
+    { signal },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch transactions: ${response.status}`);
+  }
+
+  return normalizeRemoteTransactions(
+    (await response.json()) as RemoteTransactionsResponse,
+    page,
+    pageSize,
+  );
 };
 
 /**
@@ -135,6 +209,25 @@ export async function getTransactions(
   // const json = await res.json();
   // return TransactionResponseSchema.parse(json); // zod validation here
   // ─────────────────────────────────────────────────────────────────────────
+
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  if (apiBaseUrl) {
+    return fetchRemoteTransactions(
+      apiBaseUrl,
+      requestedSafePage,
+      safePageSize,
+      {
+        searchQuery,
+        selectedFilter,
+        fromDate: safeFromDate,
+        toDate: safeToDate,
+        sortField,
+        sortDirection,
+      },
+      signal,
+    );
+  }
 
   // Abortable delay (used by tests and prevents stale UI flashes)
   if (process.env.NODE_ENV === "development") {


### PR DESCRIPTION
Closes #288.

## Summary
- route `getTransactions` through `NEXT_PUBLIC_API_BASE_URL` when configured
- preserve the existing mock-data path when no API base URL is set
- normalize remote responses that return either `data` or `transactions`
- cover remote success and failure paths in the existing transaction data-layer tests

## Validation
- `node node_modules/vitest/vitest.mjs run lib/api/__tests__/transactions.test.ts` -> passed (22 tests)
- `git diff --check` -> passed (line-ending warnings only)

## Existing local blocker
- `tsc --noEmit --pretty false` still fails on the existing `vitest.config.ts(10,5)` type mismatch, unrelated to this change