### PR TITLE
Wire transaction filter input to transactions query

### DIFF
--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -14,15 +14,19 @@ import { isDateInRange } from "@/utils/date-utils";
 
 const getTokenIcon = (token: string): string => {
   switch (token) {
-    case "USDC": return "/usdc-logo.png";
-    case "XLM":  return "/stellar-xlm-logo.png";
-    default:     return "/usd.png";
+    case "USDC":
+      return "/usdc-logo.png";
+    case "XLM":
+      return "/stellar-xlm-logo.png";
+    default:
+      return "/usd.png";
   }
 };
 
 const Transactions = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [searchParams, setSearchParams] = useState("");
+  const [filterParams, setFilterParams] = useState("");
   const [startDate, setStartDate] = useState<Date | undefined>(undefined);
   const [endDate, setEndDate] = useState<Date | undefined>(undefined);
   const itemsPerPage = 6;
@@ -30,10 +34,10 @@ const Transactions = () => {
   // Reset to page 1 whenever filters change
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchParams, startDate, endDate]);
+  }, [searchParams, filterParams, startDate, endDate]);
 
   const { data, isLoading, error } = useTransactions({
-    filters: { searchQuery: searchParams },
+    filters: { searchQuery: searchParams, filterQuery: filterParams },
     page: 1,
     pageSize: 1000, // fetch all so we can client-side date filter (same as original)
   });
