### PR TITLE
fix(ui): implement accessible inline email validation on blur

### DIFF
--- a/components/common/email-input.test.tsx
+++ b/components/common/email-input.test.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import EmailInput from "./email-input";
+
+const EmailInputWrapper = ({
+  initialValue = "",
+  error,
+  helperText,
+  onBlur,
+  required,
+}: {
+  initialValue?: string;
+  error?: boolean;
+  helperText?: string;
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
+  required?: boolean;
+}) => {
+  const [value, setValue] = React.useState(initialValue);
+  return (
+    <EmailInput
+      value={value}
+      onChange={setValue}
+      error={error}
+      helperText={helperText}
+      onBlur={onBlur}
+      required={required}
+    />
+  );
+};
+
+describe("EmailInput validation on blur", () => {
+  it("should not show any error message while the user is actively typing", async () => {
+    render(<EmailInputWrapper />);
+    const input = screen.getByLabelText("Email address");
+
+    await userEvent.type(input, "invalid-email");
+
+    expect(screen.queryByText("Please enter a valid email address")).not.toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "false");
+  });
+
+  it("should show accessible error when input loses focus with a malformed email", async () => {
+    const onBlurMock = vi.fn();
+    render(<EmailInputWrapper onBlur={onBlurMock} />);
+    const input = screen.getByLabelText("Email address");
+
+    await userEvent.type(input, "invalid-email");
+    await userEvent.click(document.body);
+
+    expect(onBlurMock).toHaveBeenCalledTimes(1);
+
+    const errorMsg = screen.getByText("Please enter a valid email address");
+    expect(errorMsg).toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "true");
+
+    const describedBy = input.getAttribute("aria-describedby");
+    expect(describedBy).toContain(errorMsg.id);
+  });
+
+  it("should clear the error message immediately once the value is corrected to a valid format", async () => {
+    render(<EmailInputWrapper />);
+    const input = screen.getByLabelText("Email address");
+
+    await userEvent.type(input, "invalid-email");
+    await userEvent.click(document.body);
+
+    expect(screen.getByText("Please enter a valid email address")).toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "true");
+
+    await userEvent.type(input, "@example.com");
+
+    expect(screen.queryByText("Please enter a valid email address")).not.toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "false");
+  });
+
+  it("should clear the error message immediately when the input is emptied", async () => {
+    render(<EmailInputWrapper />);
+    const input = screen.getByLabelText("Email address");
+
+    await userEvent.type(input, "invalid-email");
+    await userEvent.click(document.body);
+
+    expect(screen.getByText("Please enter a valid email address")).toBeInTheDocument();
+
+    await userEvent.clear(input);
+
+    expect(screen.queryByText("Please enter a valid email address")).not.toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "false");
+  });
+
+  it("should concatenate the error ID with other description IDs in aria-describedby when helperText is present", async () => {
+    render(
+      <EmailInputWrapper
+        helperText="We will never share your email"
+      />
+    );
+    const input = screen.getByLabelText("Email address");
+    const helperMsg = screen.getByText("We will never share your email");
+
+    expect(input.getAttribute("aria-describedby")).toBe(helperMsg.id);
+
+    await userEvent.type(input, "invalid-email");
+    await userEvent.click(document.body);
+
+    const errorMsg = screen.getByText("Please enter a valid email address");
+    const describedBy = input.getAttribute("aria-describedby");
+
+    expect(describedBy).toContain(helperMsg.id);
+    expect(describedBy).toContain(errorMsg.id);
+    expect(describedBy).toBe(`${helperMsg.id} ${errorMsg.id}`);
+  });
+
+  it("should display authoritative error when the error prop is true", () => {
+    render(
+      <EmailInput
+        value="invalid-email"
+        onChange={() => {}}
+        error={true}
+        helperText="Custom submit error message"
+      />
+    );
+
+    const input = screen.getByLabelText("Email address");
+    const errorMsg = screen.getByText("Custom submit error message");
+
+    expect(errorMsg).toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input.getAttribute("aria-describedby")).toContain(errorMsg.id);
+  });
+});

--- a/components/common/email-input.tsx
+++ b/components/common/email-input.tsx
@@ -1,7 +1,8 @@
-import React, { ChangeEvent } from "react";
+import React, { ChangeEvent, useState, useId, useMemo } from "react";
 import { EmailInputProps } from "@/types/ui";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/utils/commonUtils";
