### PR TITLE
Animate landing stats counters on viewport entry

### DIFF
--- a/components/landing/stats-cards.test.tsx
+++ b/components/landing/stats-cards.test.tsx
@@ -1,0 +1,170 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { StatCardItem } from "@/types/landing";
+import { StatsCards } from "./stats-cards";
+
+const stats: StatCardItem[] = [
+  { value: "$2.5B+", label: "Transaction Volume" },
+  { value: "150K+", label: "Active Users" },
+  { value: "99.9%", label: "Uptime" },
+  { value: "<3s", label: "Transaction Speed" },
+];
+
+type IntersectionCallback = ConstructorParameters<
+  typeof IntersectionObserver
+>[0];
+
+let intersectionCallback: IntersectionCallback;
+let animationFrames: FrameRequestCallback[];
+let disconnect: ReturnType<typeof vi.fn>;
+let observe: ReturnType<typeof vi.fn>;
+
+function valueFor(label: string): Element {
+  const labelElement = screen.getByText(label);
+  const valueElement = labelElement.previousElementSibling;
+
+  if (!valueElement) throw new Error(`No value found for ${label}`);
+  return valueElement;
+}
+
+function intersect(isIntersecting: boolean): void {
+  act(() => {
+    intersectionCallback(
+      [{ isIntersecting } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+  });
+}
+
+function runNextFrame(timestamp: number): void {
+  const callback = animationFrames.shift();
+  if (!callback) throw new Error("No animation frame was scheduled");
+
+  act(() => callback(timestamp));
+}
+
+describe("StatsCards", () => {
+  beforeEach(() => {
+    animationFrames = [];
+    disconnect = vi.fn();
+    observe = vi.fn();
+
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn().mockReturnValue({ matches: false }),
+    });
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: vi.fn((callback: FrameRequestCallback) => {
+        animationFrames.push(callback);
+        return animationFrames.length;
+      }),
+    });
+    Object.defineProperty(window, "cancelAnimationFrame", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(window, "IntersectionObserver", {
+      configurable: true,
+      value: vi.fn(function IntersectionObserverMock(
+        callback: IntersectionCallback,
+      ) {
+        intersectionCallback = callback;
+        return {
+          disconnect,
+          observe,
+          unobserve: vi.fn(),
+          takeRecords: vi.fn(),
+        };
+      }),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts counting only after the cards intersect the viewport", () => {
+    render(<StatsCards stats={stats} />);
+
+    expect(observe).toHaveBeenCalledOnce();
+    expect(valueFor("Transaction Volume")).toHaveTextContent("$0.0B+");
+    expect(valueFor("Active Users")).toHaveTextContent("0K+");
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+
+    intersect(false);
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+
+    intersect(true);
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(window.requestAnimationFrame).toHaveBeenCalledOnce();
+
+    runNextFrame(0);
+    runNextFrame(1_500);
+
+    expect(valueFor("Transaction Volume")).toHaveTextContent("$2.5B+");
+    expect(valueFor("Active Users")).toHaveTextContent("150K+");
+    expect(valueFor("Uptime")).toHaveTextContent("99.9%");
+    expect(valueFor("Transaction Speed")).toHaveTextContent("<3s");
+  });
+
+  it("does not restart after repeated intersections", () => {
+    render(<StatsCards stats={stats} />);
+
+    intersect(true);
+    runNextFrame(0);
+    runNextFrame(1_500);
+
+    const requestCount = vi.mocked(window.requestAnimationFrame).mock.calls
+      .length;
+    intersect(false);
+    intersect(true);
+
+    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(requestCount);
+    expect(valueFor("Transaction Volume")).toHaveTextContent("$2.5B+");
+  });
+
+  it("shows final values immediately when reduced motion is preferred", () => {
+    vi.mocked(window.matchMedia).mockReturnValue({
+      matches: true,
+    } as MediaQueryList);
+
+    render(<StatsCards stats={stats} />);
+
+    expect(valueFor("Transaction Volume")).toHaveTextContent("$2.5B+");
+    expect(valueFor("Active Users")).toHaveTextContent("150K+");
+    expect(window.IntersectionObserver).not.toHaveBeenCalled();
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  it("preserves non-numeric values", () => {
+    render(
+      <StatsCards stats={[{ value: "Available", label: "Service Status" }]} />,
+    );
+
+    expect(valueFor("Service Status")).toHaveTextContent("Available");
+  });
+
+  it("starts immediately when IntersectionObserver is unavailable", () => {
+    Object.defineProperty(window, "IntersectionObserver", {
+      configurable: true,
+      value: undefined,
+    });
+
+    const { unmount } = render(<StatsCards stats={stats} />);
+
+    expect(window.requestAnimationFrame).toHaveBeenCalledOnce();
+    unmount();
+    expect(window.cancelAnimationFrame).toHaveBeenCalledWith(1);
+  });
+
+  it("cleans up an observer before an animation has started", () => {
+    const { unmount } = render(<StatsCards stats={stats} />);
+
+    unmount();
+
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(window.cancelAnimationFrame).not.toHaveBeenCalled();
+  });
+});

--- a/components/landing/stats-cards.tsx
+++ b/components/landing/stats-cards.tsx
@@ -1,13 +1,129 @@
-import { FC } from "react";
+"use client";
+
+import { FC, useEffect, useMemo, useRef, useState } from "react";
 import type { StatCardItem } from "@/types/landing";
 
 export interface StatsCardsProps {
   stats: StatCardItem[];
 }
 
+const ANIMATION_DURATION_MS = 1_500;
+
+interface ParsedStatValue {
+  decimalPlaces: number;
+  prefix: string;
+  suffix: string;
+  target: number;
+}
+
+function parseStatValue(value: string): ParsedStatValue | null {
+  const match = value.match(/^(.*?)(-?[\d,]+(?:\.\d+)?)(.*)$/);
+
+  if (!match) return null;
+
+  const [, prefix, numericValue, suffix] = match;
+  const decimalPlaces = numericValue.includes(".")
+    ? numericValue.split(".")[1].length
+    : 0;
+
+  return {
+    decimalPlaces,
+    prefix,
+    suffix,
+    target: Number(numericValue.replaceAll(",", "")),
+  };
+}
+
+function formatStatValue(
+  originalValue: string,
+  parsedValue: ParsedStatValue | null,
+  progress: number,
+): string {
+  if (!parsedValue) return originalValue;
+
+  const { decimalPlaces, prefix, suffix, target } = parsedValue;
+  const currentValue = target * progress;
+  const formattedNumber =
+    decimalPlaces > 0
+      ? currentValue.toFixed(decimalPlaces)
+      : Math.round(currentValue).toLocaleString("en-US");
+
+  return `${prefix}${formattedNumber}${suffix}`;
+}
+
 export const StatsCards: FC<StatsCardsProps> = ({ stats }) => {
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const animationFrameRef = useRef<number | null>(null);
+  const hasAnimatedRef = useRef(false);
+  const [progress, setProgress] = useState(0);
+  const parsedStats = useMemo(
+    () => stats.map(({ value }) => parseStatValue(value)),
+    [stats],
+  );
+
+  useEffect(() => {
+    const prefersReducedMotion =
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    if (prefersReducedMotion) {
+      hasAnimatedRef.current = true;
+      setProgress(1);
+      return;
+    }
+
+    const startAnimation = () => {
+      if (hasAnimatedRef.current) return;
+
+      hasAnimatedRef.current = true;
+      let startTime: number | null = null;
+
+      const animate = (timestamp: number) => {
+        if (startTime === null) startTime = timestamp;
+
+        const elapsed = timestamp - startTime;
+        const linearProgress = Math.min(elapsed / ANIMATION_DURATION_MS, 1);
+        const easedProgress = 1 - Math.pow(1 - linearProgress, 3);
+        setProgress(easedProgress);
+
+        if (linearProgress < 1) {
+          animationFrameRef.current = window.requestAnimationFrame(animate);
+        }
+      };
+
+      animationFrameRef.current = window.requestAnimationFrame(animate);
+    };
+
+    if (typeof window.IntersectionObserver !== "function") {
+      startAnimation();
+      return () => {
+        // startAnimation schedules a frame synchronously in this fallback.
+        window.cancelAnimationFrame(animationFrameRef.current!);
+      };
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        observer.disconnect();
+        startAnimation();
+      }
+    });
+
+    if (sectionRef.current) observer.observe(sectionRef.current);
+
+    return () => {
+      observer.disconnect();
+      if (animationFrameRef.current !== null) {
+        window.cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, []);
+
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 w-full">
+    <div
+      ref={sectionRef}
+      className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 w-full"
+    >
       {stats.map((item, index) => (
         <div
           key={index}
@@ -29,7 +145,7 @@ export const StatsCards: FC<StatsCardsProps> = ({ stats }) => {
               block
             "
           >
-            {item.value}
+            {formatStatValue(item.value, parsedStats[index], progress)}
           </span>
           <span
             className="


### PR DESCRIPTION
## Summary
- start stats counter animations only when the cards enter the viewport
- prevent repeated animations and preserve numeric prefixes, suffixes, and decimal precision
- show final values immediately for reduced-motion users
- add focused coverage for intersection, repeat-entry, fallback, cleanup, and reduced-motion behavior

## Test evidence
- `npm run test` — 48 files and 550 tests passed
- targeted stats-card coverage — 100% statements, lines, and functions; 96.15% branches
- `npm run lint` — passed with two unrelated existing warnings
- `npx prettier --check components/landing/stats-cards.tsx components/landing/stats-cards.test.tsx` — passed
- `git diff --check` — passed
- `npm run type-check` — blocked by existing unrelated errors in `components/common/text-input.test.tsx` and `tests/settings-notifications.spec.ts`; changed files report no errors

Fixes #656

### Verification
- `npm run test — 48 files, 550 tests passed`
- `Targeted coverage — 100% statements/lines/functions, 96.15% branches`
- `npm run lint — passed with 2 unrelated existing warnings`
- `npx prettier --check — passed`
- `git diff --check — passed`
- `npm run type-check — existing unrelated errors remain in text-input.test.tsx and settings-notifications.spec.ts; no errors in changed files`

### Diagnostics
Recovered command failures: `/bin/zsh -lc 'npm ci'` (255), `/bin/zsh -lc 'npx vitest run components/landing/stats-cards.test.tsx --coverage=false'` (1), `/bin/zsh -lc 'npx vitest run components/landing/stats-cards.test.tsx --coverage --coverage.include=components/landing/stats-cards.tsx'` (1), `/bin/zsh -lc 'npx vitest run components/landing/stats-cards.test.tsx --coverage --coverage.include=components/landing/stats-cards.tsx'` (1), `/bin/zsh -lc 'npx prettier --check components/landing/stats-cards.tsx components/landing/stats-cards.test.tsx'` (1), `/bin/zsh -lc 'npm run type-check'` (2)