### PR TITLE
feat(verify-email): add otp entry and resend cooldown by huazhuang80-star

### DIFF
--- a/app/verify-email/page.test.tsx
+++ b/app/verify-email/page.test.tsx
@@ -1,0 +1,68 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import VerifyEmail from "./page";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    back: vi.fn(),
+  }),
+}));
+
+describe("VerifyEmail", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps continue disabled until the 6-character code is complete", () => {
+    render(<VerifyEmail />);
+
+    const continueButton = screen.getByRole("button", { name: /continue/i });
+    expect(continueButton).toBeDisabled();
+
+    for (let index = 1; index <= 6; index += 1) {
+      fireEvent.change(
+        screen.getByLabelText(`Verification code character ${index}`),
+        { target: { value: String(index) } },
+      );
+    }
+
+    expect(continueButton).toBeEnabled();
+  });
+
+  it("supports pasting a complete verification code", () => {
+    render(<VerifyEmail />);
+
+    fireEvent.paste(screen.getByLabelText("Verification code character 1"), {
+      clipboardData: { getData: () => "123456" },
+    });
+
+    expect(screen.getByLabelText("Verification code character 6")).toHaveValue(
+      "6",
+    );
+    expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled();
+  });
+
+  it("starts a resend cooldown after resending the code", async () => {
+    vi.useFakeTimers();
+    render(<VerifyEmail />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^resend$/i }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(
+      screen.getByText("Verification code resent to your email."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /resend in 30s/i })).toBeDisabled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(
+      screen.getByRole("button", { name: /resend in 29s/i }),
+    ).toBeDisabled();
+  });
+});

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -1,30 +1,100 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { X, Loader2 } from "lucide-react";
 
 type StatusType = "idle" | "loading" | "success" | "error";