+import { isValidEmail } from "@/utils/authUtils";
 
 interface EnhancedEmailInputProps extends EmailInputProps {
   label?: string;
@@ -11,6 +12,7 @@ interface EnhancedEmailInputProps extends EmailInputProps {
   disabled?: boolean;
   className?: string;
   placeholder?: string;
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
 }
 
 const EmailInput: React.FC<EnhancedEmailInputProps> = ({
@@ -23,27 +25,47 @@ const EmailInput: React.FC<EnhancedEmailInputProps> = ({
   disabled = false,
   className,
   placeholder = "example@email.com",
+  onBlur,
 }) => {
-  const fieldId = React.useId();
+  const [localError, setLocalError] = useState(false);
+  const fieldId = useId();
+
   const descriptionId = helperText ? `${fieldId}-description` : undefined;
   const errorId = error ? `${fieldId}-error` : undefined;
+  const localErrorId = localError ? `${fieldId}-local-error` : undefined;
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onChange(event.target.value);
+    const val = event.target.value;
+    onChange(val);
+    if (val.trim() === "" || isValidEmail(val)) {
+      setLocalError(false);
+    }
   };
 
-  const describedBy = React.useMemo(() => {
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    const isMalformed = value.trim() !== "" && !isValidEmail(value);
+    setLocalError(isMalformed);
+    if (onBlur) {
+      onBlur(event);
+    }
+  };
+
+  const describedBy = useMemo(() => {
     const ids = [];
-    if (descriptionId) ids.push(descriptionId);
+    if (descriptionId && !error) ids.push(descriptionId);
     if (errorId) ids.push(errorId);
+    if (localErrorId) ids.push(localErrorId);
     return ids.length > 0 ? ids.join(" ") : undefined;
-  }, [descriptionId, errorId]);
+  }, [descriptionId, errorId, localErrorId, error]);
+
+  const hasAnyError = error || localError;
 
   return (
     <div className={cn("w-full space-y-2", className)}>
       <Label
+        htmlFor={fieldId}
         required={required}
-        error={error}
+        error={hasAnyError}
         descriptionId={descriptionId}
         className="text-sm font-medium"
       >
@@ -52,7 +74,7 @@ const EmailInput: React.FC<EnhancedEmailInputProps> = ({
       <div
         className={cn(
           "flex items-center border rounded-md h-12 overflow-hidden transition-colors",
-          error ? "border-destructive ring-destructive/20" : "border-input",
+          hasAnyError ? "border-destructive ring-destructive/20" : "border-input",
           disabled && "opacity-50 cursor-not-allowed",
         )}
       >
@@ -63,9 +85,10 @@ const EmailInput: React.FC<EnhancedEmailInputProps> = ({
           placeholder={placeholder}
           value={value}
           onChange={handleChange}
+          onBlur={handleBlur}
           disabled={disabled}
           className="px-3 w-full bg-transparent focus:outline-none text-foreground"
-          aria-invalid={error ? "true" : "false"}
+          aria-invalid={hasAnyError ? "true" : "false"}
           aria-describedby={describedBy}
           aria-required={required}
           autoComplete="email"
@@ -84,6 +107,16 @@ const EmailInput: React.FC<EnhancedEmailInputProps> = ({
           aria-live="polite"
         >
           {helperText}
+        </p>
+      )}
+      {!error && localError && (
+        <p
+          id={localErrorId}
+          className="text-xs text-destructive"
+          role="alert"
+          aria-live="polite"
+        >
+          Please enter a valid email address
         </p>
       )}
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1643,7 +1643,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
       "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.61.1"
@@ -3232,7 +3232,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3242,7 +3242,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -5917,7 +5917,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8039,7 +8038,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
       "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.61.1"
@@ -8058,7 +8057,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"


### PR DESCRIPTION
Closes #648

## Description
This PR introduces accessible, blur-triggered inline validation feedback to the `EmailInput` component. It enhances user experience across authentication and settings forms by highlighting malformed inputs before full form submission without interrupting active typing.

### Proposed Changes
* **UX Form Validation:** Added an `onBlur` validation check utilizing the existing `isValidEmail` utility to toggle a local error state.
* **Typing Guard:** Configured the `onChange` handler to suppress premature alerts while the user is actively typing, immediately clearing errors once a valid format is achieved.
* **A11y Compliance:** Bound the dynamic inline error message to the input field using `aria-describedby` concatenation alongside a proper `aria-invalid` state flag.
* **Unit Testing:** Created a comprehensive test suite covering blur triggers, active typing isolation, and dynamic error clearance to satisfy coverage criteria.