### PR TITLE
feat(dashboard): add loading skeleton to summary-data while data resolves (#643)

### DIFF
--- a/components/dashboard/account-overview.test.tsx
+++ b/components/dashboard/account-overview.test.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import AccountOverview from "./account-overview";
 import { WalletProvider, useWallet } from "@/context/wallet-context";
+import * as summaryDataModule from "./summary-data";
 
 const PUBLIC_ADDRESS = "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPF123";
 const SECOND_PUBLIC_ADDRESS =
@@ -130,5 +131,297 @@ describe("AccountOverview", () => {
     expect(screen.getByTestId("account-overview-address")).toHaveTextContent(
       "GABC...F123",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loading state — skeleton shown while data resolves
+// ---------------------------------------------------------------------------
+describe("AccountOverview – loading state", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("shows the loading skeleton before data resolves", async () => {
+    // Hold the Promise indefinitely so the component stays in loading state.
+    vi.spyOn(summaryDataModule, 'summaryCardsData', 'get').mockReturnValue(
+      new Promise(() => {}) as unknown as typeof summaryDataModule.summaryCardsData,
+    );
+
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    expect(
+      screen.getByRole("status", { name: /loading account summary/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("skeleton has aria-busy='true' while loading", async () => {
+    vi.spyOn(summaryDataModule, 'summaryCardsData', 'get').mockReturnValue(
+      new Promise(() => {}) as unknown as typeof summaryDataModule.summaryCardsData,
+    );
+
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    expect(
+      screen.getByRole("status", { name: /loading account summary/i }),
+    ).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("does not show card data while loading", async () => {
+    vi.spyOn(summaryDataModule, 'summaryCardsData', 'get').mockReturnValue(
+      new Promise(() => {}) as unknown as typeof summaryDataModule.summaryCardsData,
+    );
+
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    expect(screen.queryByTestId("summary-cards-grid")).not.toBeInTheDocument();
+    expect(screen.queryByText("Total Balance")).not.toBeInTheDocument();
+  });
+
+  it("does not show an error state while loading", async () => {
+    vi.spyOn(summaryDataModule, 'summaryCardsData', 'get').mockReturnValue(
+      new Promise(() => {}) as unknown as typeof summaryDataModule.summaryCardsData,
+    );
+
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    expect(screen.queryByTestId("summary-error")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success state — real cards shown, skeleton removed
+// ---------------------------------------------------------------------------
+describe("AccountOverview – success state", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("renders the cards grid after data resolves", async () => {
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("summary-cards-grid")).toBeInTheDocument();
+    });
+  });
+
+  it("removes the skeleton after data resolves", async () => {
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("status", { name: /loading account summary/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders all three summary card titles after load", async () => {
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Total Balance")).toBeInTheDocument();
+      expect(screen.getByText("Paid This Month")).toBeInTheDocument();
+      expect(screen.getByText("To Be Paid")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show the error state after a successful load", async () => {
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("summary-error")).not.toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error state — distinct error UI, no stuck skeleton, retry re-runs load
+// ---------------------------------------------------------------------------
+describe("AccountOverview – error state", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  /**
+   * Force summaryCardsData to behave as a rejected Promise by temporarily
+   * replacing the real value with a getter that throws synchronously.
+   * The component wraps it in Promise.resolve() which catches sync throws
+   * and routes them to the .catch() branch.
+   */
+  function forceLoadError(message = "Failed to load account summary.") {
+    vi.spyOn(summaryDataModule, 'summaryCardsData', 'get').mockImplementation(
+      () => { throw new Error(message); },
+    );
+  }
+
+  it("shows the error state when data fails to load", async () => {
+    forceLoadError();
+
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("summary-error")).toBeInTheDocument();
+    });
+  });
+
+  it("error state uses role='alert'", async () => {
+    forceLoadError();
+
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+
+  it("error state shows the failure message", async () => {
+    forceLoadError("Failed to load account summary.");
+
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/failed to load account summary/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not show a stuck skeleton in the error state", async () => {
+    forceLoadError();
+
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("summary-error")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("status", { name: /loading account summary/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show card data in the error state", async () => {
+    forceLoadError();
+
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("summary-error")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("summary-cards-grid")).not.toBeInTheDocument();
+    expect(screen.queryByText("Total Balance")).not.toBeInTheDocument();
+  });
+
+  it("shows a Retry button in the error state", async () => {
+    forceLoadError();
+
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    });
+  });
+
+  it("clicking Retry re-triggers the load and shows success on recovery", async () => {
+    // First call throws, second call succeeds.
+    const spy = vi.spyOn(summaryDataModule, 'summaryCardsData', 'get')
+      .mockImplementationOnce(() => { throw new Error("transient error"); })
+      .mockReturnValue(summaryDataModule.summaryCardsData);
+
+    render(
+      <WalletProvider initialAddress={null}>
+        <AccountOverview />
+      </WalletProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("summary-error")).toBeInTheDocument();
+    });
+
+    // Restore so the second call succeeds.
+    spy.mockRestore();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("summary-cards-grid")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("summary-error")).not.toBeInTheDocument();
   });
 });

--- a/components/dashboard/account-overview.tsx
+++ b/components/dashboard/account-overview.tsx
@@ -1,10 +1,19 @@
 'use client';
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import AccountSummaryCard from './account-summary-card';
-import { summaryCardsData } from './summary-data';
-import { Wallet, BarChart3, ArrowRight, PieChart } from "lucide-react";
+import { summaryCardsData, SummaryCardsSkeleton, AccountSummaryCardProps } from './summary-data';
+import { Wallet, BarChart3, ArrowRight, PieChart, AlertCircle, RefreshCw } from "lucide-react";
 import { formatAddress, useWallet } from "@/context/wallet-context";
+
+// ─── Loading / error state types ─────────────────────────────────────────────
+
+type SummaryState =
+  | { status: 'loading' }
+  | { status: 'success'; cards: AccountSummaryCardProps[] }
+  | { status: 'error'; message: string };
+
+// ─── Component ────────────────────────────────────────────────────────────────
 
 export default function AccountOverview() {
   const { address, isConnected, connect } = useWallet();
@@ -13,6 +22,9 @@ export default function AccountOverview() {
   const handleConnect = useCallback(() => {
     connect();
   }, [connect]);
+
+  // ── Data resolution ─────────────────────────────────────────────────────
+  const [summaryState, setSummaryState] = useState<SummaryState>({ status: 'loading' });
 
   // Keep static icon/card render data stable across wallet context ticks.
   const icons = useMemo(
@@ -24,14 +36,30 @@ export default function AccountOverview() {
     [],
   );
 
-  const accountSummaryCards = useMemo(
-    () =>
-      summaryCardsData.map((card, idx) => ({
-        ...card,
-        icon: icons[idx],
-      })),
-    [icons],
-  );
+  const loadSummary = useCallback(() => {
+    setSummaryState({ status: 'loading' });
+
+    // The data currently comes from a static module (summaryCardsData).
+    // This async wrapper keeps the loading/error contract intact so that
+    // when a real API replaces the static import the component needs no
+    // structural changes — only the Promise body changes.
+    Promise.resolve(summaryCardsData)
+      .then((data) => {
+        const cards = data.map((card, idx) => ({ ...card, icon: icons[idx] }));
+        setSummaryState({ status: 'success', cards });
+      })
+      .catch((err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : 'Failed to load account summary.';
+        setSummaryState({ status: 'error', message });
+      });
+  }, [icons]);
+
+  useEffect(() => {
+    loadSummary();
+  }, [loadSummary]);
+
+  // ── Render ───────────────────────────────────────────────────────────────
 
   return (
     <div className="w-full h-full">
@@ -75,15 +103,45 @@ export default function AccountOverview() {
         </button>
       </div>
 
-      {/* Cards Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {accountSummaryCards.map((card) => (
-          <AccountSummaryCard
-            key={card.title}
-            {...card}
-          />
-        ))}
-      </div>
+      {/* Cards Grid — loading / error / success */}
+      {summaryState.status === 'loading' && (
+        <SummaryCardsSkeleton shade="dark" />
+      )}
+
+      {summaryState.status === 'error' && (
+        <div
+          role="alert"
+          data-testid="summary-error"
+          className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-destructive/20 bg-destructive/5 px-6 py-10 text-center"
+        >
+          <AlertCircle className="h-8 w-8 text-destructive" aria-hidden="true" />
+          <p className="text-sm font-medium text-destructive">
+            {summaryState.message}
+          </p>
+          <button
+            type="button"
+            onClick={loadSummary}
+            className="inline-flex items-center gap-2 rounded-lg bg-zinc-900 dark:bg-white px-4 py-2 text-sm font-semibold text-white dark:text-zinc-900 hover:opacity-90 transition-opacity"
+          >
+            <RefreshCw className="h-4 w-4" aria-hidden="true" />
+            Retry
+          </button>
+        </div>
+      )}
+
+      {summaryState.status === 'success' && (
+        <div
+          data-testid="summary-cards-grid"
+          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+        >
+          {summaryState.cards.map((card) => (
+            <AccountSummaryCard
+              key={card.title}
+              {...card}
+            />
+          ))}
+        </div>
+      )}
 
       {/* Mobile Button */}
       <button className="sm:hidden w-full mt-6 flex items-center justify-center gap-2 px-4 py-3 bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 rounded-lg text-sm font-semibold shadow-lg cursor-pointer">

--- a/components/dashboard/summary-data.test.tsx
+++ b/components/dashboard/summary-data.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * @fileoverview Tests for components/dashboard/summary-data.tsx
+ *
+ * Covers:
+ * - summaryCardsData shape and content
+ * - SummaryCardSkeleton: renders correct structure, aria-hidden, shade prop
+ * - SummaryCardsSkeleton: renders correct count, role/aria attributes, shade forwarding
+ */
+
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import {
+  summaryCardsData,
+  SummaryCardSkeleton,
+  SummaryCardsSkeleton,
+} from './summary-data';
+
+// ─── summaryCardsData ─────────────────────────────────────────────────────────
+
+describe('summaryCardsData', () => {
+  it('exports exactly three summary cards', () => {
+    expect(summaryCardsData).toHaveLength(3);
+  });
+
+  it('each card has the required fields', () => {
+    for (const card of summaryCardsData) {
+      expect(card).toHaveProperty('title');
+      expect(card).toHaveProperty('subtitle');
+      expect(card).toHaveProperty('value');
+      expect(card).toHaveProperty('change');
+      expect(card).toHaveProperty('isPositive');
+      expect(card).toHaveProperty('iconBgColor');
+      expect(card).toHaveProperty('chartColor');
+      expect(card).toHaveProperty('chartData');
+    }
+  });
+
+  it('each card has at least one chart data point', () => {
+    for (const card of summaryCardsData) {
+      expect(card.chartData.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('includes Total Balance, Paid This Month, and To Be Paid cards', () => {
+    const titles = summaryCardsData.map((c) => c.title);
+    expect(titles).toContain('Total Balance');
+    expect(titles).toContain('Paid This Month');
+    expect(titles).toContain('To Be Paid');
+  });
+});
+
+// ─── SummaryCardSkeleton ──────────────────────────────────────────────────────
+
+describe('SummaryCardSkeleton', () => {
+  it('renders without crashing', () => {
+    render(<SummaryCardSkeleton />);
+  });
+
+  it('is marked aria-hidden so screen readers skip it', () => {
+    render(<SummaryCardSkeleton />);
+    // The outermost wrapper must carry aria-hidden="true".
+    const card = document.querySelector('[aria-hidden="true"]');
+    expect(card).toBeInTheDocument();
+  });
+
+  it('contains an icon placeholder skeleton', () => {
+    const { container } = render(<SummaryCardSkeleton />);
+    // Icon placeholder: w-12 h-12 rounded-xl
+    const iconSkeleton = container.querySelector('.w-12.h-12.rounded-xl');
+    expect(iconSkeleton).toBeInTheDocument();
+  });
+
+  it('contains a value placeholder skeleton', () => {
+    const { container } = render(<SummaryCardSkeleton />);
+    // Value placeholder: h-8 w-36
+    const valueSkeleton = container.querySelector('.h-8.w-36');
+    expect(valueSkeleton).toBeInTheDocument();
+  });
+
+  it('contains a chart placeholder skeleton', () => {
+    const { container } = render(<SummaryCardSkeleton />);
+    // Chart placeholder: h-12 w-full rounded-lg
+    const chartSkeleton = container.querySelector('.h-12.rounded-lg');
+    expect(chartSkeleton).toBeInTheDocument();
+  });
+
+  it('accepts and forwards an extra className to the wrapper', () => {
+    const { container } = render(<SummaryCardSkeleton className="test-extra-class" />);
+    expect(container.firstChild).toHaveClass('test-extra-class');
+  });
+
+  it('applies the dark shade by default', () => {
+    const { container } = render(<SummaryCardSkeleton />);
+    // Skeleton dark shade uses bg-[#2D2D2D]
+    const darkSkeleton = container.querySelector('.bg-\\[\\#2D2D2D\\]');
+    expect(darkSkeleton).toBeInTheDocument();
+  });
+
+  it('applies the light shade when shade="light"', () => {
+    const { container } = render(<SummaryCardSkeleton shade="light" />);
+    // Skeleton light shade uses bg-[#3A3A3A]
+    const lightSkeleton = container.querySelector('.bg-\\[\\#3A3A3A\\]');
+    expect(lightSkeleton).toBeInTheDocument();
+  });
+});
+
+// ─── SummaryCardsSkeleton ─────────────────────────────────────────────────────
+
+describe('SummaryCardsSkeleton', () => {
+  it('renders without crashing', () => {
+    render(<SummaryCardsSkeleton />);
+  });
+
+  it('has role="status" for assistive technology', () => {
+    render(<SummaryCardsSkeleton />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('has aria-label="Loading account summary"', () => {
+    render(<SummaryCardsSkeleton />);
+    expect(
+      screen.getByRole('status', { name: /loading account summary/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('has aria-busy="true" while rendering', () => {
+    render(<SummaryCardsSkeleton />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('renders the same number of skeleton cards as summaryCardsData entries', () => {
+    const { container } = render(<SummaryCardsSkeleton />);
+    // Each SummaryCardSkeleton root carries aria-hidden="true"
+    const skeletonCards = container.querySelectorAll('[aria-hidden="true"]');
+    expect(skeletonCards).toHaveLength(summaryCardsData.length);
+  });
+
+  it('uses the dark shade by default', () => {
+    const { container } = render(<SummaryCardsSkeleton />);
+    const darkSkeletons = container.querySelectorAll('.bg-\\[\\#2D2D2D\\]');
+    expect(darkSkeletons.length).toBeGreaterThan(0);
+  });
+
+  it('forwards shade="light" to each child skeleton', () => {
+    const { container } = render(<SummaryCardsSkeleton shade="light" />);
+    const lightSkeletons = container.querySelectorAll('.bg-\\[\\#3A3A3A\\]');
+    expect(lightSkeletons.length).toBeGreaterThan(0);
+  });
+
+  it('uses the grid layout matching the real cards grid', () => {
+    render(<SummaryCardsSkeleton />);
+    const grid = screen.getByRole('status');
+    expect(grid).toHaveClass('grid');
+    expect(grid).toHaveClass('grid-cols-1');
+  });
+});

--- a/components/dashboard/summary-data.tsx
+++ b/components/dashboard/summary-data.tsx
@@ -1,4 +1,6 @@
 import { ReactNode } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/utils/commonUtils';
 
 export interface ChartData {
   value: number;
@@ -60,3 +62,109 @@ export const summaryCardsData: AccountSummaryCardProps[] = [
     ]
   }
 ];
+
+// ─── Skeleton ────────────────────────────────────────────────────────────────
+
+/**
+ * Skeleton placeholder for a single {@link AccountSummaryCard}.
+ *
+ * The layout intentionally mirrors the real card's structure so that no
+ * layout shift occurs when the resolved content replaces the skeleton:
+ *
+ * ```
+ * ┌────────────────────────────────────────┐
+ * │  [icon]  [title]                       │
+ * │          [subtitle]                    │
+ * ├────────────────────────────────────────┤
+ * │  [value — wide]                        │
+ * │  [badge]  [label]                      │
+ * ├────────────────────────────────────────┤
+ * │  [mini bar chart]                      │
+ * └────────────────────────────────────────┘
+ * ```
+ *
+ * @param className - Extra Tailwind classes forwarded to the card wrapper.
+ * @param shade     - Passed through to every {@link Skeleton} child so the
+ *   placeholder blends with the host surface (light or dark).
+ */
+export function SummaryCardSkeleton({
+  className,
+  shade = 'dark',
+}: {
+  className?: string;
+  shade?: 'light' | 'dark';
+}) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        'bg-white dark:bg-[#111111] border border-zinc-200 dark:border-zinc-800',
+        'rounded-2xl p-6 flex flex-col gap-4 shadow-sm',
+        className,
+      )}
+    >
+      {/* Row 1: icon + title / subtitle */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          {/* Icon placeholder — matches w-12 h-12 rounded-xl */}
+          <Skeleton shade={shade} className="w-12 h-12 rounded-xl" />
+          <div className="space-y-2">
+            {/* title — text-sm */}
+            <Skeleton shade={shade} className="h-3 w-28" />
+            {/* subtitle — text-xs */}
+            <Skeleton shade={shade} className="h-2.5 w-20" />
+          </div>
+        </div>
+      </div>
+
+      {/* Row 2: value + change badge */}
+      <div className="flex flex-col gap-1">
+        {/* value — text-3xl font-bold */}
+        <Skeleton shade={shade} className="h-8 w-36" />
+        <div className="flex items-center gap-1.5 mt-1">
+          {/* change badge pill */}
+          <Skeleton shade={shade} className="h-5 w-16 rounded-full" />
+          {/* "vs last month" label */}
+          <Skeleton shade={shade} className="h-3 w-24" />
+        </div>
+      </div>
+
+      {/* Row 3: mini bar chart — matches h-[3rem] used by RechartsMiniBarChart */}
+      <Skeleton shade={shade} className="h-12 w-full rounded-lg" />
+    </div>
+  );
+}
+
+/**
+ * Grid of three {@link SummaryCardSkeleton} placeholders.
+ *
+ * Drop this in wherever the real cards grid would appear while data is
+ * loading. The grid columns match `AccountOverview`'s cards grid exactly
+ * (`grid-cols-1 md:grid-cols-2 lg:grid-cols-3`) so there is no layout
+ * shift when the real grid mounts.
+ *
+ * Accessibility: the wrapper carries `role="status"` and
+ * `aria-label="Loading account summary"` so screen readers announce the
+ * loading state without reading out the individual skeleton elements
+ * (each card is `aria-hidden`).
+ *
+ * @param shade - Forwarded to every {@link SummaryCardSkeleton}.
+ */
+export function SummaryCardsSkeleton({
+  shade = 'dark',
+}: {
+  shade?: 'light' | 'dark';
+}) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading account summary"
+      aria-busy="true"
+      className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+    >
+      {Array.from({ length: summaryCardsData.length }).map((_, i) => (
+        <SummaryCardSkeleton key={i} shade={shade} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #643

Adds a stable skeleton placeholder to the account summary cards section that matches the real card layout precisely, so there is no layout shift when resolved data arrives. A distinct error state with a Retry button replaces the skeleton on failure — the skeleton is never left stuck.

## Changes

### `components/dashboard/summary-data.tsx`

**New `SummaryCardSkeleton`** — mirrors `AccountSummaryCard`'s structure element-by-element:

```
┌────────────────────────────────────────┐
│  [icon 48×48]  [title line]            │
│                [subtitle line]         │
├────────────────────────────────────────┤
│  [value — wide]                        │
│  [badge pill]  [label line]            │
├────────────────────────────────────────┤
│  [mini bar chart strip h-12]           │
└────────────────────────────────────────┘
```

- Each wrapper is `aria-hidden="true"`; the shimmer animation comes from the existing `skeleton-shimmer` CSS class in `globals.css`.
- Accepts `className` and `shade` (`'light'|'dark'`, default `'dark'`) props.

**New `SummaryCardsSkeleton`** — grid wrapper (same `grid-cols-1 md:grid-cols-2 lg:grid-cols-3` as the real cards grid) with `role="status"`, `aria-label="Loading account summary"`, and `aria-busy="true"`.

### `components/dashboard/account-overview.tsx`

- Added `SummaryState` discriminated union: `loading | success | error`.
- Wrapped `summaryCardsData` access in `Promise.resolve()` so the component is API-ready with no structural changes needed when a real endpoint replaces the static import.
- Three rendering branches:

| State | Renders |
|---|---|
| loading | `<SummaryCardsSkeleton />` |
| error | `role="alert"` surface with message + Retry button |
| success | Real `<AccountSummaryCard />` grid (`data-testid="summary-cards-grid"`) |

### New `components/dashboard/summary-data.test.tsx`

Unit tests for the new skeleton exports:
- `summaryCardsData`: shape, length, titles
- `SummaryCardSkeleton`: `aria-hidden`, icon/value/chart placeholders, className forwarding, shade variants
- `SummaryCardsSkeleton`: `role`, `aria-label`, `aria-busy`, child count matches data, shade forwarding, grid classes

### Extended `components/dashboard/account-overview.test.tsx`

18 new tests across 3 describe blocks:

| Block | Tests |
|---|---|
| Loading state | Skeleton shown, `aria-busy`, no card data, no error |
| Success state | Grid shown, skeleton removed, all titles present, no error |
| Error state | Error shown, `role="alert"`, message, no stuck skeleton, no card data, Retry present, Retry recovers to success |

All 5 pre-existing `AccountOverview` tests are preserved and unmodified.