### PR TITLE
refactor(auth): centralize password policy schema across forms

### DIFF
--- a/app/settings/preferences/components/security-tab.tsx
+++ b/app/settings/preferences/components/security-tab.tsx
@@ -25,6 +25,7 @@ import DestructiveActionDialog from "./destructive-action-dialog";
 import { Label } from "@/components/ui/label";
 import { FormMessage } from "@/components/ui/form";
 import { DEMO_SECURITY } from "@/lib/demo-data";
+import { passwordPolicy, passwordSchema } from "@/types/auth";
 
 const sessions = [
   {
@@ -44,6 +45,28 @@ const sessions = [
 interface StatusState {
   message: string;
   type: "success" | "error" | null;
+}
+
+function getPasswordValidationMessages(
+  password: string,
+  confirmPassword: string,
+) {
+  const messages: string[] = [];
+
+  if (password.length === 0) {
+    return messages;
+  }
+
+  const parsedPassword = passwordSchema.safeParse(password);
+  if (!parsedPassword.success) {
+    messages.push(...parsedPassword.error.issues.map((issue) => issue.message));
+  }
+
+  if (password !== confirmPassword) {
+    messages.push("Passwords don't match");
+  }
+
+  return messages;
 }
 
 /** Default two-factor state, exported so a parent can own the same initial value. */
@@ -83,10 +106,17 @@ export default function SecurityTab({
   };
   const [loginApprovalEnabled, setLoginApprovalEnabled] = useState(true);
   const [transferApprovalEnabled, setTransferApprovalEnabled] = useState(true);
-  const [status, setStatus] = useState<StatusState>({ message: "", type: null });
+  const [status, setStatus] = useState<StatusState>({
+    message: "",
+    type: null,
+  });
   const [isSaving, setIsSaving] = useState(false);
 
   const passwordRequirements = checkPasswordRequirements(password);
+  const passwordValidationMessages = getPasswordValidationMessages(
+    password,
+    confirmPassword,
+  );
   const isPasswordReady =
     Object.values(passwordRequirements).every(Boolean) &&
     password.length > 0 &&
@@ -94,20 +124,28 @@ export default function SecurityTab({
 
   const handleSaveChanges = async () => {
     if (!isPasswordReady) {
+      setStatus({
+        message:
+          passwordValidationMessages[0] ?? "Password policy not satisfied.",
+        type: "error",
+      });
       return;
     }
     setIsSaving(true);
     setStatus({ message: "", type: null });
     try {
-      await new Promise((resolve, reject) => setTimeout(() => {
-        if (Math.random() > 0.8) {
-          reject(new Error("Failed to save"));
-        } else {
-          resolve(null);
-        }
-      }, 1500));
+      await new Promise((resolve, reject) =>
+        setTimeout(() => {
+          if (Math.random() > 0.8) {
+            reject(new Error("Failed to save"));
+          } else {
+            resolve(null);
+          }
+        }, 1500),
+      );
       setStatus({
-        message: "Password policy satisfied. Changes are ready for backend wiring.",
+        message:
+          "Password policy satisfied. Changes are ready for backend wiring.",
         type: "success",
       });
       setPassword("");
@@ -185,30 +223,46 @@ export default function SecurityTab({
           </div>
 
           <div className="grid gap-3 sm:grid-cols-2">
-            <RequirementItem
-              label="At least 8 characters"
-              met={passwordRequirements.minLength}
-            />
-            <RequirementItem
-              label="One uppercase letter"
-              met={passwordRequirements.uppercase}
-            />
-            <RequirementItem
-              label="One special character"
-              met={passwordRequirements.specialChar}
-            />
+            {passwordPolicy.rules.map((rule) => {
+              const met =
+                rule.id === "minLength"
+                  ? passwordRequirements.minLength
+                  : rule.id === "uppercase"
+                    ? passwordRequirements.uppercase
+                    : passwordRequirements.specialChar;
+
+              return (
+                <RequirementItem key={rule.id} label={rule.label} met={met} />
+              );
+            })}
             <RequirementItem
               label="Passwords match"
               met={password.length > 0 && password === confirmPassword}
             />
           </div>
 
+          {password.length > 0 && passwordValidationMessages.length > 0 && (
+            <div className="rounded-2xl border border-destructive/20 bg-destructive/10 p-3">
+              <p className="text-sm font-medium text-destructive">
+                {passwordPolicy.title}
+              </p>
+              <ul className="mt-2 space-y-1 text-sm text-destructive">
+                {passwordValidationMessages.map((message) => (
+                  <li key={message}>• {message}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <p className="text-sm text-zinc-500 dark:text-zinc-400">
               Recovery methods stay hidden until needed to keep the primary path
               calm.
             </p>
-            <Button disabled={!isPasswordReady || isSaving} onClick={handleSaveChanges}>
+            <Button
+              disabled={!isPasswordReady || isSaving}
+              onClick={handleSaveChanges}
+            >
               {isSaving ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -232,7 +286,11 @@ export default function SecurityTab({
             >
               <FormMessage
                 variant={status.type === "success" ? "success" : "error"}
-                className={status.type === "success" ? "text-success" : "text-destructive"}
+                className={
+                  status.type === "success"
+                    ? "text-success"
+                    : "text-destructive"
+                }
               >
                 {status.message}
               </FormMessage>
@@ -353,7 +411,8 @@ export default function SecurityTab({
               confirmLabel="Force sign-out"
               onConfirm={() =>
                 setStatus({
-                  message: "Session reset requested. All other devices would be signed out.",
+                  message:
+                    "Session reset requested. All other devices would be signed out.",
                   type: "success",
                 })
               }

--- a/components/auth/sign-up/sign-up-form.tsx
+++ b/components/auth/sign-up/sign-up-form.tsx
@@ -15,7 +15,7 @@ import { Separator } from "@/components/ui/separator";
 import { Check, X } from "lucide-react";
 import { SignUpEmailModal } from "./sign-up-email-modal";
 import { AuthSocialButtons } from "../auth-social-buttons";
-import { signUpSchema, SignUpFormValues } from "@/types/auth";
+import { passwordPolicy, signUpSchema, SignUpFormValues } from "@/types/auth";
 import { checkPasswordRequirements } from "@/utils/authUtils";
 
 /**
@@ -147,84 +147,43 @@ export function SignUpForm() {
               aria-live="polite"
             >
               <p className="text-gray-300 text-sm mb-2">
-                Password must contain:
+                {passwordPolicy.title}
               </p>
               <ul
                 className="space-y-1"
                 aria-label="Password requirements checklist"
               >
-                <li className="flex items-center text-sm">
-                  {passwordRequirements.minLength ? (
-                    <Check
-                      size={16}
-                      className="text-green-400 mr-2"
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    <X
-                      size={16}
-                      className="text-red-400 mr-2"
-                      aria-hidden="true"
-                    />
-                  )}
-                  <span
-                    className={
-                      passwordRequirements.minLength
-                        ? "text-green-400"
-                        : "text-gray-300"
-                    }
-                  >
-                    Minimum of 8 characters
-                  </span>
-                </li>
-                <li className="flex items-center text-sm">
-                  {passwordRequirements.uppercase ? (
-                    <Check
-                      size={16}
-                      className="text-green-400 mr-2"
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    <X
-                      size={16}
-                      className="text-red-400 mr-2"
-                      aria-hidden="true"
-                    />
-                  )}
-                  <span
-                    className={
-                      passwordRequirements.uppercase
-                        ? "text-green-400"
-                        : "text-gray-300"
-                    }
-                  >
-                    One UPPERCASE character
-                  </span>
-                </li>
-                <li className="flex items-center text-sm">
-                  {passwordRequirements.specialChar ? (
-                    <Check
-                      size={16}
-                      className="text-green-400 mr-2"
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    <X
-                      size={16}
-                      className="text-red-400 mr-2"
-                      aria-hidden="true"
-                    />
-                  )}
-                  <span
-                    className={
-                      passwordRequirements.specialChar
-                        ? "text-green-400"
-                        : "text-gray-300"
-                    }
-                  >
-                    One unique character (e.g., @!#%$^&*)
-                  </span>
-                </li>
+                {passwordPolicy.rules.map((rule) => {
+                  const isMet =
+                    rule.id === "minLength"
+                      ? passwordRequirements.minLength
+                      : rule.id === "uppercase"
+                        ? passwordRequirements.uppercase
+                        : passwordRequirements.specialChar;
+
+                  return (
+                    <li key={rule.id} className="flex items-center text-sm">
+                      {isMet ? (
+                        <Check
+                          size={16}
+                          className="text-green-400 mr-2"
+                          aria-hidden="true"
+                        />
+                      ) : (
+                        <X
+                          size={16}
+                          className="text-red-400 mr-2"
+                          aria-hidden="true"
+                        />
+                      )}
+                      <span
+                        className={isMet ? "text-green-400" : "text-gray-300"}
+                      >
+                        {rule.label}
+                      </span>
+                    </li>
+                  );
+                })}
               </ul>
               {isPasswordStrong && (
                 <p

--- a/types/auth.test.ts
+++ b/types/auth.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { loginSchema, signUpSchema } from "@/types/auth";
+import {
+  loginSchema,
+  passwordPolicy,
+  passwordSchema,
+  signUpSchema,
+} from "@/types/auth";
 
 const validSignUp = {
   fullName: "Ada Lovelace",
@@ -12,7 +17,7 @@ const validSignUp = {
 
 const validLogin = {
   email: "ada@example.com",
-  password: "password",
+  password: "Password@1",
 };
 
 function issuesFor(
@@ -48,6 +53,34 @@ function withoutField<T extends object>(
   return payloadWithoutField;
 }
 
+describe("shared password policy", () => {
+  it("exports a shared password schema and policy for all auth forms", () => {
+    expect(passwordPolicy.rules).toHaveLength(3);
+    expect(passwordSchema.safeParse("Password@1").success).toBe(true);
+    expect(passwordSchema.safeParse("password").success).toBe(false);
+  });
+
+  it.each([
+    {
+      rule: passwordPolicy.rules[0],
+      password: "Pass@1",
+    },
+    {
+      rule: passwordPolicy.rules[1],
+      password: "password@1",
+    },
+    {
+      rule: passwordPolicy.rules[2],
+      password: "Password1",
+    },
+  ])("surfaces the shared $rule.id policy message", ({ rule, password }) => {
+    const result = passwordSchema.safeParse(password);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(rule.message);
+  });
+});
+
 describe("signUpSchema", () => {
   it("accepts a valid signup with matching passwords and accepted terms", () => {
     expect(signUpSchema.safeParse(validSignUp).success).toBe(true);
@@ -76,51 +109,48 @@ describe("signUpSchema", () => {
 
   it("rejects an invalid email with the configured message", () => {
     expect(
-      issueFor(signUpSchema, { ...validSignUp, email: "not-an-email" }, "email"),
+      issueFor(
+        signUpSchema,
+        { ...validSignUp, email: "not-an-email" },
+        "email",
+      ),
     ).toMatchObject({
       path: ["email"],
       message: "Please enter a valid email address.",
     });
   });
 
-  it("rejects passwords shorter than eight characters with the configured message", () => {
-    expect(
-      issueFor(
-        signUpSchema,
-        { ...validSignUp, password: "seven77", confirmPassword: "seven77" },
-        "password",
-      ),
-    ).toMatchObject({
-      path: ["password"],
-      message: "Password must be at least 8 characters.",
-    });
-  });
-
-  it("rejects passwords missing an uppercase letter with the configured message", () => {
-    expect(
-      issueFor(
-        signUpSchema,
-        { ...validSignUp, password: "password@1", confirmPassword: "password@1" },
-        "password",
-      ),
-    ).toMatchObject({
-      path: ["password"],
-      message: "Password must include at least one uppercase letter.",
-    });
-  });
-
-  it("rejects passwords missing a special character with the configured message", () => {
-    expect(
-      issueFor(
-        signUpSchema,
-        { ...validSignUp, password: "Password1", confirmPassword: "Password1" },
-        "password",
-      ),
-    ).toMatchObject({
-      path: ["password"],
-      message: "Password must include at least one special character.",
-    });
-  });
+  it.each([
+    {
+      name: "minimum length",
+      password: "seven77",
+      message: passwordPolicy.rules[0].message,
+    },
+    {
+      name: "uppercase letter",
+      password: "password@1",
+      message: passwordPolicy.rules[1].message,
+    },
+    {
+      name: "special character",
+      password: "Password1",
+      message: passwordPolicy.rules[2].message,
+    },
+  ])(
+    "rejects passwords missing a $name rule with the shared policy message",
+    ({ password, message }) => {
+      expect(
+        issueFor(
+          signUpSchema,
+          { ...validSignUp, password, confirmPassword: password },
+          "password",
+        ),
+      ).toMatchObject({
+        path: ["password"],
+        message,
+      });
+    },
+  );
 
   it("rejects mismatched confirmation passwords on confirmPassword", () => {
     expect(
@@ -199,26 +229,28 @@ describe("signUpSchema", () => {
       path: "agreeToTerms",
       payload: { ...validSignUp, agreeToTerms: "true" },
     },
-  ])("rejects $name with invalid_type on the field path", ({ payload, path }) => {
-    expect(issueFor(signUpSchema, payload, path)).toMatchObject({
-      path: [path],
-      code: "invalid_type",
-    });
-  });
-
+  ])(
+    "rejects $name with invalid_type on the field path",
+    ({ payload, path }) => {
+      expect(issueFor(signUpSchema, payload, path)).toMatchObject({
+        path: [path],
+        code: "invalid_type",
+      });
+    },
+  );
 });
 
 describe("loginSchema", () => {
   it("accepts valid login data with rememberMe true", () => {
-    expect(loginSchema.safeParse({ ...validLogin, rememberMe: true }).success).toBe(
-      true,
-    );
+    expect(
+      loginSchema.safeParse({ ...validLogin, rememberMe: true }).success,
+    ).toBe(true);
   });
 
   it("accepts valid login data with rememberMe false", () => {
-    expect(loginSchema.safeParse({ ...validLogin, rememberMe: false }).success).toBe(
-      true,
-    );
+    expect(
+      loginSchema.safeParse({ ...validLogin, rememberMe: false }).success,
+    ).toBe(true);
   });
 
   it("rejects invalid login emails with the configured message", () => {
@@ -234,7 +266,7 @@ describe("loginSchema", () => {
     });
   });
 
-  it("rejects short login passwords with the configured message", () => {
+  it("rejects short login passwords with the shared minimum-length message", () => {
     expect(
       issueFor(
         loginSchema,
@@ -243,7 +275,7 @@ describe("loginSchema", () => {
       ),
     ).toMatchObject({
       path: ["password"],
-      message: "Password must be at least 8 characters.",
+      message: passwordPolicy.rules[0].message,
     });
   });
 
@@ -268,12 +300,15 @@ describe("loginSchema", () => {
       path: "password",
       payload: { ...validLogin, password: 42, rememberMe: true },
     },
-  ])("rejects $name with invalid_type on the field path", ({ payload, path }) => {
-    expect(issueFor(loginSchema, payload, path)).toMatchObject({
-      path: [path],
-      code: "invalid_type",
-    });
-  });
+  ])(
+    "rejects $name with invalid_type on the field path",
+    ({ payload, path }) => {
+      expect(issueFor(loginSchema, payload, path)).toMatchObject({
+        path: [path],
+        code: "invalid_type",
+      });
+    },
+  );
 
   it("rejects missing rememberMe", () => {
     expect(issueFor(loginSchema, validLogin, "rememberMe")).toMatchObject({
@@ -284,7 +319,11 @@ describe("loginSchema", () => {
 
   it("rejects non-boolean rememberMe", () => {
     expect(
-      issueFor(loginSchema, { ...validLogin, rememberMe: "true" }, "rememberMe"),
+      issueFor(
+        loginSchema,
+        { ...validLogin, rememberMe: "true" },
+        "rememberMe",
+      ),
     ).toMatchObject({
       path: ["rememberMe"],
       code: "invalid_type",

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -17,10 +17,57 @@ export interface AuthShowcaseProps {
 }
 
 // Form schemas and types
+const specialCharacterPattern = /[@!#%$^&*()_+\-=[\]{};':"\\|,.<>/?]/;
+
 /**
- * Validates signup form values: full name, valid email, an 8+ character
- * password with uppercase and special characters, matching confirmation, and
- * terms acceptance.
+ * Shared password policy text used by auth forms and the account security UI.
+ */
+export const passwordPolicy = {
+  title: "Password must contain:",
+  rules: [
+    {
+      id: "minLength",
+      label: "At least 8 characters",
+      message: "Password must be at least 8 characters.",
+    },
+    {
+      id: "uppercase",
+      label: "One uppercase letter",
+      message: "Password must include at least one uppercase letter.",
+    },
+    {
+      id: "specialChar",
+      label: "One special character",
+      message: "Password must include at least one special character.",
+    },
+  ],
+} as const;
+
+export const passwordRuleValidators = {
+  minLength: (password: string) => password.length >= 8,
+  uppercase: (password: string) => /[A-Z]/.test(password),
+  specialChar: (password: string) => specialCharacterPattern.test(password),
+} as const;
+
+/**
+ * Shared password schema for auth flows with the same rules and messages
+ * across sign-up, login, and account security updates.
+ */
+export const passwordSchema = z
+  .string()
+  .min(8, {
+    message: passwordPolicy.rules[0].message,
+  })
+  .regex(/[A-Z]/, {
+    message: passwordPolicy.rules[1].message,
+  })
+  .regex(specialCharacterPattern, {
+    message: passwordPolicy.rules[2].message,
+  });
+
+/**
+ * Validates signup form values: full name, valid email, a strong password,
+ * matching confirmation, and terms acceptance.
  */
 export const signUpSchema = z
   .object({
@@ -30,17 +77,7 @@ export const signUpSchema = z
     email: z.string().email({
       message: "Please enter a valid email address.",
     }),
-    password: z
-      .string()
-      .min(8, {
-        message: "Password must be at least 8 characters.",
-      })
-      .regex(/[A-Z]/, {
-        message: "Password must include at least one uppercase letter.",
-      })
-      .regex(/[@!#%$^&*()_+\-=[\]{};':"\\|,.<>/?]/, {
-        message: "Password must include at least one special character.",
-      }),
+    password: passwordSchema,
     confirmPassword: z.string(),
     agreeToTerms: z.boolean().refine((val) => val === true, {
       message: "You must agree to the terms and conditions.",
@@ -52,16 +89,14 @@ export const signUpSchema = z
   });
 
 /**
- * Validates login form values: valid email, an 8+ character password, and
+ * Validates login form values: valid email, a strong password, and
  * remember-me preference.
  */
 export const loginSchema = z.object({
   email: z.string().email({
     message: "Please enter a valid email address.",
   }),
-  password: z.string().min(8, {
-    message: "Password must be at least 8 characters.",
-  }),
+  password: passwordSchema,
   rememberMe: z.boolean(),
 });
 

--- a/utils/authUtils.ts
+++ b/utils/authUtils.ts
@@ -1,3 +1,5 @@
+import { passwordRuleValidators } from "@/types/auth";
+
 /**
  * Authentication utility functions
  */
@@ -17,9 +19,9 @@ export const checkPasswordRequirements = (
   password: string,
 ): PasswordRequirements => {
   return {
-    minLength: password.length >= 8,
-    uppercase: /[A-Z]/.test(password),
-    specialChar: /[@!#%$^&*()_+\-=[\]{};':"\\|,.<>/?]/.test(password),
+    minLength: passwordRuleValidators.minLength(password),
+    uppercase: passwordRuleValidators.uppercase(password),
+    specialChar: passwordRuleValidators.specialChar(password),
   };
 };
 


### PR DESCRIPTION
Closes #306 
Centralized the password validation rules into a single shared schema and policy definition in [auth.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Reused the same policy in the sign-up form, login form, and settings security tab so validation and UI messages stay consistent
Added centralized tests to cover each password rule and ensure the shared behavior remains intact