### PR TITLE
test(e2e): add firefox/webkit projects and retries to playwright config

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,27 @@ stellopay-frontend
 
 - `npm run test` runs the Vitest unit suite with coverage for auth, transaction, and pagination utils plus auth schemas.
 - `npm run test:watch` runs Vitest in watch mode while developing unit tests.
-- `npm run test:e2e` is the Playwright local/E2E command.
+- `npm run test:e2e` runs the full Playwright suite across **chromium**, **firefox**, and **webkit**.
+
+### Running a single browser locally
+
+Pass `--project=<name>` to target one browser:
+
+```bash
+npx playwright test --project=chromium
+npx playwright test --project=firefox
+npx playwright test --project=webkit
+```
+
+You can also scope to a single spec file at the same time:
+
+```bash
+npx playwright test tests/wallet.spec.ts --project=firefox
+```
+
+### Retries
+
+Tests run with **0 retries** locally. In CI (`CI=true`) each test is retried up to **2 times** to absorb transient flakes.
 
 ## Iconography
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// Retry twice in CI to absorb transient flakes; run clean locally.
+const isCI = !!process.env.CI;
+
 export default defineConfig({
   testDir: ".",
   testMatch: ["tests/**/*.spec.ts", "e2e/**/*.spec.ts"],
@@ -7,16 +10,27 @@ export default defineConfig({
   // NetworkSwitcher integration; the first cold compile under `next dev`
   // routinely needs more than the previous 60s budget.
   timeout: 180_000,
+  retries: isCI ? 2 : 0,
+  // Keep workers:1 so independent tests don't race on the single dev server.
   fullyParallel: false,
   workers: 1,
   use: {
-    baseURL: "http://127.0.0.1:3000",
+    baseURL: process.env.BASE_URL ?? "http://127.0.0.1:3000",
     trace: "retain-on-failure",
   },
   projects: [
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      // webkit — covers Safari rendering and dialog behaviour
+      use: { ...devices["Desktop Safari"] },
     },
   ],
   webServer: {


### PR DESCRIPTION
## Summary

Resolves cross-browser coverage gap reported in issue #334.

### Changes

- **`playwright.config.ts`** — adds `firefox` and `webkit` projects alongside the existing `chromium` project; configures `retries: 2` in CI (`CI=true`), `0` locally; reads `BASE_URL` from environment so the base URL is never committed.
- **`README.md`** — documents running a single browser with `--project=<name>` and the retry behaviour.

### Testing

All existing specs in `tests/` and `e2e/` are browser-agnostic and pass on all three engines. No secrets are baked into the config.

### Security

Base URLs and credentials are read from environment variables (`BASE_URL`), not committed to the config.

Closes #334