### PR TITLE
fix(settings): derive summary cards from live section state (#324)

### DIFF
--- a/app/settings/preferences/components/account-section.tsx
+++ b/app/settings/preferences/components/account-section.tsx
@@ -18,13 +18,44 @@ import { FormMessage } from "@/components/ui/form";
 import DestructiveActionDialog from "./destructive-action-dialog";
 import { DEMO_PROFILE } from "@/lib/demo-data";
 
-interface ProfileState {
+export interface ProfileState {
   firstName: string;
   lastName: string;
   displayName: string;
   email: string;
   timezone: string;
   currency: string;
+}
+
+/**
+ * Default profile values seeded from demo data. Exported so a parent surface
+ * (e.g. the settings summary cards) can own the same initial state when it
+ * lifts this section into a controlled component.
+ */
+export const DEFAULT_PROFILE: ProfileState = {
+  firstName: DEMO_PROFILE.firstName,
+  lastName: DEMO_PROFILE.lastName,
+  displayName: DEMO_PROFILE.displayName,
+  email: DEMO_PROFILE.email,
+  timezone: DEMO_PROFILE.timezone,
+  currency: DEMO_PROFILE.currency,
+};
+
+/** Number of profile fields that have a non-empty value. */
+export function countCompletedProfileFields(profile: ProfileState): number {
+  return (Object.values(profile) as string[]).filter(
+    (value) => value.trim().length > 0,
+  ).length;
+}
+
+/** Total number of profile fields tracked. */
+export function totalProfileFields(profile: ProfileState): number {
+  return Object.keys(profile).length;
+}
+
+/** A profile is "complete" once every tracked field is filled in. */
+export function isProfileComplete(profile: ProfileState): boolean {
+  return countCompletedProfileFields(profile) === totalProfileFields(profile);
 }
 
 interface StatusState {
@@ -60,15 +91,23 @@ const sectionMap = [
  * Renders user profile information, identity details, and regional settings.
  * Uses placeholder demo data pending full backend API integration.
  */
-export default function AccountSection() {
-  const [profile, setProfile] = useState<ProfileState>({
-    firstName: DEMO_PROFILE.firstName,
-    lastName: DEMO_PROFILE.lastName,
-    displayName: DEMO_PROFILE.displayName,
-    email: DEMO_PROFILE.email,
-    timezone: DEMO_PROFILE.timezone,
-    currency: DEMO_PROFILE.currency,
-  });
+interface AccountSectionProps {
+  /**
+   * Controlled profile state. When provided the component renders this value
+   * and reports edits through `onProfileChange`. When omitted the section
+   * manages its own internal state (standalone use).
+   */
+  profile?: ProfileState;
+  onProfileChange?: (next: ProfileState) => void;
+}
+
+export default function AccountSection({
+  profile: controlledProfile,
+  onProfileChange,
+}: AccountSectionProps = {}) {
+  const [internalProfile, setInternalProfile] =
+    useState<ProfileState>(DEFAULT_PROFILE);
+  const profile = controlledProfile ?? internalProfile;
   const [status, setStatus] = useState<StatusState>({
     message: "",
     type: null,
@@ -106,10 +145,12 @@ export default function AccountSection() {
   };
 
   const updateProfileField = (field: keyof ProfileState, value: string) => {
-    setProfile((currentProfile) => ({
-      ...currentProfile,
-      [field]: value,
-    }));
+    const next: ProfileState = { ...profile, [field]: value };
+    if (onProfileChange) {
+      onProfileChange(next);
+    } else {
+      setInternalProfile(next);
+    }
   };
 
   const handleSave = async () => {

--- a/app/settings/preferences/components/notifications-section.tsx
+++ b/app/settings/preferences/components/notifications-section.tsx
@@ -12,7 +12,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-interface NotificationSettingsState {
+export interface NotificationSettingsState {
   transactionAlerts: boolean;
   securityAlerts: boolean;
   productUpdates: boolean;
@@ -22,26 +22,60 @@ interface NotificationSettingsState {
   smsChannel: boolean;
 }
 
-export default function NotificationsSection() {
-  const [settings, setSettings] = useState<NotificationSettingsState>({
-    transactionAlerts: true,
-    securityAlerts: true,
-    productUpdates: true,
-    marketing: false,
-    emailChannel: true,
-    pushChannel: true,
-    smsChannel: false,
-  });
+/**
+ * Default notification preferences. Exported so a parent surface (e.g. the
+ * settings summary cards) can own the same initial state when it lifts this
+ * section into a controlled component.
+ */
+export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettingsState = {
+  transactionAlerts: true,
+  securityAlerts: true,
+  productUpdates: true,
+  marketing: false,
+  emailChannel: true,
+  pushChannel: true,
+  smsChannel: false,
+};
+
+/**
+ * Count how many notification preferences are currently enabled. Used by the
+ * settings summary "Alerts enabled" card so the number tracks real state.
+ */
+export function countActiveNotifications(
+  settings: NotificationSettingsState,
+): number {
+  return Object.values(settings).filter(Boolean).length;
+}
+
+interface NotificationsSectionProps {
+  /**
+   * Controlled notification state. When provided the component renders this
+   * value and reports edits through `onSettingsChange`. When omitted the
+   * section manages its own internal state (standalone use).
+   */
+  settings?: NotificationSettingsState;
+  onSettingsChange?: (next: NotificationSettingsState) => void;
+}
+
+export default function NotificationsSection({
+  settings: controlledSettings,
+  onSettingsChange,
+}: NotificationsSectionProps = {}) {
+  const [internalSettings, setInternalSettings] =
+    useState<NotificationSettingsState>(DEFAULT_NOTIFICATION_SETTINGS);
+  const settings = controlledSettings ?? internalSettings;
   const [statusMessage, setStatusMessage] = useState("");
 
   const updateSetting = (
     field: keyof NotificationSettingsState,
     value: boolean,
   ) => {
-    setSettings((currentSettings) => ({
-      ...currentSettings,
-      [field]: value,
-    }));
+    const next: NotificationSettingsState = { ...settings, [field]: value };
+    if (onSettingsChange) {
+      onSettingsChange(next);
+    } else {
+      setInternalSettings(next);
+    }
   };
 
   return (

--- a/app/settings/preferences/components/security-tab.tsx
+++ b/app/settings/preferences/components/security-tab.tsx
@@ -46,15 +46,41 @@ interface StatusState {
   type: "success" | "error" | null;
 }
 
+/** Default two-factor state, exported so a parent can own the same initial value. */
+export const DEFAULT_TWO_FACTOR_ENABLED = true;
+
+interface SecurityTabProps {
+  /**
+   * Controlled two-factor state. When provided the component renders this value
+   * and reports changes through `onTwoFactorEnabledChange`. When omitted the
+   * section manages its own internal state (standalone use).
+   */
+  twoFactorEnabled?: boolean;
+  onTwoFactorEnabledChange?: (next: boolean) => void;
+}
+
 /**
  * SecurityTab component.
  * Renders security-sensitive forms (password updates, two-factor authentication, active sessions).
  * Uses placeholder demo data pending full backend API integration.
  */
-export default function SecurityTab() {
+export default function SecurityTab({
+  twoFactorEnabled: controlledTwoFactor,
+  onTwoFactorEnabledChange,
+}: SecurityTabProps = {}) {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [twoFactorEnabled, setTwoFactorEnabled] = useState(true);
+  const [internalTwoFactor, setInternalTwoFactor] = useState(
+    DEFAULT_TWO_FACTOR_ENABLED,
+  );
+  const twoFactorEnabled = controlledTwoFactor ?? internalTwoFactor;
+  const setTwoFactorEnabled = (next: boolean) => {
+    if (onTwoFactorEnabledChange) {
+      onTwoFactorEnabledChange(next);
+    } else {
+      setInternalTwoFactor(next);
+    }
+  };
   const [loginApprovalEnabled, setLoginApprovalEnabled] = useState(true);
   const [transferApprovalEnabled, setTransferApprovalEnabled] = useState(true);
   const [status, setStatus] = useState<StatusState>({ message: "", type: null });

--- a/app/settings/preferences/components/settings-page-shell.test.tsx
+++ b/app/settings/preferences/components/settings-page-shell.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import SettingsPageShell from "./settings-page-shell";
+
+// next/navigation is only available inside the Next.js runtime; stub the two
+// hooks the shell calls so it can render under jsdom.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  usePathname: () => "/settings/preferences",
+}));
+
+// AccountSection renders an avatar with next/image, which jsdom cannot load.
+vi.mock("next/image", () => ({
+  default: ({
+    alt,
+    priority: _priority,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & { priority?: boolean }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} {...props} />
+  ),
+}));
+
+/** Return the summary card element identified by its label text. */
+function summaryValue(label: string): HTMLElement {
+  const card = screen.getByText(label).closest('[data-slot="card"]');
+  if (!card) throw new Error(`Summary card for "${label}" not found`);
+  return card as HTMLElement;
+}
+
+describe("SettingsPageShell summary cards", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("derives every summary card value from live state, not hardcoded copy", () => {
+    render(<SettingsPageShell />);
+
+    // Defaults: profile fully seeded, 5 notification prefs on, 2FA on, 2 wallets.
+    expect(within(summaryValue("Profile readiness")).getByText("Complete"))
+      .toBeInTheDocument();
+    expect(within(summaryValue("Alerts enabled")).getByText("5 active"))
+      .toBeInTheDocument();
+    expect(within(summaryValue("Security posture")).getByText("2-step on"))
+      .toBeInTheDocument();
+    expect(within(summaryValue("Wallet coverage")).getByText("2 linked"))
+      .toBeInTheDocument();
+  });
+
+  it("updates the Alerts enabled card when a notification toggle changes", () => {
+    // Open straight on the Notifications section so its toggles are mounted.
+    render(<SettingsPageShell initialSection="notifications" />);
+
+    expect(within(summaryValue("Alerts enabled")).getByText("5 active"))
+      .toBeInTheDocument();
+
+    // Disable one alert in the section editor.
+    const transactionToggle = screen.getByRole("switch", {
+      name: /transaction alerts, enabled/i,
+    });
+    fireEvent.click(transactionToggle);
+
+    // The always-visible summary card reflects the change immediately.
+    expect(within(summaryValue("Alerts enabled")).getByText("4 active"))
+      .toBeInTheDocument();
+    expect(
+      within(summaryValue("Alerts enabled")).queryByText("5 active"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/settings/preferences/components/settings-page-shell.tsx
+++ b/app/settings/preferences/components/settings-page-shell.tsx
@@ -14,10 +14,26 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
-import AccountSection from "./account-section";
-import NotificationsSection from "./notifications-section";
-import SecurityTab from "./security-tab";
+import { DEMO_WALLETS } from "@/lib/demo-data";
+import AccountSection, {
+  DEFAULT_PROFILE,
+  isProfileComplete,
+  countCompletedProfileFields,
+  totalProfileFields,
+} from "./account-section";
+import NotificationsSection, {
+  DEFAULT_NOTIFICATION_SETTINGS,
+  countActiveNotifications,
+} from "./notifications-section";
+import SecurityTab, { DEFAULT_TWO_FACTOR_ENABLED } from "./security-tab";
 import WalletsSection from "./wallets-section";
+
+/**
+ * Number of wallets currently linked. Sourced from the wallets data the
+ * Wallets section renders (eventually `useWallet()` context) rather than a
+ * hardcoded "2 linked" literal so the summary stays in sync with reality.
+ */
+const linkedWalletCount = DEMO_WALLETS.length;
 
 const sections: SettingsHeaderSection[] = [
   {
@@ -42,7 +58,7 @@ const sections: SettingsHeaderSection[] = [
     value: "wallets",
     label: "Wallets",
     description: "Connected wallets and transfer safeguards.",
-    badge: "2 linked",
+    badge: `${linkedWalletCount} linked`,
   },
 ];
 
@@ -61,6 +77,25 @@ export default function SettingsPageShell({
     ? initialSection!
     : "account";
   const [activeSection, setActiveSection] = useState(resolvedInitialSection);
+
+  // The shell owns the summary-relevant slice of each section's state so the
+  // summary cards and the section editors share a single source of truth. The
+  // sections fall back to their own internal state when rendered standalone.
+  const [profile, setProfile] = useState(DEFAULT_PROFILE);
+  const [notificationSettings, setNotificationSettings] = useState(
+    DEFAULT_NOTIFICATION_SETTINGS,
+  );
+  const [twoFactorEnabled, setTwoFactorEnabled] = useState(
+    DEFAULT_TWO_FACTOR_ENABLED,
+  );
+
+  // Summary card values, derived from live state rather than hardcoded copy.
+  const profileReadiness = isProfileComplete(profile)
+    ? "Complete"
+    : `${countCompletedProfileFields(profile)}/${totalProfileFields(profile)} done`;
+  const activeAlerts = countActiveNotifications(notificationSettings);
+  const securityPosture = twoFactorEnabled ? "2-step on" : "2-step off";
+  const walletCoverage = `${linkedWalletCount} linked`;
 
   const handleSectionChange = (nextSection: string) => {
     setActiveSection(nextSection);
@@ -87,39 +122,45 @@ export default function SettingsPageShell({
           <SummaryCard
             icon={UserRound}
             label="Profile readiness"
-            value="Complete"
+            value={profileReadiness}
             description="Identity, locale, and billing defaults are grouped together."
           />
           <SummaryCard
             icon={Bell}
             label="Alerts enabled"
-            value="5 active"
+            value={`${activeAlerts} active`}
             description="Critical alerts remain above lower-priority updates."
           />
           <SummaryCard
             icon={Shield}
             label="Security posture"
-            value="2-step on"
+            value={securityPosture}
             description="Password, verification, and session controls share one section."
           />
           <SummaryCard
             icon={Wallet}
             label="Wallet coverage"
-            value="2 linked"
+            value={walletCoverage}
             description="Connected wallets sit next to transfer safeguards."
           />
         </section>
 
         <TabsContent value="account" className="mt-0">
-          <AccountSection />
+          <AccountSection profile={profile} onProfileChange={setProfile} />
         </TabsContent>
 
         <TabsContent value="notifications" className="mt-0">
-          <NotificationsSection />
+          <NotificationsSection
+            settings={notificationSettings}
+            onSettingsChange={setNotificationSettings}
+          />
         </TabsContent>
 
         <TabsContent value="security" className="mt-0">
-          <SecurityTab />
+          <SecurityTab
+            twoFactorEnabled={twoFactorEnabled}
+            onTwoFactorEnabledChange={setTwoFactorEnabled}
+          />
         </TabsContent>
 
         <TabsContent value="wallets" className="mt-0">


### PR DESCRIPTION
Closes #324

I have now been assigned to this issue — re-raising the PR per the assignment-first workflow (apologies for the earlier premature #447).

## Problem
The Settings summary cards rendered hard-coded values (`Complete`, `5 active`, `2-step on`, `2 linked`) that never reacted to edits made in the individual sections.

## Fix
Lifted notifications / security / profile state up into `settings-page-shell` as a single source of truth, so all four summary cards are derived from live state. Wallet count is derived from `DEMO_WALLETS.length`. Each section now accepts optional controlled props with an internal fallback, so existing tests and usages are untouched.

## Verification
- Settings tests: 10/10 passed (incl. new `settings-page-shell.test.tsx` — defaults + live-update Alerts 5->4)
- Full suite: 231 passed (1 pre-existing PostCSS metadata.test.ts failure, present on clean main)
- `npm run lint` clean for changed files; `tsc` only the pre-existing window.setTimeout typing in account-section

Fully satisfies the acceptance criteria of #324.