### PR TITLE
fix(landing): make FAQ copy Stellar accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,14 @@ queue up.
 - All third-party actions are pinned to commit SHAs, not mutable version tags.
 - The workflow requests only `contents: read` — no write access is granted.
 
+## Landing FAQ Copy
+
+The landing FAQ in [`components/landing/faq-section.tsx`](components/landing/faq-section.tsx)
+must stay aligned with StelloPay's Stellar product surface. Public copy should
+reference Stellar wallets such as Freighter, Albedo, and xBull; Stellar assets
+such as XLM and USDC on Stellar; and the active mainnet/testnet context. Avoid
+EVM-only wallet names, ETH asset claims, seed phrase handling claims, or
+unverifiable fee-savings guarantees.
 
 ## Performance Optimization & Code-Splitting
 

--- a/components/landing/faq-section.test.tsx
+++ b/components/landing/faq-section.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import FAQSection from "./faq-section";
+
+describe("FAQSection", () => {
+  it("uses Stellar-accurate wallet, asset, and fee copy", () => {
+    render(<FAQSection />);
+
+    expect(
+      screen.getByText(/Freighter, Albedo, and xBull/i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /What are the supported currencies/i,
+      }),
+    );
+    expect(screen.getByText(/XLM and USDC on Stellar/i)).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /StelloPay charges lower fees than traditional services/i,
+      }),
+    );
+    expect(
+      screen.getByText(
+        /Stellar network fees are typically fractions of a cent/i,
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(/MetaMask|Trust Wallet|Coinbase Wallet/i),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/\bETH\b/i)).not.toBeInTheDocument();
+  });
+
+  it("preserves accordion open and close behavior", () => {
+    render(<FAQSection />);
+
+    const walletQuestion = screen.getByRole("button", {
+      name: /Do I need a crypto wallet/i,
+    });
+    const currenciesQuestion = screen.getByRole("button", {
+      name: /What are the supported currencies/i,
+    });
+
+    expect(walletQuestion).toHaveAttribute("aria-expanded", "true");
+    expect(currenciesQuestion).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(walletQuestion);
+    expect(walletQuestion).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(currenciesQuestion);
+    expect(currenciesQuestion).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(/XLM and USDC on Stellar/i)).toBeInTheDocument();
+  });
+});

--- a/components/landing/faq-section.tsx
+++ b/components/landing/faq-section.tsx
@@ -12,26 +12,27 @@ interface FAQItem {
   answer: string;
 }
 
+/** Landing-page FAQ copy describing Stellar-specific wallet, asset, and fee expectations. */
 const faqData: FAQItem[] = [
   {
     question: "Do I need a crypto wallet?",
     answer:
-      "Yes, StelloPay requires you to connect a cryptocurrency wallet to send and receive payments. We support all major wallets including MetaMask, Trust Wallet, Coinbase Wallet, and more. Your wallet remains under your full control at all times.",
+      "Yes. StelloPay connects to Stellar wallets such as Freighter, Albedo, and xBull so you can approve payments on Stellar mainnet or testnet. StelloPay never asks for your seed phrase or private key.",
   },
   {
     question: "What are the supported currencies?",
     answer:
-      "StelloPay supports a wide range of popular cryptocurrencies and stablecoins, including USDC, USDT, ETH, and more. We are constantly adding support for new assets based on user feedback.",
+      "StelloPay focuses on Stellar assets such as XLM and USDC on Stellar. Supported assets can vary by network, so always confirm whether you are using Stellar mainnet or testnet before sending funds.",
   },
   {
     question: "Have any questions? We've Got Your Answers",
     answer:
-      "Our support team is available 24/7 to help you with any questions or issues you might have. You can reach out to us via email or our help center.",
+      "Our support team can help with Stellar wallet setup, supported assets, network selection, and payment questions. You can reach out to us via email or our help center.",
   },
   {
     question: "StelloPay charges lower fees than traditional services?",
     answer:
-      "Yes, StelloPay leverages blockchain technology to significantly reduce transaction costs compared to traditional payment processors. You can save up to 80% on international transfer fees.",
+      "Stellar network fees are typically fractions of a cent, which can make on-chain payments more cost-efficient than many traditional rails. Review any StelloPay service fees and the selected Stellar network before confirming a payment.",
   },
 ];
 


### PR DESCRIPTION
## Summary\n- Replaced EVM-oriented FAQ answers with Stellar-accurate wallet, asset, network, and fee copy.\n- Removed MetaMask/Trust Wallet/Coinbase Wallet and ETH references from the public landing FAQ.\n- Added a README guardrail for future landing FAQ copy so it stays aligned with Stellar mainnet/testnet, wallets, and assets.\n\n## Tests\n- RED check first: the new FAQ copy test failed on the existing MetaMask/ETH copy before the fix.\n- npm run test\n- npm run lint\n- npm run type-check\n- npm run build\n- npx vitest run components/landing/faq-section.test.tsx --coverage.enabled=false\n- git diff --check\n\n## Security / accuracy notes\n- The copy avoids seed phrase/private key handling claims beyond stating StelloPay does not ask for them.\n- The fee answer avoids a fixed savings promise and asks users to review service fees and the selected Stellar network before confirming a payment.\n\nCloses #458