### PR TITLE
fix(verify-email): add accessible labeling and live validation to code input

### DIFF
--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { X, Loader2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
 
 type StatusType = "idle" | "loading" | "success" | "error";
 
@@ -12,10 +13,28 @@ export default function VerifyEmail() {
   const [status, setStatus] = useState<StatusType>("idle");
   const [message, setMessage] = useState("");
   const [resendStatus, setResendStatus] = useState<StatusType>("idle");
+  const [fieldError, setFieldError] = useState("");
+  const [truncated, setTruncated] = useState(false);
+
+  const codeDescId = "verify-code-desc";
+  const codeErrorId = "verify-code-error";
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/[^0-9a-zA-Z]/g, "");
-    if (value.length <= 6) setCode(value);
+    const raw = e.target.value;
+    const sanitized = raw.replace(/[^0-9a-zA-Z]/g, "");
+    if (sanitized.length > 6) {
+      setCode(sanitized.slice(0, 6));
+      setTruncated(true);
+      setTimeout(() => setTruncated(false), 3000);
+    } else {
+      setCode(sanitized);
+      setTruncated(false);
+    }
+    if (sanitized.length > 0 && sanitized.length < 6) {
+      setFieldError("Code must be 6 characters.");
+    } else {
+      setFieldError("");
+    }
   };
 
   const handleResend = async () => {
@@ -92,17 +111,40 @@ export default function VerifyEmail() {
           </button>
         </p>
 
-        {/* Input */}
-        <input
-          type="text"
-          inputMode="numeric"
-          maxLength={6}
-          value={code}
-          onChange={handleInputChange}
-          aria-label="Verification code"
-          className="w-full text-left py-3 px-4 rounded-[8px] border border-[#2D2D2D] bg-transparent text-white mb-4 outline-none mt-5"
-          placeholder="- - - - - - - -"
-        />
+        {/* Code input */}
+        <div className="text-left mt-5 mb-4">
+          <label htmlFor="verify-code" className="sr-only">
+            Verification code
+          </label>
+          <p id={codeDescId} className="text-xs text-[#ACB4B5] mb-2">
+            Enter the 6-character code sent to your email.
+          </p>
+          <Input
+            id="verify-code"
+            name="verify-code"
+            type="text"
+            inputMode="numeric"
+            maxLength={6}
+            value={code}
+            onChange={handleInputChange}
+            aria-label="Verification code"
+            placeholder="- - - - - - - -"
+            className="w-full text-left py-3 px-4 rounded-[8px] border border-[#2D2D2D] bg-transparent text-white outline-none"
+            error={!!fieldError}
+            descriptionId={codeDescId}
+            errorId={codeErrorId}
+          />
+          {fieldError && (
+            <p id={codeErrorId} role="alert" className="text-xs text-red-300 mt-1">
+              {fieldError}
+            </p>
+          )}
+          {truncated && (
+            <p role="status" aria-live="polite" className="text-xs text-yellow-300 mt-1">
+              Code truncated to 6 characters.
+            </p>
+          )}
+        </div>
 
         {/* Status Messages */}
         {message && (

--- a/tests/verify-email.spec.ts
+++ b/tests/verify-email.spec.ts
@@ -95,6 +95,71 @@ test.describe("Verify email — code input", () => {
     await input.fill("12-34$");
     await expect(input).toHaveValue("1234");
   });
+
+  test("input has accessible id and name attributes", async ({ page }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    await expect(input).toHaveId("verify-code");
+    await expect(input).toHaveAttribute("name", "verify-code");
+  });
+
+  test("input is reachable via its associated label", async ({ page }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    await expect(input).toBeVisible();
+    await expect(input).toHaveAttribute("id", "verify-code");
+  });
+
+  test("shows inline validation error for short code", async ({ page }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    await input.fill("12");
+    await expect(page.getByRole("alert")).toContainText(
+      /code must be 6 characters/i,
+    );
+  });
+
+  test("input has aria-invalid when inline error is present", async ({
+    page,
+  }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    await input.fill("12");
+    await expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  test("clears inline validation when 6 characters entered", async ({
+    page,
+  }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    await input.fill("123");
+    await expect(page.getByRole("alert")).toContainText(
+      /code must be 6 characters/i,
+    );
+    await input.fill("123456");
+    await expect(page.getByRole("alert")).not.toBeVisible();
+  });
+
+  test("shows feedback when pasted code is truncated to 6 characters", async ({
+    page,
+  }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+    // Simulate a paste that bypasses maxLength
+    await input.evaluate((el) => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      nativeInputValueSetter?.call(el, "ABCDEFG");
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await expect(input).toHaveValue("ABCDEF");
+    await expect(
+      page.getByText("Code truncated to 6 characters."),
+    ).toBeVisible();
+  });
 });
 
 test.describe("Verify email — resend action", () => {


### PR DESCRIPTION
## Summary

Adds proper id, name, label, and ARIA attributes to the verification code input in app/verify-email/page.tsx, along with inline validation and truncation feedback.

## Changes

### app/verify-email/page.tsx
- Replaced plain input with the shared Input component which natively supports aria-describedby, aria-invalid, descriptionId, and errorId.
- Added id=verify-code, name=verify-code, and a label htmlFor=verify-code (screen-reader-only via sr-only) for proper label association.
- Added aria-describedby pointing to a description element and an error element.
- Added aria-invalid set when inline validation fails.
- Added inline validation: an error message appears as the user types when the code is between 1-5 characters.
- Added truncation feedback: when a pasted code exceeds 6 characters, it is truncated and a message is shown for 3 seconds.

### tests/verify-email.spec.ts
Added 6 new Playwright tests for id/name attributes, label reachability, inline validation, aria-invalid, validation clearing, and truncation feedback.

Closes #329