### PR TITLE
feat: add dashboard hook refetch retries

### DIFF
--- a/app/metadata.test.ts
+++ b/app/metadata.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/font/google", () => ({
+  Inter: () => ({ variable: "font-inter" }),
+}));
+
+vi.mock("next/font/local", () => ({
+  default: () => ({ variable: "font-local" }),
+}));
 
 import { metadata as rootMetadata } from "@/app/layout";
 import { metadata as dashboardMetadata } from "@/app/dashboard/layout";

--- a/app/settings/preferences/components/account-section.tsx
+++ b/app/settings/preferences/components/account-section.tsx
@@ -74,9 +74,7 @@ export default function AccountSection() {
     type: null,
   });
   const [isSaving, setIsSaving] = useState(false);
-  const statusTimeoutRef = useRef<ReturnType<typeof window.setTimeout> | null>(
-    null,
-  );
+  const statusTimeoutRef = useRef<number | null>(null);
   const isMountedRef = useRef(true);
 
   useEffect(() => {

--- a/components/dashboard/account-summary.test.tsx
+++ b/components/dashboard/account-summary.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+import AccountSummary from "./account-summary";
+
+const mockUseAccountSummary = vi.fn();
+
+vi.mock("@/hooks/useAccountSummary", () => ({
+  useAccountSummary: () => mockUseAccountSummary(),
+}));
+
+describe("AccountSummary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls the hook refetch callback from the dashboard error state", () => {
+    const refetch = vi.fn();
+    mockUseAccountSummary.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: "Account summary failed",
+      refetch,
+    });
+
+    render(<AccountSummary />);
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/dashboard/account-summary.tsx
+++ b/components/dashboard/account-summary.tsx
@@ -4,12 +4,13 @@ import { useState } from "react";
 import Image from "next/image";
 import { copyToClipboardWithTimeout } from "@/utils/clipboardUtils";
 import { AccountSummaryCardSkeleton } from "@/components/ui/card-skeleton";
+import { ErrorState } from "@/components/ui/error-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAccountSummary } from "@/hooks/useAccountSummary";
 
 export default function AccountSummary() {
   const [copied, setCopied] = useState(false);
-  const { data, isLoading, error } = useAccountSummary();
+  const { data, isLoading, error, refetch } = useAccountSummary();
 
   if (isLoading) {
     return (
@@ -29,11 +30,12 @@ export default function AccountSummary() {
 
   if (error || !data) {
     return (
-      <div
-        role="alert"
-        className="max-w-full p-4 rounded-xl my-6 border-[1px] border-[#2D2D2D] bg-[#0D0D0D80] text-red-400 text-sm text-center"
-      >
-        Failed to load account summary.
+      <div className="max-w-full my-6">
+        <ErrorState
+          title="Failed to Load"
+          description="Failed to load account summary."
+          onRetry={refetch}
+        />
       </div>
     );
   }

--- a/components/dashboard/payment-history.test.tsx
+++ b/components/dashboard/payment-history.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+import PaymentHistory from "./payment-history";
+
+const mockUsePaymentHistory = vi.fn();
+
+vi.mock("@/hooks/usePaymentHistory", () => ({
+  usePaymentHistory: () => mockUsePaymentHistory(),
+}));
+
+describe("PaymentHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls the hook refetch callback from the dashboard error state", () => {
+    const refetch = vi.fn();
+
+    mockUsePaymentHistory.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: "Payment history failed",
+      refetch,
+    });
+
+    render(<PaymentHistory />);
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/dashboard/payment-history.tsx
+++ b/components/dashboard/payment-history.tsx
@@ -7,7 +7,7 @@ import { ErrorState } from "@/components/ui/error-state";
 import { EmptyState } from "@/components/ui/empty-state";
 
 export default function PaymentHistory() {
-  const { data, isLoading, error } = usePaymentHistory();
+  const { data, isLoading, error, refetch } = usePaymentHistory();
 
   if (isLoading) {
     return (
@@ -24,7 +24,7 @@ export default function PaymentHistory() {
       <ErrorState
         title="Failed to Load"
         description="Failed to load payment history."
-        onRetry={() => window.location.reload()}
+        onRetry={refetch}
       />
     );
   }

--- a/hooks/useAccountSummary.test.ts
+++ b/hooks/useAccountSummary.test.ts
@@ -1,0 +1,99 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi, type Mock } from "vitest";
+
+import { useAccountSummary } from "./useAccountSummary";
+import { getAccountSummary, type AccountSummary } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  getAccountSummary: vi.fn(),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+const summary = (walletAddress: string): AccountSummary => ({
+  balance: "$ 2,432 USDC",
+  balanceRaw: 2432,
+  paidThisMonth: "$ 0",
+  paidThisMonthCount: 0,
+  toBePaid: "$ 0",
+  toBePaidCount: 0,
+  walletAddress,
+});
+
+describe("useAccountSummary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exposes refetch and clears a stale error before retrying", async () => {
+    (getAccountSummary as Mock)
+      .mockRejectedValueOnce(new Error("Network unavailable"))
+      .mockResolvedValueOnce(summary("retry-wallet"));
+
+    const { result } = renderHook(() => useAccountSummary());
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("Network unavailable");
+    });
+
+    expect(typeof result.current.refetch).toBe("function");
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.data?.walletAddress).toBe("retry-wallet");
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it("keeps an older overlapping request from overwriting the latest refetch result", async () => {
+    const first = deferred<AccountSummary>();
+    const second = deferred<AccountSummary>();
+
+    (getAccountSummary as Mock)
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    const { result } = renderHook(() => useAccountSummary());
+
+    await waitFor(() => {
+      expect(getAccountSummary).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(getAccountSummary).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      second.resolve(summary("latest-wallet"));
+      await Promise.resolve();
+    });
+
+    expect(result.current.data?.walletAddress).toBe("latest-wallet");
+
+    await act(async () => {
+      first.resolve(summary("stale-wallet"));
+      await Promise.resolve();
+    });
+
+    expect(result.current.data?.walletAddress).toBe("latest-wallet");
+  });
+});

--- a/hooks/useAccountSummary.ts
+++ b/hooks/useAccountSummary.ts
@@ -1,35 +1,49 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { getAccountSummary, AccountSummary } from "@/lib/api";
 
 interface UseAccountSummaryResult {
   data: AccountSummary | null;
   isLoading: boolean;
   error: string | null;
+  refetch: () => void;
 }
 
 /**
  * Hook to fetch account summary data for the dashboard.
+ * Returns a stable `refetch` callback so error states can retry without remounting.
  */
 export function useAccountSummary(): UseAccountSummaryResult {
   const [data, setData] = useState<AccountSummary | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [requestTick, setRequestTick] = useState(0);
+  const latestRequestId = useRef(0);
+
+  const refetch = useCallback(() => {
+    setError(null);
+    setIsLoading(true);
+    setRequestTick((tick) => tick + 1);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
+    const requestId = latestRequestId.current + 1;
+    latestRequestId.current = requestId;
+
     setIsLoading(true);
+    setError(null);
 
     getAccountSummary()
       .then((result) => {
-        if (!cancelled) {
+        if (!cancelled && requestId === latestRequestId.current) {
           setData(result);
           setIsLoading(false);
         }
       })
       .catch((err: unknown) => {
-        if (!cancelled) {
+        if (!cancelled && requestId === latestRequestId.current) {
           setError(
             err instanceof Error ? err.message : "Failed to load account summary"
           );
@@ -40,7 +54,7 @@ export function useAccountSummary(): UseAccountSummaryResult {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [requestTick]);
 
-  return { data, isLoading, error };
+  return { data, isLoading, error, refetch };
 }

--- a/hooks/usePaymentHistory.test.ts
+++ b/hooks/usePaymentHistory.test.ts
@@ -1,0 +1,72 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi, type Mock } from "vitest";
+
+import { usePaymentHistory } from "./usePaymentHistory";
+import { getPaymentHistory, type PaymentHistoryItem } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  getPaymentHistory: vi.fn(),
+}));
+
+const historyItems: PaymentHistoryItem[] = [
+  {
+    id: "payment-1",
+    paymentDescription: "Payment Received",
+    paymentId: "#PAY-1",
+    history: "Received 42 USDC",
+  },
+];
+
+describe("usePaymentHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exposes refetch and recovers from an error without remounting", async () => {
+    (getPaymentHistory as Mock)
+      .mockRejectedValueOnce(new Error("History unavailable"))
+      .mockResolvedValueOnce(historyItems);
+
+    const { result } = renderHook(() => usePaymentHistory());
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("History unavailable");
+    });
+
+    expect(typeof result.current.refetch).toBe("function");
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(historyItems);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it("does not update state after the hook is unmounted", async () => {
+    let resolveHistory!: (value: PaymentHistoryItem[]) => void;
+    (getPaymentHistory as Mock).mockReturnValue(
+      new Promise<PaymentHistoryItem[]>((resolve) => {
+        resolveHistory = resolve;
+      })
+    );
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { unmount } = renderHook(() => usePaymentHistory());
+    unmount();
+
+    await act(async () => {
+      resolveHistory(historyItems);
+      await Promise.resolve();
+    });
+
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/hooks/usePaymentHistory.ts
+++ b/hooks/usePaymentHistory.ts
@@ -1,35 +1,49 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { getPaymentHistory, PaymentHistoryItem } from "@/lib/api";
 
 interface UsePaymentHistoryResult {
   data: PaymentHistoryItem[];
   isLoading: boolean;
   error: string | null;
+  refetch: () => void;
 }
 
 /**
  * Hook to fetch payment history items for the dashboard sidebar.
+ * Returns a stable `refetch` callback so error states can retry without remounting.
  */
 export function usePaymentHistory(): UsePaymentHistoryResult {
   const [data, setData] = useState<PaymentHistoryItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [requestTick, setRequestTick] = useState(0);
+  const latestRequestId = useRef(0);
+
+  const refetch = useCallback(() => {
+    setError(null);
+    setIsLoading(true);
+    setRequestTick((tick) => tick + 1);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
+    const requestId = latestRequestId.current + 1;
+    latestRequestId.current = requestId;
+
     setIsLoading(true);
+    setError(null);
 
     getPaymentHistory()
       .then((result) => {
-        if (!cancelled) {
+        if (!cancelled && requestId === latestRequestId.current) {
           setData(result);
           setIsLoading(false);
         }
       })
       .catch((err: unknown) => {
-        if (!cancelled) {
+        if (!cancelled && requestId === latestRequestId.current) {
           setError(
             err instanceof Error ? err.message : "Failed to load payment history"
           );
@@ -40,7 +54,7 @@ export function usePaymentHistory(): UsePaymentHistoryResult {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [requestTick]);
 
-  return { data, isLoading, error };
+  return { data, isLoading, error, refetch };
 }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,7 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
 };
 
 export default config;


### PR DESCRIPTION
Closes #321

## Summary
- add stable `refetch` callbacks to `useAccountSummary` and `usePaymentHistory`
- clear stale errors before retries and guard commits with request ids plus the existing cleanup cancellation pattern
- wire dashboard error states to retry in place instead of requiring a remount or page reload
- add focused hook and dashboard tests for retry, recovery, stale request protection, and unmount cleanup
- fix small validation blockers in the test/type environment so the requested verification commands run cleanly

## Security / race-safety notes
- overlapping requests are guarded by a monotonically increasing request id, so older responses cannot overwrite a newer refetch result
- each effect still keeps a cancellation flag so resolved promises do not update state after unmount

## Validation
- `npx vitest run hooks/useAccountSummary.test.ts hooks/usePaymentHistory.test.ts components/dashboard/account-summary.test.tsx components/dashboard/payment-history.test.tsx`
- `npx vitest run hooks/useTransactions.test.ts components/analytics/analytics-view.test.tsx components/ui/error-state.test.tsx`
- `npm run type-check`
- `npm run lint` (passes with existing warnings in `components/common/toggle-card.tsx` and `components/transactions/transactions-content.test.tsx`)
- `npm test` (28 files, 239 tests, coverage: 98.16% statements / 97.74% branches / 100% functions / 99.2% lines)
- `npm run build` (passes with the same existing lint warnings plus Next metadataBase warning)
- `git diff --check`