+const OTP_LENGTH = 6;
+const RESEND_COOLDOWN_SECONDS = 30;
 
 export default function VerifyEmail() {
-  const [code, setCode] = useState("");
+  const [code, setCode] = useState<string[]>(Array(OTP_LENGTH).fill(""));
   const router = useRouter();
   const [status, setStatus] = useState<StatusType>("idle");
   const [message, setMessage] = useState("");
   const [resendStatus, setResendStatus] = useState<StatusType>("idle");
+  const [cooldown, setCooldown] = useState(0);
+  const inputRefs = useRef<Array<HTMLInputElement | null>>([]);
+  const codeValue = code.join("");
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/[^0-9a-zA-Z]/g, "");
-    if (value.length <= 6) setCode(value);
+  useEffect(() => {
+    if (cooldown === 0) return;
+
+    const timerId = window.setInterval(() => {
+      setCooldown((seconds) => Math.max(0, seconds - 1));
+    }, 1000);
+
+    return () => window.clearInterval(timerId);
+  }, [cooldown]);
+
+  const updateCodeAt = (index: number, value: string) => {
+    const nextValue = value.replace(/[^0-9a-zA-Z]/g, "").slice(-1);
+    setCode((current) => {
+      const next = [...current];
+      next[index] = nextValue;
+      return next;
+    });
+
+    if (nextValue && index < OTP_LENGTH - 1) {
+      inputRefs.current[index + 1]?.focus();
+    }
+  };
+
+  const handleInputChange = (
+    index: number,
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    updateCodeAt(index, e.target.value);
+  };
+
+  const handleKeyDown = (
+    index: number,
+    e: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (e.key === "Backspace" && !code[index] && index > 0) {
+      inputRefs.current[index - 1]?.focus();
+      return;
+    }
+
+    if (e.key === "ArrowLeft" && index > 0) {
+      e.preventDefault();
+      inputRefs.current[index - 1]?.focus();
+    }
+
+    if (e.key === "ArrowRight" && index < OTP_LENGTH - 1) {
+      e.preventDefault();
+      inputRefs.current[index + 1]?.focus();
+    }
+  };
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const pastedCode = e.clipboardData
+      .getData("text")
+      .replace(/[^0-9a-zA-Z]/g, "")
+      .slice(0, OTP_LENGTH)
+      .split("");
+
+    if (pastedCode.length === 0) return;
+
+    setCode([
+      ...pastedCode,
+      ...Array(OTP_LENGTH - pastedCode.length).fill(""),
+    ]);
+    inputRefs.current[Math.min(pastedCode.length, OTP_LENGTH) - 1]?.focus();
   };
 
   const handleResend = async () => {
+    if (cooldown > 0 || resendStatus === "loading") return;
+
     setResendStatus("loading");
     setMessage("");
     try {
       // Simulate API call
       await new Promise((resolve) => setTimeout(resolve, 1500));
       setResendStatus("success");
+      setCooldown(RESEND_COOLDOWN_SECONDS);
       setMessage("Verification code resent to your email.");
     } catch {
       setResendStatus("error");
@@ -35,12 +105,18 @@ export default function VerifyEmail() {
   };
 
   const handleContinue = async () => {
+    if (codeValue.length !== OTP_LENGTH) {
+      setStatus("error");
+      setMessage("Enter the 6-character verification code.");
+      return;
+    }
+
     setStatus("loading");
     setMessage("");
     try {
       // Simulate API call
       await new Promise((resolve, reject) => setTimeout(() => {
-        if (code === "123456") {
+        if (codeValue === "123456") {
           resolve(null);
         } else {
           reject(new Error("Invalid code"));
@@ -76,28 +152,50 @@ export default function VerifyEmail() {
           Didn&apos;t get code?{" "}
           <button
             onClick={handleResend}
-            disabled={resendStatus === "loading"}
+            disabled={resendStatus === "loading" || cooldown > 0}
             className="text-white font-semibold underline cursor-pointer disabled:opacity-50"
+            aria-describedby="resend-status"
           >
             {resendStatus === "loading" ? (
               <>
                 <Loader2 className="inline h-4 w-4 mr-1 animate-spin" />
                 Sending...
               </>
+            ) : cooldown > 0 ? (
+              `Resend in ${cooldown}s`
             ) : "Resend"}
           </button>
         </p>
+        <p id="resend-status" aria-live="polite" className="sr-only">
+          {cooldown > 0
+            ? `You can request a new code in ${cooldown} seconds.`
+            : "You can request a new verification code."}
+        </p>
 
-        {/* Input */}
-        <input
-          type="text"
-          inputMode="numeric"
-          maxLength={6}
-          value={code}
-          onChange={handleInputChange}
-          className="w-full text-left py-3 px-4 rounded-[8px] border border-[#2D2D2D] bg-transparent text-white mb-4 outline-none mt-5"
-          placeholder="- - - - - - - -"
-        />
+        {/* OTP input */}
+        <fieldset className="mt-5 mb-4">
+          <legend className="sr-only">Verification code</legend>
+          <div className="grid grid-cols-6 gap-2">
+            {code.map((value, index) => (
+              <input
+                key={index}
+                ref={(node) => {
+                  inputRefs.current[index] = node;
+                }}
+                type="text"
+                inputMode="text"
+                autoComplete={index === 0 ? "one-time-code" : "off"}
+                maxLength={1}
+                value={value}
+                onChange={(event) => handleInputChange(index, event)}
+                onKeyDown={(event) => handleKeyDown(index, event)}
+                onPaste={handlePaste}
+                aria-label={`Verification code character ${index + 1}`}
+                className="h-12 rounded-[8px] border border-[#2D2D2D] bg-transparent text-center text-lg font-semibold text-white outline-none focus:border-[#F8D2FE] focus:ring-1 focus:ring-[#F8D2FE]"
+              />
+            ))}
+          </div>
+        </fieldset>
 
         {/* Status Messages */}
         {message && (
@@ -119,9 +217,9 @@ export default function VerifyEmail() {
         {/* Continue Button */}
         <button
           onClick={handleContinue}
-          disabled={code.length !== 6 || status === "loading"}
+          disabled={codeValue.length !== OTP_LENGTH || status === "loading"}
           className={`w-full py-3 px-4 rounded-[8px] bg-[#FFFFFF] text-black font-medium transition mt-2 flex items-center justify-center gap-2 ${
-            code.length === 6 && status !== "loading"
+            codeValue.length === OTP_LENGTH && status !== "loading"
               ? "cursor-pointer"
               : "opacity-80 cursor-not-allowed"
           }`}


### PR DESCRIPTION
Closes #270.

## Summary
- replace the single code field with a 6-cell OTP entry
- support paste, backspace focus movement, and arrow-key navigation
- keep Continue disabled until the 6-character code is complete
- add inline status messaging and a 30-second resend cooldown with an aria-live announcement
- add focused tests for completion gating, paste handling, and resend cooldown

## Validation
- `node node_modules/vitest/vitest.mjs run app/verify-email/page.test.tsx` -> passed (3 tests)
- `git diff --check` -> passed (line-ending warnings only)

## Existing local blocker
- `tsc --noEmit --pretty false` still fails on the existing `vitest.config.ts(10,5)` type mismatch, unrelated to this change