### PR TITLE
feat: add filter-by-amount-range UI and wiring to transaction filters

### DIFF
--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -27,6 +27,8 @@ const Transactions = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [searchParams, setSearchParams] = useState("");
   const [filterParams, setFilterParams] = useState("");
+  const [minAmount, setMinAmount] = useState<number | undefined>(undefined);
+  const [maxAmount, setMaxAmount] = useState<number | undefined>(undefined);
   const [startDate, setStartDate] = useState<Date | undefined>(undefined);
   const [endDate, setEndDate] = useState<Date | undefined>(undefined);
   const itemsPerPage = 6;
@@ -34,10 +36,10 @@ const Transactions = () => {
   // Reset to page 1 whenever filters change
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchParams, filterParams, startDate, endDate]);
+  }, [searchParams, filterParams, startDate, endDate, minAmount, maxAmount]);
 
   const { data, isLoading, error } = useTransactions({
-    filters: { searchQuery: searchParams, filterQuery: filterParams },
+    filters: { searchQuery: searchParams, filterQuery: filterParams, minAmount, maxAmount },
     page: 1,
     pageSize: 1000, // fetch all so we can client-side date filter (same as original)
   });
@@ -130,7 +132,14 @@ const Transactions = () => {
 
             <div className="flex items-center gap-2">
               <TableSearchbar onSearch={setSearchParams} />
-              <Filter value={filterParams} onChange={setFilterParams} />
+              <Filter 
+                value={filterParams} 
+                onChange={setFilterParams} 
+                minAmount={minAmount}
+                maxAmount={maxAmount}
+                onMinAmountChange={setMinAmount}
+                onMaxAmountChange={setMaxAmount}
+              />
               <Sort />
             </div>
           </div>

--- a/components/transactions/filter.test.tsx
+++ b/components/transactions/filter.test.tsx
@@ -40,4 +40,98 @@ describe("Filter", () => {
 
     expect(onChange).toHaveBeenCalledWith("");
   });
+
+  it("applies min and max amount filters correctly for a valid range", () => {
+    vi.useFakeTimers();
+    const onMinChange = vi.fn();
+    const onMaxChange = vi.fn();
+
+    render(
+      <Filter
+        value=""
+        onChange={vi.fn()}
+        onMinAmountChange={onMinChange}
+        onMaxAmountChange={onMaxChange}
+        debounceMs={250}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Min amount"), {
+      target: { value: "10" },
+    });
+    fireEvent.change(screen.getByLabelText("Max amount"), {
+      target: { value: "100" },
+    });
+
+    vi.advanceTimersByTime(250);
+
+    expect(onMinChange).toHaveBeenCalledWith(10);
+    expect(onMaxChange).toHaveBeenCalledWith(100);
+    expect(screen.queryByText("Min > Max")).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it("shows an error and does not apply filter for an inverted range", () => {
+    vi.useFakeTimers();
+    const onMinChange = vi.fn();
+    const onMaxChange = vi.fn();
+
+    render(
+      <Filter
+        value=""
+        onChange={vi.fn()}
+        onMinAmountChange={onMinChange}
+        onMaxAmountChange={onMaxChange}
+        debounceMs={250}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Min amount"), {
+      target: { value: "200" },
+    });
+    fireEvent.change(screen.getByLabelText("Max amount"), {
+      target: { value: "50" },
+    });
+
+    vi.advanceTimersByTime(250);
+
+    expect(screen.getByText("Min > Max")).toBeInTheDocument();
+    expect(onMinChange).not.toHaveBeenCalled();
+    expect(onMaxChange).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("handles no-range (unchanged) cases properly", () => {
+    vi.useFakeTimers();
+    const onMinChange = vi.fn();
+    const onMaxChange = vi.fn();
+
+    render(
+      <Filter
+        value=""
+        onChange={vi.fn()}
+        onMinAmountChange={onMinChange}
+        onMaxAmountChange={onMaxChange}
+        debounceMs={250}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Min amount"), {
+      target: { value: "" },
+    });
+    fireEvent.change(screen.getByLabelText("Max amount"), {
+      target: { value: "" },
+    });
+
+    vi.advanceTimersByTime(250);
+
+    // Initial state is undefined, clearing an empty input means it remains unchanged
+    expect(onMinChange).not.toHaveBeenCalled();
+    expect(onMaxChange).not.toHaveBeenCalled();
+    expect(screen.queryByText("Min > Max")).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
 });

--- a/components/transactions/filter.tsx
+++ b/components/transactions/filter.tsx
@@ -10,45 +10,98 @@ interface FilterProps {
   value: string;
   /** Receives debounced filter text changes, or an immediate empty string on clear. */
   onChange: (value: string) => void;
+  /** Current committed min amount */
+  minAmount?: number;
+  /** Receives debounced min amount changes */
+  onMinAmountChange?: (value: number | undefined) => void;
+  /** Current committed max amount */
+  maxAmount?: number;
+  /** Receives debounced max amount changes */
+  onMaxAmountChange?: (value: number | undefined) => void;
   /** Debounce delay in milliseconds before `onChange` fires. Defaults to 300ms. */
   debounceMs?: number;
 }
 
-const Filter = ({ value, onChange, debounceMs = 300 }: FilterProps) => {
+const Filter = ({
+  value,
+  onChange,
+  minAmount,
+  onMinAmountChange,
+  maxAmount,
+  onMaxAmountChange,
+  debounceMs = 300,
+}: FilterProps) => {
   const [draftValue, setDraftValue] = useState(value);
+  const [draftMin, setDraftMin] = useState<string>(minAmount !== undefined ? String(minAmount) : "");
+  const [draftMax, setDraftMax] = useState<string>(maxAmount !== undefined ? String(maxAmount) : "");
+  const [error, setError] = useState<string | null>(null);
+
   const onChangeRef = useRef(onChange);
+  const onMinChangeRef = useRef(onMinAmountChange);
+  const onMaxChangeRef = useRef(onMaxAmountChange);
 
   useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
+  useEffect(() => {
+    onMinChangeRef.current = onMinAmountChange;
+  }, [onMinAmountChange]);
+  useEffect(() => {
+    onMaxChangeRef.current = onMaxAmountChange;
+  }, [onMaxAmountChange]);
 
   useEffect(() => {
     setDraftValue(value);
   }, [value]);
+  useEffect(() => {
+    setDraftMin(minAmount !== undefined ? String(minAmount) : "");
+  }, [minAmount]);
+  useEffect(() => {
+    setDraftMax(maxAmount !== undefined ? String(maxAmount) : "");
+  }, [maxAmount]);
 
   useEffect(() => {
-    if (draftValue === value) {
-      return;
-    }
-
     const timer = setTimeout(() => {
-      onChangeRef.current(draftValue);
+      // Validate range
+      let minParsed = draftMin !== "" ? parseFloat(draftMin) : undefined;
+      let maxParsed = draftMax !== "" ? parseFloat(draftMax) : undefined;
+      minParsed = minParsed !== undefined && !isNaN(minParsed) ? minParsed : undefined;
+      maxParsed = maxParsed !== undefined && !isNaN(maxParsed) ? maxParsed : undefined;
+
+      if (minParsed !== undefined && maxParsed !== undefined && minParsed > maxParsed) {
+        setError("Min > Max");
+        // Don't apply invalid filters to parent
+      } else {
+        setError(null);
+        if (draftValue !== value) onChangeRef.current(draftValue);
+        // Only trigger updates if valid and changed
+        if (onMinChangeRef.current && minParsed !== minAmount) {
+          onMinChangeRef.current(minParsed);
+        }
+        if (onMaxChangeRef.current && maxParsed !== maxAmount) {
+          onMaxChangeRef.current(maxParsed);
+        }
+      }
     }, debounceMs);
 
     return () => clearTimeout(timer);
-  }, [draftValue, debounceMs, value]);
+  }, [draftValue, draftMin, draftMax, debounceMs, value, minAmount, maxAmount]);
 
   const clearFilter = () => {
     setDraftValue("");
+    setDraftMin("");
+    setDraftMax("");
     onChangeRef.current("");
+    if (onMinChangeRef.current) onMinChangeRef.current(undefined);
+    if (onMaxChangeRef.current) onMaxChangeRef.current(undefined);
   };
 
   return (
-    <div className="flex items-center bg-transparent rounded-[6.25rem]">
+    <div className="relative flex items-center bg-transparent rounded-[6.25rem]">
       <ListFilter
         aria-hidden="true"
         data-testid="transactions-filter-icon"
-        className="text-gray-600 w-5 h-5"
+        className="text-gray-600 w-5 h-5 ml-1"
       />
       <Input
         type="text"
@@ -58,15 +111,44 @@ const Filter = ({ value, onChange, debounceMs = 300 }: FilterProps) => {
         onChange={(event) => setDraftValue(event.target.value)}
         className="border-none py-1 focus-visible:ring-0 text-[13px] p-1 sm:text-[14px]"
       />
-      {draftValue && (
+      
+      <div className="flex items-center space-x-1 border-l border-gray-600 pl-2 ml-1">
+        <Input
+          type="number"
+          placeholder="Min $"
+          aria-label="Min amount"
+          value={draftMin}
+          onChange={(e) => setDraftMin(e.target.value)}
+          className="border-none py-1 focus-visible:ring-0 text-[13px] p-1 sm:text-[14px] w-16 px-1"
+        />
+        <span className="text-gray-400">-</span>
+        <Input
+          type="number"
+          placeholder="Max $"
+          aria-label="Max amount"
+          value={draftMax}
+          onChange={(e) => setDraftMax(e.target.value)}
+          className="border-none py-1 focus-visible:ring-0 text-[13px] p-1 sm:text-[14px] w-16 px-1"
+        />
+      </div>
+
+      {(draftValue || draftMin || draftMax) && (
         <button
           type="button"
           aria-label="Clear transaction filter"
           onClick={clearFilter}
-          className="rounded-full p-1 text-gray-500 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500"
+          className="rounded-full p-1 ml-1 text-gray-500 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500"
         >
           <X aria-hidden="true" className="h-4 w-4" />
         </button>
+      )}
+
+      {error && (
+        <div className="absolute top-full left-1/2 transform -translate-x-1/2 mt-1 whitespace-nowrap">
+          <span className="text-red-500 text-[11px] font-medium px-2 py-1 bg-red-500/10 rounded-md border border-red-500/20">
+            {error}
+          </span>
+        </div>
       )}
     </div>
   );

--- a/hooks/useTransactions.ts
+++ b/hooks/useTransactions.ts
@@ -99,6 +99,8 @@ export function useTransactions(
     filters?.toDate,
     filters?.sortField,
     filters?.sortDirection,
+    filters?.minAmount,
+    filters?.maxAmount,
     page,
     pageSize,
     tick,

--- a/lib/api/transactions.ts
+++ b/lib/api/transactions.ts
@@ -108,6 +108,8 @@ export async function getTransactions(
     toDate = MOCK_TO_DATE,
     sortField = "date",
     sortDirection = "desc",
+    minAmount,
+    maxAmount,
   } = filters;
 
   const safePageSize = normalizePositiveInteger(
@@ -168,6 +170,8 @@ export async function getTransactions(
     safeFromDate,
     safeToDate,
     filterQuery,
+    minAmount,
+    maxAmount,
   );
 
   const sorted = sortTransactions(filtered, sortField, sortDirection);

--- a/types/transaction.ts
+++ b/types/transaction.ts
@@ -25,6 +25,8 @@ export interface TransactionFilters {
   selectedFilter: string;
   sortField: SortField;
   sortDirection: SortDirection;
+  minAmount?: number;
+  maxAmount?: number;
 }
 
 export interface TransactionProps {
@@ -63,4 +65,8 @@ export interface TransactionsFiltersProps {
   onSearchChange: (query: string) => void;
   onFilterChange: (filter: string) => void;
   onSort: (field: SortField) => void;
+  minAmount?: number;
+  maxAmount?: number;
+  onMinAmountChange?: (amount: number | undefined) => void;
+  onMaxAmountChange?: (amount: number | undefined) => void;
 }

--- a/utils/transactionUtils.ts
+++ b/utils/transactionUtils.ts
@@ -42,6 +42,8 @@ export const filterTransactions = (
   fromDate: string,
   toDate: string,
   filterQuery = "",
+  minAmount?: number,
+  maxAmount?: number,
 ): Transaction[] => {
   let filtered = transactions;
 
@@ -81,6 +83,14 @@ export const filterTransactions = (
     const to = new Date(toDate);
     return transactionDate >= from && transactionDate <= to;
   });
+
+  if (minAmount !== undefined) {
+    filtered = filtered.filter((transaction) => Math.abs(transaction.amount) >= minAmount);
+  }
+
+  if (maxAmount !== undefined) {
+    filtered = filtered.filter((transaction) => Math.abs(transaction.amount) <= maxAmount);
+  }
 
   return filtered;
 };


### PR DESCRIPTION
What was done

Extended the <Filter /> component (components/transactions/filter.tsx) to render numeric Min $ and Max $ inputs alongside the text filter.
Lifted new minAmount and maxAmount states up to app/transactions/page.tsx and wired them sequentially down into hooks/useTransactions.ts, lib/api/transactions.ts, and utils/transactionUtils.ts.
Implemented client-side filtering by absolute amount and inline error handling when an inverted range is provided (min > max).
Why it was done

Filtering by amount range is a commonly requested way to narrow down the transaction list. The existing filter component lacked a way to bracket specific transaction sizes (Issue #589).
How it was verified

Added test coverage in filter.test.tsx verifying three core scenarios: valid range assignments, inverted ranges preventing callbacks and showing inline errors, and unchanged/cleared inputs behaving normally.
Closes #589