### PR TITLE
test: cover transaction pagination page counts

### DIFF
--- a/components/transactions/transactions-pagination.test.tsx
+++ b/components/transactions/transactions-pagination.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import TransactionsPagination from "./transactions-pagination";
+
+describe("TransactionsPagination", () => {
+  it("shows the correct partial last page when total items are not a multiple of page size", () => {
+    const onPageChange = vi.fn();
+
+    render(
+      <TransactionsPagination
+        totalItems={13}
+        currentPage={4}
+        itemsPerPage={4}
+        onPageChange={onPageChange}
+      />,
+    );
+
+    expect(
+      screen.getByText("Showing 13 to 13 of 13 items"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Page 4" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(
+      screen.queryByRole("button", { name: "Page 5" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /go to next page/i }),
+    ).toBeDisabled();
+  });
+
+  it("does not render a phantom page when total items exactly fill the last page", () => {
+    render(
+      <TransactionsPagination
+        totalItems={12}
+        currentPage={3}
+        itemsPerPage={4}
+        onPageChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Showing 9 to 12 of 12 items")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Page 3" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(
+      screen.queryByRole("button", { name: "Page 4" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /go to next page/i }),
+    ).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add focused `TransactionsPagination` regression tests for non-multiple item totals and exact-multiple totals.
- Assert the last partial page summary, active last-page button, absence of a phantom next page, and disabled Next state.
- No production code change was needed: the new regression coverage passes against the current implementation.

Closes #608

## Verification

- `npx vitest run components/transactions/transactions-pagination.test.tsx` - passed, 2 tests.
- `npx vitest run components/transactions/transactions-pagination.test.tsx utils/paginationUtils.test.ts components/ui/pagination.test.tsx` - passed, 47 tests. Vitest/JSDOM emits an existing canvas `getContext()` warning.
- `npm test` - passed, 46 files / 526 tests, coverage summary above the configured 95% thresholds. Vitest/JSDOM emits the same existing canvas warning.
- `npx prettier --check components/transactions/transactions-pagination.test.tsx` - passed.
- `npm run lint` - passed with two existing warnings in unrelated files (`components/common/toggle-card.tsx`, `components/transactions/transactions-content.test.tsx`).
- `npm run build` - passed with the same lint warnings and existing `metadataBase` warning.

## Not run / blocked

- `npx playwright test tests/pagination.spec.ts --project=chromium` could not run because the local Playwright Chromium executable is missing from `/Users/yfengj/Library/Caches/ms-playwright/...`; all 13 tests failed at browser launch before exercising app code.
- `npm run type-check` currently fails on pre-existing unrelated test/spec typing issues in `components/common/text-input.test.tsx` and `tests/settings-notifications.spec.ts`; the new pagination test file is not reported in those errors.