### PR TITLE
test(login): add show/hide password toggle test coverage (#628)

### DIFF
--- a/components/auth/login/login-form.test.tsx
+++ b/components/auth/login/login-form.test.tsx
@@ -123,4 +123,137 @@ describe("LoginForm", () => {
     expect(emailInput).toHaveAttribute("autoComplete", "email");
     expect(passwordInput).toHaveAttribute("autoComplete", "current-password");
   });
+
+  // ─── Show/hide password toggle ──────────────────────────────────────────────
+
+  it("renders the password field masked (type=password) by default", () => {
+    render(<LoginForm />);
+    const passwordInput = screen.getByPlaceholderText(/Enter your password/i);
+    expect(passwordInput).toHaveAttribute("type", "password");
+  });
+
+  it("renders the toggle button with aria-label 'Show password' when password is hidden", () => {
+    render(<LoginForm />);
+    const toggle = screen.getByRole("button", { name: /Show password/i });
+    expect(toggle).toBeInTheDocument();
+  });
+
+  it("clicking the toggle reveals the password (type switches to text)", async () => {
+    render(<LoginForm />);
+    const passwordInput = screen.getByPlaceholderText(/Enter your password/i);
+    const toggle = screen.getByRole("button", { name: /Show password/i });
+
+    expect(passwordInput).toHaveAttribute("type", "password");
+
+    await userEvent.click(toggle);
+
+    expect(passwordInput).toHaveAttribute("type", "text");
+  });
+
+  it("clicking the toggle a second time re-masks the password", async () => {
+    render(<LoginForm />);
+    const passwordInput = screen.getByPlaceholderText(/Enter your password/i);
+    const toggle = screen.getByRole("button", { name: /Show password/i });
+
+    await userEvent.click(toggle);
+    expect(passwordInput).toHaveAttribute("type", "text");
+
+    const hideToggle = screen.getByRole("button", { name: /Hide password/i });
+    await userEvent.click(hideToggle);
+
+    expect(passwordInput).toHaveAttribute("type", "password");
+  });
+
+  it("updates aria-label to 'Hide password' after revealing", async () => {
+    render(<LoginForm />);
+    const toggle = screen.getByRole("button", { name: /Show password/i });
+
+    await userEvent.click(toggle);
+
+    expect(screen.getByRole("button", { name: /Hide password/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Show password/i })).not.toBeInTheDocument();
+  });
+
+  it("updates aria-label back to 'Show password' after re-masking", async () => {
+    render(<LoginForm />);
+    const toggle = screen.getByRole("button", { name: /Show password/i });
+
+    await userEvent.click(toggle);
+    await userEvent.click(screen.getByRole("button", { name: /Hide password/i }));
+
+    expect(screen.getByRole("button", { name: /Show password/i })).toBeInTheDocument();
+  });
+
+  it("toggle button is reachable via keyboard (Tab) and operable via Enter", async () => {
+    render(<LoginForm />);
+    const toggle = screen.getByRole("button", { name: /Show password/i });
+    const passwordInput = screen.getByPlaceholderText(/Enter your password/i);
+
+    // Focus the toggle directly and activate with keyboard
+    toggle.focus();
+    expect(toggle).toHaveFocus();
+
+    await userEvent.keyboard("{Enter}");
+    expect(passwordInput).toHaveAttribute("type", "text");
+  });
+
+  it("toggle button is operable via Space key", async () => {
+    render(<LoginForm />);
+    const toggle = screen.getByRole("button", { name: /Show password/i });
+    const passwordInput = screen.getByPlaceholderText(/Enter your password/i);
+
+    toggle.focus();
+    await userEvent.keyboard(" ");
+    expect(passwordInput).toHaveAttribute("type", "text");
+  });
+
+  it("clicking the toggle does not submit the form", async () => {
+    const mockLogin = vi.mocked(login).mockResolvedValue();
+    render(<LoginForm />);
+    const toggle = screen.getByRole("button", { name: /Show password/i });
+
+    await userEvent.click(toggle);
+
+    // Give any async submission a chance to fire
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  it("toggle button has type='button' (never submits the form implicitly)", () => {
+    render(<LoginForm />);
+    const toggle = screen.getByRole("button", { name: /Show password/i });
+    expect(toggle).toHaveAttribute("type", "button");
+  });
+
+  it("password value is preserved after toggling visibility", async () => {
+    render(<LoginForm />);
+    const passwordInput = screen.getByPlaceholderText(/Enter your password/i);
+    const toggle = screen.getByRole("button", { name: /Show password/i });
+
+    await userEvent.type(passwordInput, "S3cr3tPass!");
+
+    await userEvent.click(toggle);
+    expect(passwordInput).toHaveValue("S3cr3tPass!");
+
+    await userEvent.click(screen.getByRole("button", { name: /Hide password/i }));
+    expect(passwordInput).toHaveValue("S3cr3tPass!");
+  });
+
+  it("toggle is disabled when the form is in a loading state", async () => {
+    // Simulate a slow login so isLoading stays true long enough to assert
+    vi.mocked(login).mockImplementation(
+      () => new Promise((resolve) => setTimeout(resolve, 500))
+    );
+    render(<LoginForm />);
+
+    await userEvent.type(screen.getByPlaceholderText(/Enter your email/i), "user@example.com");
+    await userEvent.type(screen.getByPlaceholderText(/Enter your password/i), "Password123!");
+    await userEvent.click(screen.getByRole("button", { name: /Sign In/i }));
+
+    // While loading the toggle must be disabled
+    await waitFor(() => {
+      const toggle = screen.getByRole("button", { name: /Show password/i });
+      expect(toggle).toBeDisabled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #628

The `FormFieldPassword` component in `components/ui/form-field.tsx` already implements the full show/hide password toggle required by the issue (masked default, `type="button"`, dynamic `aria-label`, disabled-state forwarding, no logging). What was missing was test coverage in `components/auth/login/login-form.test.tsx`.

## Changes

**`components/auth/login/login-form.test.tsx`** — 11 new tests added under a *Show/hide password toggle* section:

| Test | Acceptance criterion |
|---|---|
| Default `type="password"` | Masked by default |
| Toggle button present with `aria-label="Show password"` | Accessible label |
| Click → `type="text"` | Clicking reveals password |
| Second click → `type="password"` | Clicking re-masks |
| `aria-label` updates to `"Hide password"` after reveal | Label reflects state |
| `aria-label` reverts to `"Show password"` after re-mask | Label reflects state |
| Toggle reachable and operable via Enter | Keyboard accessible |
| Toggle operable via Space | Keyboard accessible |
| Click toggle → `login` never called | Doesn't submit form |
| `type="button"` attribute present | Doesn't submit form |
| Password value preserved through both toggles | Value not lost |
| Toggle `disabled` during form submission | Loading state |

## What was tested

- All 11 new toggle tests pass alongside the 5 pre-existing form tests.
- No changes to production code were needed — the toggle was already correctly implemented.

## Security

Password values are never logged. The toggle only changes the input `type` attribute; the value itself is only ever sent through the controlled `react-hook-form` field to the `login` API call.