### PR TITLE
fix(verify-email): add accessible code input validation

### DIFF
--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -6,16 +6,44 @@ import { X, Loader2 } from "lucide-react";
 
 type StatusType = "idle" | "loading" | "success" | "error";
 
+/**
+ * Keeps the verification code limited to numeric characters and six digits.
+ * The entered code is never logged or exposed outside component state.
+ */
+const normalizeVerificationCode = (value: string) =>
+  value.replace(/\D/g, "").slice(0, 6);
+
 export default function VerifyEmail() {
   const [code, setCode] = useState("");
   const router = useRouter();
   const [status, setStatus] = useState<StatusType>("idle");
   const [message, setMessage] = useState("");
+  const [codeError, setCodeError] = useState("");
   const [resendStatus, setResendStatus] = useState<StatusType>("idle");
 
+  const codeInputId = "verification-code";
+  const codeHelpId = "verification-code-help";
+  const codeErrorId = "verification-code-error";
+  const codeDescriptionIds = codeError
+    ? `${codeHelpId} ${codeErrorId}`
+    : codeHelpId;
+
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/[^0-9a-zA-Z]/g, "");
-    if (value.length <= 6) setCode(value);
+    const rawValue = e.target.value;
+    const numericValue = rawValue.replace(/\D/g, "");
+    const normalizedValue = normalizeVerificationCode(rawValue);
+
+    setCode(normalizedValue);
+
+    if (rawValue !== numericValue) {
+      setCodeError("Verification codes can only contain numbers.");
+    } else if (numericValue.length > 6) {
+      setCodeError("Verification codes are 6 digits. Extra digits were removed.");
+    } else if (normalizedValue.length > 0 && normalizedValue.length < 6) {
+      setCodeError("Enter the full 6-digit verification code.");
+    } else {
+      setCodeError("");
+    }
   };
 
   const handleResend = async () => {
@@ -35,8 +63,14 @@ export default function VerifyEmail() {
   };
 
   const handleContinue = async () => {
+    if (code.length !== 6) {
+      setCodeError("Enter the full 6-digit verification code.");
+      return;
+    }
+
     setStatus("loading");
     setMessage("");
+    setCodeError("");
     try {
       // Simulate API call
       await new Promise((resolve, reject) =>
@@ -53,6 +87,7 @@ export default function VerifyEmail() {
     } catch {
       setStatus("error");
       setMessage("Invalid verification code. Please try again.");
+      setCodeError("Invalid verification code. Please try again.");
     } finally {
       setTimeout(() => setStatus("idle"), 3000);
     }
@@ -93,16 +128,36 @@ export default function VerifyEmail() {
         </p>
 
         {/* Input */}
+        <label htmlFor={codeInputId} className="sr-only">
+          Verification code
+        </label>
         <input
+          id={codeInputId}
+          name="verificationCode"
           type="text"
           inputMode="numeric"
-          maxLength={6}
+          required
           value={code}
           onChange={handleInputChange}
           aria-label="Verification code"
-          className="w-full text-left py-3 px-4 rounded-[8px] border border-[#2D2D2D] bg-transparent text-white mb-4 outline-none mt-5"
+          aria-describedby={codeDescriptionIds}
+          aria-invalid={codeError ? "true" : "false"}
+          className="w-full text-left py-3 px-4 rounded-[8px] border border-[#2D2D2D] bg-transparent text-white mb-2 outline-none mt-5"
           placeholder="- - - - - - - -"
         />
+        <p id={codeHelpId} className="text-left text-xs text-[#ACB4B5] mb-2">
+          Enter the 6-digit code sent to your email.
+        </p>
+        {codeError && (
+          <p
+            id={codeErrorId}
+            role="alert"
+            aria-live="polite"
+            className="text-left text-xs text-red-300 mb-4"
+          >
+            {codeError}
+          </p>
+        )}
 
         {/* Status Messages */}
         {message && (

--- a/tests/verify-email.spec.ts
+++ b/tests/verify-email.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 const VERIFY_EMAIL_URL = "/verify-email";
 
-test.describe("Verify email — code input", () => {
+test.describe("Verify email - code input", () => {
   test("renders the form without console errors", async ({ page }) => {
     const errors: string[] = [];
     page.on("pageerror", (err) => errors.push(err.message));
@@ -12,6 +12,24 @@ test.describe("Verify email — code input", () => {
       page.getByRole("heading", { name: /check your email/i }),
     ).toBeVisible();
     expect(errors).toHaveLength(0);
+  });
+
+  test("code input is reachable by label and exposes accessibility attributes", async ({
+    page,
+  }) => {
+    await page.goto(VERIFY_EMAIL_URL);
+    const input = page.getByLabel("Verification code");
+
+    await expect(input).toBeVisible();
+    await expect(input).toHaveAttribute("id", "verification-code");
+    await expect(input).toHaveAttribute("name", "verificationCode");
+    await expect(input).toHaveAttribute("inputmode", "numeric");
+    await expect(input).toHaveAttribute("required", "");
+    await expect(input).toHaveAttribute(
+      "aria-describedby",
+      "verification-code-help",
+    );
+    await expect(input).toHaveAttribute("aria-invalid", "false");
   });
 
   test("Continue button is disabled when code is empty", async ({ page }) => {
@@ -28,6 +46,10 @@ test.describe("Verify email — code input", () => {
     await input.fill("123");
     const continueBtn = page.getByRole("button", { name: /continue/i });
     await expect(continueBtn).toBeDisabled();
+    await expect(page.locator("#verification-code-error")).toContainText(
+      /enter the full 6-digit verification code/i,
+    );
+    await expect(input).toHaveAttribute("aria-invalid", "true");
   });
 
   test("Continue button is enabled with 6-digit code", async ({ page }) => {
@@ -36,6 +58,7 @@ test.describe("Verify email — code input", () => {
     await input.fill("123456");
     const continueBtn = page.getByRole("button", { name: /continue/i });
     await expect(continueBtn).toBeEnabled();
+    await expect(input).toHaveAttribute("aria-invalid", "false");
   });
 
   test("shows error for invalid verification code", async ({ page }) => {
@@ -44,6 +67,9 @@ test.describe("Verify email — code input", () => {
     await input.fill("000000");
     await page.getByRole("button", { name: /continue/i }).click();
     await expect(page.getByRole("status")).toContainText(
+      /invalid verification code/i,
+    );
+    await expect(page.locator("#verification-code-error")).toContainText(
       /invalid verification code/i,
     );
   });
@@ -82,22 +108,35 @@ test.describe("Verify email — code input", () => {
     ).toBeDisabled();
   });
 
-  test("input only accepts up to 6 characters", async ({ page }) => {
+  test("input only accepts up to 6 digits and communicates truncation", async ({
+    page,
+  }) => {
     await page.goto(VERIFY_EMAIL_URL);
     const input = page.getByLabel("Verification code");
     await input.fill("1234567");
     await expect(input).toHaveValue("123456");
+    await expect(page.locator("#verification-code-error")).toContainText(
+      /extra digits were removed/i,
+    );
+    await expect(input).toHaveAttribute(
+      "aria-describedby",
+      "verification-code-help verification-code-error",
+    );
+    await expect(input).toHaveAttribute("aria-invalid", "true");
   });
 
-  test("input strips non-alphanumeric characters", async ({ page }) => {
+  test("input strips non-numeric characters", async ({ page }) => {
     await page.goto(VERIFY_EMAIL_URL);
     const input = page.getByLabel("Verification code");
-    await input.fill("12-34$");
+    await input.fill("12ab-34$");
     await expect(input).toHaveValue("1234");
+    await expect(page.locator("#verification-code-error")).toContainText(
+      /verification codes can only contain numbers/i,
+    );
   });
 });
 
-test.describe("Verify email — resend action", () => {
+test.describe("Verify email - resend action", () => {
   test("Resend button triggers loading state then success message", async ({
     page,
   }) => {
@@ -121,7 +160,7 @@ test.describe("Verify email — resend action", () => {
   });
 });
 
-test.describe("Verify email — navigation", () => {
+test.describe("Verify email - navigation", () => {
   test("close button is visible with correct aria-label", async ({ page }) => {
     await page.goto(VERIFY_EMAIL_URL);
     const closeBtn = page.getByRole("button", { name: /close/i });


### PR DESCRIPTION
## Description

This PR updates the verification code input on the verify-email page to improve accessibility and validation.

I added the missing input attributes and ARIA connections so the field can be reached by label and properly described for assistive technologies. I also added inline validation so users get clear feedback when the code is incomplete, contains non-numeric characters, is invalid, or is shortened to the expected 6-digit format.

Changes included:

* Added `id`, `name`, hidden label, `aria-label`, `aria-describedby`, `aria-invalid`, `required`, and `inputMode="numeric"` to the verification code input.
* Added numeric-only handling for the verification code.
* Added inline feedback for incomplete, invalid, non-numeric, and too-long codes.
* Added visible feedback when a pasted code is shortened to 6 digits.
* Added a documented helper for normalizing the verification code.
* Updated the Playwright tests to cover the labeled input and validation cases.

## Related Issue

Closes #329

## Checklist

* [x] I have tested the changes locally.
* [x] I have added/updated documentation as needed.
* [x] I have reviewed the code and ensured it follows the project guidelines.
* [x] I have added necessary tests.

## Screenshots/Recordings

Not applicable. This PR does not introduce a visual layout change. It updates accessibility attributes, validation behavior, and test coverage.

## Additional Notes

Tested locally with:

* `npm run type-check`
* `.\node_modules\.bin\playwright.cmd test tests/verify-email.spec.ts`

Result: 45 passed locally.

Security notes:

* The verification code input only keeps numeric characters.
* The verification code is never logged.
