### PR TITLE
feat: persist remember-me email via safeStorage

### DIFF
--- a/components/auth/login/login-form.test.tsx
+++ b/components/auth/login/login-form.test.tsx
@@ -15,6 +15,23 @@ vi.mock("@/lib/api/auth", () => ({
   },
 }));
 
+// In-memory store standing in for localStorage via safeStorage
+const mockStore = new Map<string, string>();
+vi.mock("@/utils/safeStorage", () => ({
+  safeStorage: {
+    getItem: vi.fn((key: string) => mockStore.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      mockStore.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      mockStore.delete(key);
+    }),
+  },
+}));
+
+import { safeStorage } from "@/utils/safeStorage";
+const REMEMBERED_EMAIL_KEY = "stellopay:rememberedEmail";
+
 // Mock ResizeObserver which is needed by Radix UI
 class ResizeObserverMock {
   observe() {}
@@ -26,6 +43,7 @@ global.ResizeObserver = ResizeObserverMock;
 describe("LoginForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockStore.clear();
   });
 
   it("submits the form with provided values and calls login adapter (rememberMe: true)", async () => {
@@ -255,5 +273,83 @@ describe("LoginForm", () => {
       const toggle = screen.getByRole("button", { name: /Show password/i });
       expect(toggle).toBeDisabled();
     });
+  });
+
+  // ─── Remember me persistence ─────────────────────────────────────────────
+
+  it("persists the email via safeStorage when rememberMe is checked on login", async () => {
+    vi.mocked(login).mockResolvedValue();
+    render(<LoginForm />);
+
+    await userEvent.type(screen.getByPlaceholderText(/Enter your email/i), "user@example.com");
+    await userEvent.type(screen.getByPlaceholderText(/Enter your password/i), "Password123!");
+    await userEvent.click(screen.getByRole("checkbox", { name: /Remember me/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Sign In/i }));
+
+    await waitFor(() => {
+      expect(safeStorage.setItem).toHaveBeenCalledWith(REMEMBERED_EMAIL_KEY, "user@example.com");
+    });
+    expect(mockStore.get(REMEMBERED_EMAIL_KEY)).toBe("user@example.com");
+  });
+
+  it("clears any persisted email via safeStorage when rememberMe is unchecked on login", async () => {
+    mockStore.set(REMEMBERED_EMAIL_KEY, "old@example.com");
+    vi.mocked(login).mockResolvedValue();
+    render(<LoginForm />);
+
+    await userEvent.type(screen.getByPlaceholderText(/Enter your password/i), "Password123!");
+    // rememberMe checkbox pre-checked because a remembered email exists;
+    // uncheck it explicitly for this test.
+    const checkbox = screen.getByRole("checkbox", { name: /Remember me/i });
+    if (checkbox.getAttribute("aria-checked") === "true") {
+      await userEvent.click(checkbox);
+    }
+    await userEvent.click(screen.getByRole("button", { name: /Sign In/i }));
+
+    await waitFor(() => {
+      expect(safeStorage.removeItem).toHaveBeenCalledWith(REMEMBERED_EMAIL_KEY);
+    });
+    expect(mockStore.has(REMEMBERED_EMAIL_KEY)).toBe(false);
+  });
+
+  it("never persists the password to storage regardless of rememberMe", async () => {
+    vi.mocked(login).mockResolvedValue();
+    render(<LoginForm />);
+
+    await userEvent.type(screen.getByPlaceholderText(/Enter your email/i), "user@example.com");
+    await userEvent.type(screen.getByPlaceholderText(/Enter your password/i), "S3cr3tPass!");
+    await userEvent.click(screen.getByRole("checkbox", { name: /Remember me/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Sign In/i }));
+
+    await waitFor(() => {
+      expect(safeStorage.setItem).toHaveBeenCalled();
+    });
+
+    for (const call of vi.mocked(safeStorage.setItem).mock.calls) {
+      expect(call[1]).not.toContain("S3cr3tPass!");
+    }
+    expect(Array.from(mockStore.values())).not.toContain("S3cr3tPass!");
+  });
+
+  it("pre-fills the email field from a remembered value on mount", () => {
+    mockStore.set(REMEMBERED_EMAIL_KEY, "remembered@example.com");
+    render(<LoginForm />);
+
+    const emailInput = screen.getByPlaceholderText(/Enter your email/i);
+    expect(emailInput).toHaveValue("remembered@example.com");
+  });
+
+  it("never pre-fills the password field from storage", () => {
+    mockStore.set(REMEMBERED_EMAIL_KEY, "remembered@example.com");
+    render(<LoginForm />);
+
+    const passwordInput = screen.getByPlaceholderText(/Enter your password/i);
+    expect(passwordInput).toHaveValue("");
+  });
+
+  it("does not pre-fill the email field when nothing is remembered", () => {
+    render(<LoginForm />);
+    const emailInput = screen.getByPlaceholderText(/Enter your email/i);
+    expect(emailInput).toHaveValue("");
   });
 });