@@ -56,8 +60,9 @@ const Transactions = () => {
   }, [data]);
 
   const dateFiltered = useMemo(
-    () => allTransactions.filter((t) => isDateInRange(t.date, startDate, endDate)),
-    [allTransactions, startDate, endDate]
+    () =>
+      allTransactions.filter((t) => isDateInRange(t.date, startDate, endDate)),
+    [allTransactions, startDate, endDate],
   );
 
   const paginated = useMemo(() => {
@@ -79,11 +84,40 @@ const Transactions = () => {
         <div className="bg-foreground border rounded-[1.5rem] border-[#2D2D2D] p-2">
           <div className="grid items-center justify-between pb-2 md:pb-0 md:flex">
             <h1 className="flex items-center gap-1 p-2 mb-4 text-xl font-medium">
-              <div className="bg-[#121212] rounded-lg border border-[#2E2E2E] p-1" aria-hidden="true">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-                  <path d="M18.9999 10.5V9.99995C18.9999 6.22876 18.9998 4.34311 17.8283 3.17154C16.6567 2 14.7711 2 10.9999 2C7.22883 2 5.3432 2.00006 4.17163 3.17159C3.00009 4.34315 3.00007 6.22872 3.00004 9.99988L3 14.5C2.99997 17.7874 2.99996 19.4312 3.90788 20.5375C4.07412 20.7401 4.25986 20.9258 4.46243 21.0921C5.56877 22 7.21249 22 10.4999 22" stroke="#E5E5E5" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                  <path d="M7 7H15M7 11H11" stroke="#E5E5E5" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                  <path d="M18 18.5L16.5 17.95V15.5M12 17.5C12 19.9853 14.0147 22 16.5 22C18.9853 22 21 19.9853 21 17.5C21 15.0147 18.9853 13 16.5 13C14.0147 13 12 15.0147 12 17.5Z" stroke="#E5E5E5" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+              <div
+                className="bg-[#121212] rounded-lg border border-[#2E2E2E] p-1"
+                aria-hidden="true"
+              >
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <path
+                    d="M18.9999 10.5V9.99995C18.9999 6.22876 18.9998 4.34311 17.8283 3.17154C16.6567 2 14.7711 2 10.9999 2C7.22883 2 5.3432 2.00006 4.17163 3.17159C3.00009 4.34315 3.00007 6.22872 3.00004 9.99988L3 14.5C2.99997 17.7874 2.99996 19.4312 3.90788 20.5375C4.07412 20.7401 4.25986 20.9258 4.46243 21.0921C5.56877 22 7.21249 22 10.4999 22"
+                    stroke="#E5E5E5"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M7 7H15M7 11H11"
+                    stroke="#E5E5E5"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M18 18.5L16.5 17.95V15.5M12 17.5C12 19.9853 14.0147 22 16.5 22C18.9853 22 21 19.9853 21 17.5C21 15.0147 18.9853 13 16.5 13C14.0147 13 12 15.0147 12 17.5Z"
+                    stroke="#E5E5E5"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
                 </svg>
               </div>
               <span>All Transactions</span>
@@ -96,7 +130,7 @@ const Transactions = () => {
 
             <div className="flex items-center gap-2">
               <TableSearchbar onSearch={setSearchParams} />
-              <Filter />
+              <Filter value={filterParams} onChange={setFilterParams} />
               <Sort />
             </div>
           </div>
@@ -115,11 +149,16 @@ const Transactions = () => {
           {!isLoading && !error && (
             <>
               <TransactionsTable transactions={paginated} />
-              {(searchParams || startDate || endDate) && paginated.length === 0 && (
-                <div role="status" aria-live="polite" className="py-4 text-center text-gray-400">
-                  No Transactions Found
-                </div>
-              )}
+              {(searchParams || filterParams || startDate || endDate) &&
+                paginated.length === 0 && (
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    className="py-4 text-center text-gray-400"
+                  >
+                    No Transactions Found
+                  </div>
+                )}
             </>
           )}
         </div>

--- a/components/transactions/filter.test.tsx
+++ b/components/transactions/filter.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Filter from "./filter";
+
+describe("Filter", () => {
+  it("debounces filter updates from the controlled input", () => {
+    vi.useFakeTimers();
+    const onChange = vi.fn();
+
+    render(<Filter value="" onChange={onChange} debounceMs={250} />);
+
+    fireEvent.change(screen.getByLabelText("Filter transactions"), {
+      target: { value: "failed" },
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(249);
+    expect(onChange).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onChange).toHaveBeenCalledWith("failed");
+
+    vi.useRealTimers();
+  });
+
+  it("marks the filter icon decorative and clears a populated value", () => {
+    const onChange = vi.fn();
+
+    render(<Filter value="pending" onChange={onChange} debounceMs={0} />);
+
+    expect(screen.getByTestId("transactions-filter-icon")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Clear transaction filter" }),
+    );
+
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+});

--- a/components/transactions/filter.tsx
+++ b/components/transactions/filter.tsx
@@ -1,17 +1,73 @@
-import React from "react";
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
 
 import { Input } from "@/components/ui/input";
-import { ListFilter } from "lucide-react";
+import { ListFilter, X } from "lucide-react";
 
-const Filter = () => {
+interface FilterProps {
+  /** Current committed transaction filter text. Treated as plain text only. */
+  value: string;
+  /** Receives debounced filter text changes, or an immediate empty string on clear. */
+  onChange: (value: string) => void;
+  /** Debounce delay in milliseconds before `onChange` fires. Defaults to 300ms. */
+  debounceMs?: number;
+}
+
+const Filter = ({ value, onChange, debounceMs = 300 }: FilterProps) => {
+  const [draftValue, setDraftValue] = useState(value);
+  const onChangeRef = useRef(onChange);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    setDraftValue(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (draftValue === value) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      onChangeRef.current(draftValue);
+    }, debounceMs);
+
+    return () => clearTimeout(timer);
+  }, [draftValue, debounceMs, value]);
+
+  const clearFilter = () => {
+    setDraftValue("");
+    onChangeRef.current("");
+  };
+
   return (
-    <div className="flex items-center bg-transparent     rounded-[6.25rem]">
-      <ListFilter className="text-gray-600 w-5 h-5 " />
+    <div className="flex items-center bg-transparent rounded-[6.25rem]">
+      <ListFilter
+        aria-hidden="true"
+        data-testid="transactions-filter-icon"
+        className="text-gray-600 w-5 h-5"
+      />
       <Input
         type="text"
         placeholder="Filter"
+        aria-label="Filter transactions"
+        value={draftValue}
+        onChange={(event) => setDraftValue(event.target.value)}
         className="border-none py-1 focus-visible:ring-0 text-[13px] p-1 sm:text-[14px]"
       />
+      {draftValue && (
+        <button
+          type="button"
+          aria-label="Clear transaction filter"
+          onClick={clearFilter}
+          className="rounded-full p-1 text-gray-500 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500"
+        >
+          <X aria-hidden="true" className="h-4 w-4" />
+        </button>
+      )}
     </div>
   );
 };

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useState, useMemo, useCallback } from "react";
-import type { SortField, TransactionFilters, Transaction, TransactionProps } from "@/types/transaction";
+import type {
+  SortField,
+  TransactionFilters,
+  Transaction,
+  TransactionProps,
+} from "@/types/transaction";
 import { useTransactions } from "@/hooks/useTransactions";
 import { TransactionTableSkeleton } from "@/components/ui/table-skeleton";
 import TransactionsHeader from "./transactions-header";
@@ -9,14 +14,20 @@ import TransactionsFilters from "./transactions-filters";
 import { TransactionsTable } from "./transactions-table";
 import TransactionsPagination from "./transactions-pagination";
 import { ErrorState } from "@/components/ui/error-state";
-import { TRANSACTIONS_PAGE_SIZE, getDefaultDateRange } from "./transactions-config";
+import {
+  TRANSACTIONS_PAGE_SIZE,
+  getDefaultDateRange,
+} from "./transactions-config";
 
 /** Map token symbol → icon path */
 const getTokenIcon = (token: string): string => {
   switch (token) {
-    case "USDC": return "/usdc-logo.png";
-    case "XLM":  return "/stellar-xlm-logo.png";
-    default:     return "/usd.png";
+    case "USDC":
+      return "/usdc-logo.png";
+    case "XLM":
+      return "/stellar-xlm-logo.png";
+    default:
+      return "/usd.png";
   }
 };
 
@@ -39,6 +50,7 @@ const toTransactionProps = (t: Transaction): TransactionProps => ({
 export default function TransactionsContent() {
   const [filters, setFilters] = useState<TransactionFilters>(() => ({
     searchQuery: "",
+    filterQuery: "",
     ...getDefaultDateRange(),
     selectedFilter: "All Transactions",
     sortField: "date",
@@ -55,15 +67,18 @@ export default function TransactionsContent() {
 
   const paginatedTransactions: TransactionProps[] = useMemo(
     () => (data?.data ?? []).map(toTransactionProps),
-    [data]
+    [data],
   );
 
   const updateFilter = useCallback(
-    <K extends keyof TransactionFilters>(key: K, value: TransactionFilters[K]) => {
+    <K extends keyof TransactionFilters>(
+      key: K,
+      value: TransactionFilters[K],
+    ) => {
       setFilters((prev) => ({ ...prev, [key]: value }));
       setCurrentPage(1);
     },
-    []
+    [],
   );
 
   const handleSort = useCallback((field: SortField) => {
@@ -71,7 +86,9 @@ export default function TransactionsContent() {
       ...prev,
       sortField: field,
       sortDirection:
-        prev.sortField === field && prev.sortDirection === "asc" ? "desc" : "asc",
+        prev.sortField === field && prev.sortDirection === "asc"
+          ? "desc"
+          : "asc",
     }));
     setCurrentPage(1);
   }, []);

--- a/hooks/useTransactions.ts
+++ b/hooks/useTransactions.ts
@@ -30,7 +30,7 @@ interface UseTransactionsResult {
  * @param options - filters, page, and pageSize
  */
 export function useTransactions(
-  options: UseTransactionsOptions = {}
+  options: UseTransactionsOptions = {},
 ): UseTransactionsResult {
   const { filters, page = 1, pageSize = 6 } = options;
 
@@ -54,13 +54,11 @@ export function useTransactions(
     // commits by request identity.
     const latestRequestId = requestId;
 
-
     setIsLoading(true);
 
     setError(null);
 
     getTransactions({ filters, page, pageSize }, controller.signal)
-
       .then((result) => {
         if (controller.signal.aborted) return;
         if (requestId !== latestRequestId) return;
@@ -73,7 +71,7 @@ export function useTransactions(
         if (requestId !== latestRequestId) return;
 
         setError(
-          err instanceof Error ? err.message : "Failed to load transactions"
+          err instanceof Error ? err.message : "Failed to load transactions",
         );
 
         setIsLoading(false);
@@ -84,6 +82,7 @@ export function useTransactions(
     };
   }, [
     filters?.searchQuery,
+    filters?.filterQuery,
 
     filters?.selectedFilter,
     filters?.fromDate,

--- a/lib/api/__tests__/transactions.test.ts
+++ b/lib/api/__tests__/transactions.test.ts
@@ -130,6 +130,29 @@ describe("getTransactions", () => {
     expect(result.total).toBe(0);
   });
 
+  it("filters by plain-text transaction filter query across status and address", async () => {
+    const failed = await getTransactions({
+      filters: { filterQuery: "failed" },
+      pageSize: 100,
+    });
+    expect(failed.total).toBeGreaterThan(0);
+    failed.data.forEach((t) =>
+      expect(t.status.toLowerCase()).toContain("failed"),
+    );
+
+    const address = failed.data[0]?.address.slice(0, 8);
+    expect(address).toBeTruthy();
+
+    const byAddress = await getTransactions({
+      filters: { filterQuery: address },
+      pageSize: 100,
+    });
+    expect(byAddress.total).toBeGreaterThan(0);
+    byAddress.data.forEach((t) =>
+      expect(t.address.toLowerCase()).toContain(address!.toLowerCase()),
+    );
+  });
+
   it("each transaction has required fields", async () => {
     const result = await getTransactions({ pageSize: 100 });
     result.data.forEach((t) => {

--- a/lib/api/transactions.ts
+++ b/lib/api/transactions.ts
@@ -91,7 +91,7 @@ const normalizeDateFilter = (
  */
 export async function getTransactions(
   params: GetTransactionsParams = {},
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ): Promise<PaginatedTransactions> {
   const {
     filters = {},
@@ -101,6 +101,7 @@ export async function getTransactions(
 
   const {
     searchQuery = "",
+    filterQuery = "",
 
     selectedFilter = "All Transactions",
     fromDate = MOCK_FROM_DATE,
@@ -161,12 +162,12 @@ export async function getTransactions(
   }
 
   const filtered = filterTransactions(
-
     allTransactions,
     searchQuery,
     selectedFilter,
     safeFromDate,
     safeToDate,
+    filterQuery,
   );
 
   const sorted = sortTransactions(filtered, sortField, sortDirection);

--- a/types/transaction.ts
+++ b/types/transaction.ts
@@ -19,6 +19,7 @@ export type SortDirection = "asc" | "desc";
 
 export interface TransactionFilters {
   searchQuery: string;
+  filterQuery: string;
   fromDate: string;
   toDate: string;
   selectedFilter: string;

--- a/utils/transactionUtils.ts
+++ b/utils/transactionUtils.ts
@@ -41,6 +41,7 @@ export const filterTransactions = (
   selectedFilter: string,
   fromDate: string,
   toDate: string,
+  filterQuery = "",
 ): Transaction[] => {
   let filtered = transactions;
 
@@ -60,6 +61,16 @@ export const filterTransactions = (
   if (selectedFilter !== "All Transactions") {
     filtered = filtered.filter(
       (transaction) => transaction.type === selectedFilter,
+    );
+  }
+
+  const normalizedFilterQuery = filterQuery.trim().toLowerCase();
+  if (normalizedFilterQuery) {
+    filtered = filtered.filter(
+      (transaction) =>
+        transaction.type.toLowerCase().includes(normalizedFilterQuery) ||
+        transaction.status.toLowerCase().includes(normalizedFilterQuery) ||
+        transaction.address.toLowerCase().includes(normalizedFilterQuery),
     );
   }
 


### PR DESCRIPTION
Closes Stellopay/stellopay-frontend#454.

## Summary
- make the transaction Filter a controlled, accessible input with debounced updates and an explicit clear action
- thread filterQuery through the transaction filters, hook dependency list, API helper, and local transaction matching
- keep filtering as plain text against transaction type, status, and address fields without HTML or URL interpolation

## Tests
- npm test
- npm run type-check
- npm run lint
- npm run build
- git diff --check