### PR TITLE
fix(account-overview): catch synchronous throws in loadSummary; fix t…

### DIFF
--- a/components/dashboard/account-overview.test.tsx
+++ b/components/dashboard/account-overview.test.tsx
@@ -62,7 +62,7 @@ describe("AccountOverview", () => {
     window.localStorage.clear();
   });
 
-  it("renders correctly when wallet is disconnected", () => {
+  it("renders correctly when wallet is disconnected", async () => {
     renderWithWallet(null);
 
     expect(
@@ -72,9 +72,13 @@ describe("AccountOverview", () => {
     expect(
       screen.getByText("Connect your Stellar wallet to view balances and send payments."),
     ).toBeInTheDocument();
-    expect(screen.getByText("Total Balance")).toBeInTheDocument();
-    expect(screen.getByText("Paid This Month")).toBeInTheDocument();
-    expect(screen.getByText("To Be Paid")).toBeInTheDocument();
+
+    // Cards load asynchronously — wait for the skeleton to be replaced.
+    await waitFor(() => {
+      expect(screen.getByText("Total Balance")).toBeInTheDocument();
+      expect(screen.getByText("Paid This Month")).toBeInTheDocument();
+      expect(screen.getByText("To Be Paid")).toBeInTheDocument();
+    });
   });
 
   it("renders correctly when wallet is connected", () => {
@@ -396,10 +400,15 @@ describe("AccountOverview – error state", () => {
   });
 
   it("clicking Retry re-triggers the load and shows success on recovery", async () => {
-    // First call throws, second call succeeds.
-    const spy = vi.spyOn(summaryDataModule, 'summaryCardsData', 'get')
+    // Capture the real data BEFORE installing the spy so that accessing
+    // summaryDataModule.summaryCardsData as the mockReturnValue argument does
+    // not accidentally consume the one-time throw.
+    const realData = summaryDataModule.summaryCardsData;
+
+    // First call throws, second call returns the real data.
+    vi.spyOn(summaryDataModule, 'summaryCardsData', 'get')
       .mockImplementationOnce(() => { throw new Error("transient error"); })
-      .mockReturnValue(summaryDataModule.summaryCardsData);
+      .mockReturnValue(realData);
 
     render(
       <WalletProvider initialAddress={null}>
@@ -410,9 +419,6 @@ describe("AccountOverview – error state", () => {
     await waitFor(() => {
       expect(screen.getByTestId("summary-error")).toBeInTheDocument();
     });
-
-    // Restore so the second call succeeds.
-    spy.mockRestore();
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /retry/i }));

--- a/components/dashboard/account-overview.tsx
+++ b/components/dashboard/account-overview.tsx
@@ -43,7 +43,18 @@ export default function AccountOverview() {
     // This async wrapper keeps the loading/error contract intact so that
     // when a real API replaces the static import the component needs no
     // structural changes — only the Promise body changes.
-    Promise.resolve(summaryCardsData)
+    //
+    // NOTE: summaryCardsData is accessed inside new Promise() so that
+    // synchronous throws (e.g. from a vi.spyOn getter in tests, or from a
+    // future API helper that throws before returning a Promise) are captured
+    // by the rejection path rather than propagating as uncaught exceptions.
+    new Promise<typeof summaryCardsData>((resolve, reject) => {
+      try {
+        resolve(summaryCardsData);
+      } catch (err) {
+        reject(err);
+      }
+    })
       .then((data) => {
         const cards = data.map((card, idx) => ({ ...card, icon: icons[idx] }));
         setSummaryState({ status: 'success', cards });


### PR DESCRIPTION
fix(account-overview): skeleton loading state & test fixes
  
  Summary
  
  Wires the existing SummaryCardsSkeleton correctly into the async data-load path of
  AccountOverview, and fixes three test failures that prevented the loading/error/retry coverage
  from running.
  
  What changed
  
  components/dashboard/account-overview.tsx
  
  Replaced Promise.resolve(summaryCardsData) with a new Promise() constructor that wraps the
  summaryCardsData access in a try/catch. The previous pattern evaluated the getter before
  .catch() was attached, so any synchronous throw (from a test spy or a future API helper)
  escaped the rejection handler entirely and crashed as an uncaught error instead of
  transitioning the component to the error state.
  
  components/dashboard/account-overview.test.tsx
  
  Two test bugs fixed:
  
  1. "renders correctly when wallet is disconnected" — the test synchronously asserted card
  titles (Total Balance, etc.) but data now resolves asynchronously through a Promise. Added
  await waitFor() so the assertions run after the skeleton is replaced by real cards.
  2. "clicking Retry re-triggers the load" — mockReturnValue(summaryDataModule.summaryCardsData)
   was called while the throw-once spy was active, which consumed the one-time throw before the
  component even mounted. Fixed by capturing const realData = summaryDataModule.summaryCardsData
   before installing the spy.
  
  Skeleton details (pre-existing, now fully tested)
  
  SummaryCardsSkeleton in summary-data.tsx was already implemented correctly:
  
  - role="status" + aria-label="Loading account summary" + aria-busy="true" for screen-reader
  announcements
  - Grid layout (grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6) matches the real cards grid
  exactly — no layout shift on data arrival
  - Each SummaryCardSkeleton mirrors the icon, title/subtitle, value, change badge, and mini
  chart rows with matching dimensions
  
  Tests
  
  All 20 account-overview tests pass across four suites: loading state, success state, error
  state, and retry recovery.
  
  Acceptance criteria
  
  - ✅ Skeleton shown during loading, matching final layout dimensions
  - ✅ No layout shift when data arrives (grid structure is identical)
  - ✅ Existing error and empty states unaffected

closes #595 
closes #591 