--- a/components/auth/login/login-form.tsx
+++ b/components/auth/login/login-form.tsx
@@ -16,6 +16,9 @@ import { Loader2 } from "lucide-react";
 import { AuthSocialButtons } from "../auth-social-buttons";
 import { login, AuthError } from "@/lib/api/auth";
 import { loginSchema, LoginFormValues } from "@/types/auth";
+import { safeStorage } from "@/utils/safeStorage";
+
+const REMEMBERED_EMAIL_KEY = "stellopay:rememberedEmail";
 
 /**
  * LoginForm – renders the `/auth/login` page form.
@@ -31,12 +34,14 @@ export function LoginForm() {
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
 
+  const rememberedEmail = safeStorage.getItem(REMEMBERED_EMAIL_KEY);
+
   const form = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),
     defaultValues: {
-      email: "",
+      email: rememberedEmail ?? "",
       password: "",
-      rememberMe: false,
+      rememberMe: !!rememberedEmail,
     },
   });
 
@@ -45,6 +50,13 @@ export function LoginForm() {
     setErrorMessage("");
     try {
       await login(_data);
+      // Persist only a non-sensitive identifier (email). The password is
+      // never written to storage in any branch of this logic.
+      if (_data.rememberMe) {
+        safeStorage.setItem(REMEMBERED_EMAIL_KEY, _data.email);
+      } else {
+        safeStorage.removeItem(REMEMBERED_EMAIL_KEY);
+      }
       // Handle successful login redirect or state update here
     } catch (error) {
       if (error instanceof AuthError) {


### PR DESCRIPTION
Closes #632

## Summary
Adds "remember me" persistence to the login form. When checked, the
entered email is stored via `utils/safeStorage.ts` and pre-fills the
email field on next visit. The password is never written to storage
in any code path.

## Changes
- `components/auth/login/login-form.tsx`:
  - Reads a remembered email from `safeStorage` on mount and pre-fills
    the email field (and pre-checks "remember me") if present
  - On successful login: if `rememberMe` is checked, stores the email
    via `safeStorage.setItem`; if unchecked, clears any existing value
    via `safeStorage.removeItem`
- `components/auth/login/login-form.test.tsx`: added 6 tests covering
  persistence, clearing, pre-fill, and that the password is never
  written to or read from storage

## Testing
`npx vitest run components/auth/login/login-form.test.tsx` — all 23
tests pass (17 pre-existing + 6 new).

## Notes
`npx tsc --noEmit` reports 44 pre-existing errors across 8 unrelated
files (`text-input.test.tsx`, `RechartsMiniBarChart.tsx`,
`faq-section.tsx`, `date.tsx`, `transactions-header.tsx`,
`calendar.test.tsx`, `calendar.tsx`, `settings-notifications.spec.ts`).
None were touched by this PR.

## Security notes
- Only the email is persisted; the password field is never read from
  or written to `safeStorage` in any branch
- Unchecking "remember me" on a successful login clears any previously
  stored value