### PR TITLE
feat(app): add loading.tsx skeletons for dashboard/transactions/settings

### DIFF
--- a/app/dashboard/loading.test.tsx
+++ b/app/dashboard/loading.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import Loading from "./loading";
+
+describe("Dashboard loading fallback", () => {
+  it("exposes an accessible busy status region", () => {
+    render(<Loading />);
+
+    const status = screen.getByRole("status");
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(status).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("provides an sr-only label for screen readers", () => {
+    render(<Loading />);
+    expect(screen.getByText("Loading dashboard")).toHaveClass("sr-only");
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Loading />);
+    const results = await axe(container);
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,0 +1,72 @@
+import Skeleton from "@/components/ui/skeleton";
+import { AccountSummaryCardSkeleton } from "@/components/ui/card-skeleton";
+
+/**
+ * Route-level loading UI for the `/dashboard` segment.
+ *
+ * Next.js wraps `app/dashboard/page.tsx` in a Suspense boundary and renders
+ * this component as the fallback while the route segment streams in. It mirrors
+ * the real dashboard layout — welcome header, three account summary cards,
+ * six quick-action tiles, and the four-up analytics KPI grid — so the visible
+ * structure stays stable and Cumulative Layout Shift (CLS) is minimized when
+ * the actual content mounts.
+ *
+ * @remarks
+ * Security: this fallback renders only empty skeleton shapes. It never reads,
+ * fetches, or displays real account data or PII — there is nothing sensitive to
+ * leak in a transient loading state.
+ */
+export default function Loading() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className="w-full min-h-screen bg-white dark:bg-[#0D0D0D]"
+    >
+      <span className="sr-only">Loading dashboard</span>
+
+      <div className="flex-1 p-6 lg:p-10 max-w-[1600px] mx-auto w-full space-y-10">
+        {/* Welcome / Account Overview header */}
+        <div className="space-y-3">
+          <Skeleton className="h-10 w-72 md:h-12 md:w-96" />
+          <Skeleton className="h-5 w-80 max-w-full" />
+        </div>
+
+        {/* Account summary cards — matches grid-cols-1 md:grid-cols-2 lg:grid-cols-3 */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <AccountSummaryCardSkeleton />
+          <AccountSummaryCardSkeleton />
+          <AccountSummaryCardSkeleton />
+        </div>
+
+        {/* Quick actions — matches grid up to xl:grid-cols-6 */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-28 rounded-xl" />
+          ))}
+        </div>
+
+        {/* Analytics insights — mirrors the dynamic-import fallback shape */}
+        <div className="w-full rounded-2xl border border-zinc-200 dark:border-zinc-800 p-6 bg-white dark:bg-[#111111] space-y-6">
+          <div className="flex flex-col sm:flex-row justify-between gap-4">
+            <div className="space-y-2">
+              <Skeleton className="h-6 w-48" />
+              <Skeleton className="h-4 w-64 max-w-full" />
+            </div>
+            <div className="flex gap-3">
+              <Skeleton className="h-10 w-24 rounded-xl" />
+              <Skeleton className="h-10 w-24 rounded-xl" />
+            </div>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            <Skeleton className="h-32 rounded-2xl" />
+            <Skeleton className="h-32 rounded-2xl" />
+            <Skeleton className="h-32 rounded-2xl" />
+            <Skeleton className="h-32 rounded-2xl" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/settings/preferences/loading.test.tsx
+++ b/app/settings/preferences/loading.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import Loading from "./loading";
+
+describe("Settings preferences loading fallback", () => {
+  it("exposes an accessible busy status region", () => {
+    render(<Loading />);
+
+    const status = screen.getByRole("status");
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(status).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("provides an sr-only label for screen readers", () => {
+    render(<Loading />);
+    expect(screen.getByText("Loading preferences")).toHaveClass("sr-only");
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Loading />);
+    const results = await axe(container);
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/app/settings/preferences/loading.tsx
+++ b/app/settings/preferences/loading.tsx
@@ -1,0 +1,77 @@
+import Skeleton from "@/components/ui/skeleton";
+import {
+  CardSkeleton,
+  AccountSummaryCardSkeleton,
+} from "@/components/ui/card-skeleton";
+
+/**
+ * Route-level loading UI for the `/settings/preferences` segment.
+ *
+ * Serves as the Suspense fallback for `app/settings/preferences/page.tsx` (an
+ * async server component that awaits `searchParams`) while it streams in. It
+ * mirrors the settings shell: the four-up summary card row and the
+ * account-section grid (a form-shaped card plus a sidebar), so the form layout
+ * holds its place and CLS is minimized once the interactive content mounts.
+ *
+ * @remarks
+ * Security: only empty skeleton shapes are rendered. No profile fields, email,
+ * wallet data, or any other PII are read or displayed in this transient state.
+ */
+export default function Loading() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className="mx-auto flex w-full max-w-screen-xl flex-1 flex-col gap-8 px-4 py-8 md:px-6"
+    >
+      <span className="sr-only">Loading preferences</span>
+
+      {/* Settings header */}
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-56" />
+        <Skeleton className="h-4 w-80 max-w-full" />
+      </div>
+
+      {/* Summary cards — matches grid gap-4 md:grid-cols-2 xl:grid-cols-4 */}
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <AccountSummaryCardSkeleton />
+        <AccountSummaryCardSkeleton />
+        <AccountSummaryCardSkeleton />
+        <AccountSummaryCardSkeleton />
+      </div>
+
+      {/* Account section — form card + sidebar */}
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+        {/* Main form card: header + paired form fields */}
+        <div className="rounded-xl border border-[#2D2D2D] p-6 space-y-6">
+          <div className="flex items-center gap-4">
+            <Skeleton className="h-16 w-16 rounded-full" />
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-9 w-32 rounded-lg" />
+            </div>
+          </div>
+
+          {/* Six form fields in a two-column layout (label + input) */}
+          <div className="grid gap-4 md:grid-cols-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-10 w-full rounded-lg" />
+              </div>
+            ))}
+          </div>
+
+          <Skeleton className="h-10 w-44 rounded-lg" />
+        </div>
+
+        {/* Sidebar: section map + danger zone */}
+        <div className="space-y-6">
+          <CardSkeleton lines={4} />
+          <CardSkeleton lines={2} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/transactions/loading.test.tsx
+++ b/app/transactions/loading.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import Loading from "./loading";
+
+describe("Transactions loading fallback", () => {
+  it("exposes an accessible busy status region", () => {
+    render(<Loading />);
+
+    const status = screen.getByRole("status");
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(status).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("provides an sr-only label for screen readers", () => {
+    render(<Loading />);
+    expect(screen.getByText("Loading transactions")).toHaveClass("sr-only");
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Loading />);
+    const results = await axe(container);
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/app/transactions/loading.tsx
+++ b/app/transactions/loading.tsx
@@ -1,0 +1,50 @@
+import Skeleton from "@/components/ui/skeleton";
+import { TransactionTableSkeleton } from "@/components/ui/table-skeleton";
+
+/**
+ * Route-level loading UI for the `/transactions` segment.
+ *
+ * Rendered as the Suspense fallback for `app/transactions/page.tsx` while the
+ * route streams in. It reproduces the transactions header band and the bordered
+ * table card, then reuses {@link TransactionTableSkeleton} with the same row
+ * count the page paginates by (`itemsPerPage = 6`) so the six-column table
+ * keeps its dimensions and CLS stays low when real rows arrive.
+ *
+ * @remarks
+ * Security: the skeleton renders only empty placeholder shapes — no real
+ * transaction records, addresses, amounts, or other PII are loaded or shown
+ * during this transient state.
+ */
+export default function Loading() {
+  return (
+    <div role="status" aria-busy="true" aria-live="polite">
+      <span className="sr-only">Loading transactions</span>
+
+      {/* Header band — mirrors TransactionHeader height/spacing */}
+      <div className="flex items-center justify-between px-8 py-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-10 w-40 rounded-lg" />
+      </div>
+
+      <div className="container mx-auto py-8 px-8">
+        <div className="bg-foreground border rounded-[1.5rem] border-[#2D2D2D] p-2">
+          {/* Toolbar row — title + search/filter/sort controls */}
+          <div className="grid items-center justify-between pb-2 md:pb-0 md:flex">
+            <div className="flex items-center gap-2 p-2 mb-4">
+              <Skeleton className="h-9 w-9 rounded-lg" />
+              <Skeleton className="h-6 w-40" />
+            </div>
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-9 w-40 rounded-lg" />
+              <Skeleton className="h-9 w-24 rounded-lg" />
+              <Skeleton className="h-9 w-24 rounded-lg" />
+            </div>
+          </div>
+
+          {/* Table body — six columns, six rows, matching the real table */}
+          <TransactionTableSkeleton rows={6} />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What & why

Adds route-level `loading.tsx` Suspense fallbacks for three App Router segments so users see an instant, accessible skeleton while each route streams in (improved perceived performance via streaming Suspense boundaries), with stable layout to minimize Cumulative Layout Shift (CLS).

Each fallback **reuses the existing skeleton primitives** rather than reinventing them, and **mirrors the real page dimensions** so the visible structure stays put when the actual content mounts:

- **`app/dashboard/loading.tsx`** — welcome header, 3 summary cards (`AccountSummaryCardSkeleton`, `md:grid-cols-2 lg:grid-cols-3`), 6 quick-action tiles, and the 4-up analytics KPI grid (mirrors the existing dynamic-import fallback shape).
- **`app/transactions/loading.tsx`** — header band + bordered table card reusing `TransactionTableSkeleton rows={6}` (six columns, matching the real table and its `itemsPerPage = 6`).
- **`app/settings/preferences/loading.tsx`** — 4 summary cards (`xl:grid-cols-4`) + the account-section grid (form-shaped `CardSkeleton` with 6 paired fields + sidebar cards).

## Files added

| File | Purpose |
| --- | --- |
| `app/dashboard/loading.tsx` | Dashboard segment Suspense fallback |
| `app/transactions/loading.tsx` | Transactions segment Suspense fallback |
| `app/settings/preferences/loading.tsx` | Settings/preferences segment Suspense fallback |
| `app/dashboard/loading.test.tsx` | Vitest unit test (a11y + structure) |
| `app/transactions/loading.test.tsx` | Vitest unit test (a11y + structure) |
| `app/settings/preferences/loading.test.tsx` | Vitest unit test (a11y + structure) |

## Accessibility

Each fallback follows the repo's existing a11y loading pattern (the dynamic-import fallback in `components/dashboard/dashboard-page.tsx`): a container with `role="status"`, `aria-busy="true"`, `aria-live="polite"`, and a `<span className="sr-only">` label (`Loading dashboard` / `Loading transactions` / `Loading preferences`).

> Note: the `app/help/support/accountManagement/loading.tsx` referenced in the issue as a canonical a11y pattern is actually a `return null` no-op, so the `dashboard-page.tsx` fallback was used as the real reference instead.

## Security note

The skeletons render **only empty placeholder shapes**. They never read, fetch, or display real account data, transaction records, or any PII — there is nothing sensitive to leak in a transient loading state. This is stated explicitly in each file's TSDoc.

## Test output

Deterministic Vitest unit tests (jsdom + `vitest-axe`) for all three fallbacks:

```
 RUN  v4.1.9
 Test Files  3 passed (3)
      Tests  9 passed (9)
```

Each suite asserts: the `role="status"` region exists with `aria-busy="true"` and `aria-live="polite"`, the correct `sr-only` label is present, and there are **zero axe accessibility violations**.

## Acceptance-criteria checklist

- [x] Three `loading.tsx` files (dashboard, transactions, settings/preferences)
- [x] `role="status"` + `aria-busy`/`aria-live` + `sr-only` label on each
- [x] Reuses `CardSkeleton` / `AccountSummaryCardSkeleton` / `TransactionTableSkeleton`
- [x] Anti-CLS: skeleton dimensions mirror the real pages
- [x] Skeletons render no real data / no PII (security note)
- [x] Automated test assertions for the loading skeletons (Vitest)

## Honest notes for reviewers

- **"95% coverage" requirement:** the `vitest.config.ts` coverage threshold applies only to an explicit `include` allowlist (selected utils/hooks/components). Route `loading.tsx` files are not in that list and are not measured by it, and Playwright E2E does not contribute to coverage — so the "95% coverage" figure from the issue is not literally measurable for these files. They are instead covered by the dedicated Vitest unit tests above.
- **Playwright E2E for the skeleton:** the issue suggests a Playwright test asserting the skeleton during navigation. A route-level Suspense fallback is only observable when the target route is prefetched (so the loading boundary is known client-side) and then its navigation data is delayed. The Playwright `webServer` here runs `next dev`, which **disables `<Link>` prefetching**, so soft navigation is blocking and never paints `loading.tsx`; and these pages resolve synchronously, so a hard navigation doesn't stream the fallback either. A production build (where prefetch works) is the only reliable way to assert this, but `next build` currently fails on **pre-existing** type/lint errors unrelated to this change. The deterministic Vitest tests were chosen as the robust substitute that fully covers the accessibility/structure acceptance criteria.
- **Pre-existing red gates (out of scope):** on `main`, `tsc --noEmit` reports 15 errors and `next lint` reports 5, all in files unrelated to this issue (`components/common/text-input.test.tsx`, `tests/settings-notifications.spec.ts`, `app/settings/preferences/components/notifications-section.tsx`, `app/settings/preferences/components/security-tab.tsx`, `components/common/support-tabs.tsx`). Per scope, they were **not** touched. All files added in this PR are type-check clean and lint clean in isolation.

Closes #283
