### PR TITLE
fix: correct active-route matching for nested routes (#601)

### DIFF
--- a/utils/navigationUtils.test.ts
+++ b/utils/navigationUtils.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getActiveLinkLayoutId,
+  isLinkActive,
+  shouldExpandSidebar,
+} from "@/utils/navigationUtils";
+
+describe("isLinkActive", () => {
+  describe("root route", () => {
+    it("matches when pathname is exactly the root", () => {
+      expect(isLinkActive("/", "/")).toBe(true);
+    });
+
+    it("does not match a non-root pathname", () => {
+      expect(isLinkActive("/", "/dashboard")).toBe(false);
+    });
+  });
+
+  describe("exact match", () => {
+    it("matches when pathname equals the route", () => {
+      expect(isLinkActive("/dashboard", "/dashboard")).toBe(true);
+      expect(isLinkActive("/settings/preferences", "/settings/preferences")).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("nested match", () => {
+    it("matches a child route nested under the link's route", () => {
+      expect(isLinkActive("/settings", "/settings/preferences")).toBe(true);
+    });
+
+    it("matches a deeply nested child route", () => {
+      expect(
+        isLinkActive("/settings/preferences", "/settings/preferences/theme"),
+      ).toBe(true);
+    });
+  });
+
+  describe("similar-but-unrelated paths", () => {
+    it("does not match a route that merely shares a prefix", () => {
+      expect(isLinkActive("/settings", "/settings-old")).toBe(false);
+    });
+
+    it("does not match a sibling route with a shared prefix", () => {
+      expect(isLinkActive("/transactions", "/transactions-archive")).toBe(
+        false,
+      );
+    });
+
+    it("does not match an unrelated route", () => {
+      expect(isLinkActive("/settings", "/help/support")).toBe(false);
+    });
+  });
+});
+
+describe("shouldExpandSidebar", () => {
+  it("expands on mobile regardless of sidebar state", () => {
+    expect(shouldExpandSidebar(true, false)).toBe(true);
+    expect(shouldExpandSidebar(true, true)).toBe(true);
+  });
+
+  it("expands on desktop only when the sidebar is open", () => {
+    expect(shouldExpandSidebar(false, true)).toBe(true);
+    expect(shouldExpandSidebar(false, false)).toBe(false);
+  });
+});
+
+describe("getActiveLinkLayoutId", () => {
+  it("returns the mobile layout id on mobile", () => {
+    expect(getActiveLinkLayoutId(true, true)).toBe("activeLink-mobile");
+    expect(getActiveLinkLayoutId(true, false)).toBe("activeLink-mobile");
+  });
+
+  it("returns the desktop layout id when expanded", () => {
+    expect(getActiveLinkLayoutId(false, true)).toBe("activeLink-desktop");
+  });
+
+  it("returns the collapsed layout id when not expanded", () => {
+    expect(getActiveLinkLayoutId(false, false)).toBe("activeLink-collapsed");
+  });
+});

--- a/utils/navigationUtils.ts
+++ b/utils/navigationUtils.ts
@@ -12,7 +12,16 @@ export const isLinkActive = (route: string, pathname: string): boolean => {
   if (route === "/") {
     return pathname === "/";
   }
-  return pathname.startsWith(route);
+
+  if (pathname === route) {
+    return true;
+  }
+
+  // Prefix-match nested routes (e.g. "/settings/preferences/theme" under
+  // "/settings/preferences"), while requiring a "/" boundary so a
+  // similar-but-unrelated path like "/settings-old" doesn't falsely match
+  // "/settings".
+  return pathname.startsWith(`${route}/`);
 };
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
         "utils/authUtils.ts",
         "utils/date-utils.ts",
         "utils/formatUtils.ts",
+        "utils/navigationUtils.ts",
         "utils/transactionUtils.ts",
         "utils/paginationUtils.ts",
         "utils/stellarAddress.ts",


### PR DESCRIPTION
isLinkActive used a naive pathname.startsWith(route) check, which caused similar-but-unrelated paths (e.g. /settings-old) to falsely match /settings. It also didn't reliably highlight a nav item for routes nested one level deeper than the link's own route.

Now matches on exact equality first, then requires a '/' boundary for prefix matches, so nested routes highlight correctly and lookalike paths don't false-positive.



## Description

<!-- Briefly describe the changes introduced in this pull request. -->

## Related Issue

<!-- Link to the issue(s) this pull request addresses, if any. -->

## Checklist

- [ ] I have tested the changes locally.
- [ ] I have added/updated documentation as needed.
- [ ] I have reviewed the code and ensured it follows the project guidelines.
- [ ] I have added necessary tests.

## Screenshots/Recordings

<!-- Attach relevant images or videos to show the effect of your changes. -->

## Additional Notes

<!-- Any other information reviewers should be aware of. -->
close #601 