### PR TITLE
Mark active sidebar link with aria-current

### DIFF
--- a/components/common/nav-link.test.tsx
+++ b/components/common/nav-link.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const mockPathname = vi.hoisted(() => ({ value: "/dashboard" }));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname.value,
+}));
+
+vi.mock("@/context/sidebar-context", () => ({
+  __esModule: true,
+  default: () => ({ isSidebarOpen: true, isMobile: false }),
+}));
+
+vi.mock("@/context/theme-context", () => ({
+  useTheme: () => ({ theme: "light" }),
+}));
+
+vi.mock("@material-tailwind/react", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: (props: React.HTMLAttributes<HTMLDivElement>) => <div {...props} />,
+  },
+}));
+
+vi.mock("@/public/svg/svg", () => ({
+  DashBoardIcon: () => <svg aria-hidden="true" />,
+  TransactionIcon: () => <svg aria-hidden="true" />,
+  HelpCircleIcon: () => <svg aria-hidden="true" />,
+  SettinIcon: () => <svg aria-hidden="true" />,
+}));
+
+import { NavLink } from "./nav-link";
+
+describe("NavLink aria-current", () => {
+  it("marks exactly one active sidebar link as the current page", () => {
+    mockPathname.value = "/transactions";
+    render(<NavLink />);
+
+    const currentLinks = screen
+      .getAllByRole("link")
+      .filter((link) => link.getAttribute("aria-current") === "page");
+
+    expect(currentLinks).toHaveLength(1);
+    expect(currentLinks[0]).toHaveAccessibleName(/Transactions/);
+    expect(screen.getByRole("link", { name: "Dashboard" })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
+  it("updates aria-current when the client-side pathname changes", () => {
+    const { rerender } = render(<NavLink />);
+    expect(screen.getByRole("link", { name: "Dashboard" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+
+    mockPathname.value = "/settings/preferences/security";
+    rerender(<NavLink />);
+
+    expect(screen.getByRole("link", { name: "Settings" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("link", { name: "Dashboard" })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+});

--- a/components/common/nav-link.tsx
+++ b/components/common/nav-link.tsx
@@ -67,6 +67,7 @@ export const NavLink = () => {
               <li key={index} className="w-full">
                 <Link
                   href={link.route}
+                  aria-current={isActive ? "page" : undefined}
                   className={`cursor-pointer py-3.5 px-4 w-full relative rounded-xl flex justify-between items-center transition-all duration-200 group ${
                     isActive 
                       ? "text-white dark:text-[#0D0D0D]" 
@@ -116,6 +117,7 @@ export const NavLink = () => {
               <li className="w-fit self-center relative w-full flex justify-center">
                 <Link
                   href={link.route}
+                  aria-current={isActive ? "page" : undefined}
                   className={`cursor-pointer my-1.5 p-3 relative rounded-xl flex items-center justify-center transition-all duration-200 ${
                     isActive 
                       ? "" 

--- a/design/a11y-checklist.md
+++ b/design/a11y-checklist.md
@@ -234,5 +234,5 @@
 | `components/auth/sign-up/sign-up-form.tsx` | Password toggles → `<button>`, aria-describedby, aria-live on requirements |
 | `components/auth/sign-up/sign-up-email-modal.tsx` | `DialogDescription`, aria-live resend status, button types, focus rings |
 | `components/transactions/transactions-table.tsx` | `<caption>`, `scope="col"`, aria-label on badges, aria-hidden on icons, `<time>` element |
-| `components/common/side-bar.tsx` | aria-label, aria-expanded, aria-hidden icons, focus rings |
+| `components/common/side-bar.tsx` / `components/common/nav-link.tsx` | aria-label, aria-expanded, aria-hidden icons, focus rings, active link `aria-current="page"` |
 | `design/a11y-checklist.md` | This document |


### PR DESCRIPTION
## Summary
- set `aria-current="page"` on the active sidebar navigation link in both expanded and collapsed sidebar modes
- add a focused `NavLink` regression test that asserts exactly one current page link and updates after client-side pathname changes
- update the accessibility checklist to include the sidebar/nav-link current-page state

Closes #767.

## Validation
- `git diff --check`
- static inspection confirmed both sidebar `Link` render paths now set `aria-current` from `isActive`
- static test inspection confirms one-current-link and client-side pathname-change coverage

I did not run Vitest because this fresh workspace has no `node_modules`, and I avoided installing dependencies or running extra project toolchains on the user's machine.