### PR TITLE
replace full page reload retries with in-place recovery

### DIFF
--- a/components/common/toggle-card.test.tsx
+++ b/components/common/toggle-card.test.tsx
@@ -3,14 +3,13 @@ import { describe, it, expect, vi } from 'vitest';
 import ToggleCard from './toggle-card';
 
 describe('ToggleCard Accessibility', () => {
-  it('exposes aria-pressed and aria-checked attributes that flip on toggle', () => {
+  it('exposes aria-checked attributes that flip on toggle', () => {
     const handleToggle = vi.fn();
     const { rerender } = render(
       <ToggleCard title="Notifications" enabled={false} onToggle={handleToggle} />
     );
     
     const button = screen.getByRole('switch');
-    expect(button).toHaveAttribute('aria-pressed', 'false');
     expect(button).toHaveAttribute('aria-checked', 'false');
     expect(button).toHaveAttribute('aria-label', 'Notifications, disabled');
     
@@ -20,7 +19,6 @@ describe('ToggleCard Accessibility', () => {
     
     // Rerender with new state
     rerender(<ToggleCard title="Notifications" enabled={true} onToggle={handleToggle} />);
-    expect(button).toHaveAttribute('aria-pressed', 'true');
     expect(button).toHaveAttribute('aria-checked', 'true');
     expect(button).toHaveAttribute('aria-label', 'Notifications, enabled');
   });

--- a/components/common/toggle-card.tsx
+++ b/components/common/toggle-card.tsx
@@ -48,7 +48,6 @@ export default function ToggleCard({
         type="button"
         role="switch"
         aria-checked={enabled}
-        aria-pressed={enabled}
         aria-label={`${title}, ${enabled ? "enabled" : "disabled"}`}
         disabled={disabled}
         onClick={() => onToggle(!enabled)}

--- a/components/transactions/transactions-content.test.tsx
+++ b/components/transactions/transactions-content.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import TransactionsContent from "./transactions-content";
 
 import { TRANSACTIONS_PAGE_SIZE, getDefaultDateRange } from "./transactions-config";
 import { TransactionsTable } from "./transactions-table";
@@ -8,6 +9,7 @@ import { TransactionsTable } from "./transactions-table";
 // next/image is not available in jsdom — swap it for a plain <img>.
 vi.mock("next/image", () => ({
   default: ({ src, alt }: { src: string; alt: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
     <img src={src} alt={alt} />
   ),
 }));
@@ -107,5 +109,138 @@ describe("TransactionsTable skeleton count parity", () => {
     const tbody = document.querySelector("tbody");
     const dataRows = tbody?.querySelectorAll("tr") ?? [];
     expect(dataRows.length).toBe(TRANSACTIONS_PAGE_SIZE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TransactionsContent component error/recovery handling
+// ---------------------------------------------------------------------------
+
+const mockUseTransactions = vi.fn();
+vi.mock("@/hooks/useTransactions", () => ({
+  useTransactions: (options?: unknown) => mockUseTransactions(options),
+}));
+
+describe("TransactionsContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders loading state skeleton", () => {
+    mockUseTransactions.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<TransactionsContent />);
+    const shimmer = document.querySelector(".skeleton-shimmer");
+    expect(shimmer).toBeInTheDocument();
+  });
+
+  it("renders ErrorState and triggers refetch on retry click", () => {
+    const refetchMock = vi.fn();
+    mockUseTransactions.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: "Failed to load transactions",
+      refetch: refetchMock,
+    });
+
+    render(<TransactionsContent />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Failed to Load")).toBeInTheDocument();
+    expect(screen.getByText("Failed to load transactions. Please try again.")).toBeInTheDocument();
+
+    const retryButton = screen.getByRole("button", { name: /try again/i });
+    fireEvent.click(retryButton);
+
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("prevents duplicate retries and disables button by transition to loading state", () => {
+    const refetchMock = vi.fn();
+    
+    mockUseTransactions.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: "Failed to fetch",
+      refetch: refetchMock,
+    });
+
+    const { rerender } = render(<TransactionsContent />);
+    
+    const retryButton = screen.getByRole("button", { name: /try again/i });
+    fireEvent.click(retryButton);
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+
+    mockUseTransactions.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      refetch: refetchMock,
+    });
+
+    rerender(<TransactionsContent />);
+    expect(screen.queryByRole("button", { name: /try again/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("supports multiple retries upon repeated failures", () => {
+    const refetchMock = vi.fn();
+    mockUseTransactions.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: "Failed twice",
+      refetch: refetchMock,
+    });
+
+    render(<TransactionsContent />);
+
+    const retryButton = screen.getByRole("button", { name: /try again/i });
+    fireEvent.click(retryButton);
+    fireEvent.click(retryButton);
+    expect(refetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("successfully recovers and renders data state", () => {
+    const refetchMock = vi.fn();
+    
+    mockUseTransactions.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: "Error",
+      refetch: refetchMock,
+    });
+
+    const { rerender } = render(<TransactionsContent />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    mockUseTransactions.mockReturnValue({
+      data: {
+        total: 1,
+        data: [
+          {
+            id: "tx-1",
+            type: "Payment",
+            address: "GAddress123",
+            date: "2024-01-01",
+            time: "10:00",
+            token: "USDC",
+            amount: 100.5,
+            status: "Completed",
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+      refetch: refetchMock,
+    });
+
+    rerender(<TransactionsContent />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getAllByText("+$100.50").length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -47,7 +47,7 @@ export default function TransactionsContent() {
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = TRANSACTIONS_PAGE_SIZE;
 
-  const { data, isLoading, error } = useTransactions({
+  const { data, isLoading, error, refetch } = useTransactions({
     filters,
     page: currentPage,
     pageSize: itemsPerPage,
@@ -106,7 +106,9 @@ export default function TransactionsContent() {
               <ErrorState
                 title="Failed to Load"
                 description="Failed to load transactions. Please try again."
-                onRetry={() => window.location.reload()}
+                // Recover only the failed request in-place using refetch() to avoid full page reloads,
+                // which destroys the React tree, loses client state, and refetches the entire application.
+                onRetry={refetch}
               />
             )}
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,4 @@
+process.env.TZ = "UTC";
+
 import "@testing-library/jest-dom/vitest";
+


### PR DESCRIPTION
Replaced the window.location.reload() recovery strategy inside the dashboard's Transactions segment error state with an in-place refetch() query recovery from the hook. This prevents full browser page reloads, keeping the React component tree alive and retaining client state (such as search filters and current page numbers).

Additionally:

Resolved a11y linter warnings by removing aria-pressed from the ToggleCard switch button.
Cleaned up strict TypeScript warnings in tests by replacing any type annotations with unknown.
Configured a UTC timezone fallback (process.env.TZ = 'UTC') inside vitest.setup.ts to prevent timezone offsets from failing date utility unit tests on developer environments.
Related Issue
Fixes/Refactors reload-based retry behavior in dashboard components.

Checklist
 I have tested the changes locally.
 I have added/updated documentation as needed.
 I have reviewed the code and ensured it follows the project guidelines.
 I have added necessary tests.

Closes #479