### PR TITLE
feat(theme): harden system-mode coverage and guard matchMedia absence

### DIFF
--- a/context/theme-context.test.tsx
+++ b/context/theme-context.test.tsx
@@ -1,7 +1,8 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import React from "react";
-import { ThemeProvider, useTheme } from "@/context/theme-context";
+import { ThemeProvider, useTheme, getStoredTheme } from "@/context/theme-context";
+import { safeStorage } from "@/utils/safeStorage";
 
 // ---------------------------------------------------------------------------
 // matchMedia mock helpers
@@ -324,5 +325,63 @@ describe("useTheme outside provider", () => {
     expect(() => renderHook(() => useTheme())).toThrow(
       /useTheme must be used within ThemeProvider/,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("ThemeProvider – system mode, matchMedia unavailable", () => {
+  let originalMatchMedia: typeof window.matchMedia;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem("theme", "system");
+    originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: undefined,
+    });
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  it("resolves to 'light' when matchMedia is unavailable (SSR fallback)", () => {
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    expect(result.current.theme).toBe("system");
+    expect(result.current.resolvedTheme).toBe("light");
+  });
+
+  it("does not add 'dark' class when matchMedia is unavailable", () => {
+    renderHook(() => useTheme(), { wrapper });
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("does not register a listener when matchMedia is unavailable", () => {
+    // Should not throw; listener setup is skipped when matchMedia is absent.
+    expect(() => renderHook(() => useTheme(), { wrapper })).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("getStoredTheme – storage error handling", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    document.documentElement.classList.remove("dark");
+  });
+
+  it("returns 'system' when safeStorage.getItem throws unexpectedly", () => {
+    vi.spyOn(safeStorage, "getItem").mockImplementationOnce(() => {
+      throw new Error("simulated unexpected storage error");
+    });
+    expect(getStoredTheme()).toBe("system");
   });
 });

--- a/context/theme-context.tsx
+++ b/context/theme-context.tsx
@@ -124,6 +124,9 @@ export const ThemeProvider: React.FC<React.PropsWithChildren<{}>> = ({
       return;
     }
 
+    // Guard: matchMedia may be absent in test stubs or non-standard environments.
+    if (!window.matchMedia) return;
+
     // Subscribe to live OS preference changes.
     const mql = window.matchMedia("(prefers-color-scheme: dark)");
 


### PR DESCRIPTION
- Add `if (!window.matchMedia) return` guard in the second useEffect before the listener setup, consistent with the defensive check already present in getSystemPreference(); prevents a TypeError in SSR or non-standard environments where matchMedia is absent.

- Import getStoredTheme and safeStorage into the test file so both can be exercised directly.

- Add "ThemeProvider – system mode, matchMedia unavailable" suite (3 tests): sets window.matchMedia = undefined, verifies resolvedTheme falls back to "light", no dark class is applied, and no exception is thrown.

- Add "getStoredTheme – storage error handling" suite (1 test): spies on safeStorage.getItem to throw, verifying the catch block returns "system" rather than propagating the error.

These additions close the two branch-coverage gaps left by the original implementation (the SSR fallback in getSystemPreference and the catch block in getStoredTheme) and ensure the 95% threshold is met across lines/functions/branches/statements.

## Description

<!-- Briefly describe the changes introduced in this pull request. -->

## Related Issue

<!-- Link to the issue(s) this pull request addresses, if any. -->

## Checklist

- [ ] I have tested the changes locally.
- [ ] I have added/updated documentation as needed.
- [ ] I have reviewed the code and ensured it follows the project guidelines.
- [ ] I have added necessary tests.

## Screenshots/Recordings

closes #461 
