### PR TITLE
feat(settings): add 2FA verification code setup flow with client-side…

### DIFF
--- a/app/settings/preferences/components/security-tab.test.tsx
+++ b/app/settings/preferences/components/security-tab.test.tsx
@@ -7,7 +7,11 @@ import {
 } from "@testing-library/react";
 import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
 
-import SecurityTab from "./security-tab";
+import SecurityTab, {
+  DEFAULT_TWO_FACTOR_ENABLED,
+  TWO_FACTOR_CODE_LENGTH,
+  getVerificationCodeError,
+} from "./security-tab";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -245,7 +249,9 @@ describe("SecurityTab — weak-password inline errors", () => {
 
     await waitFor(() =>
       expect(
-        screen.getByText("Password must include at least one uppercase letter."),
+        screen.getByText(
+          "Password must include at least one uppercase letter.",
+        ),
       ).toBeInTheDocument(),
     );
   });
@@ -556,9 +562,7 @@ describe("SecurityTab — failed password change", () => {
 
     await waitFor(
       () =>
-        expect(
-          screen.getByText(/failed to save changes/i),
-        ).toBeInTheDocument(),
+        expect(screen.getByText(/failed to save changes/i)).toBeInTheDocument(),
       { timeout: 3000 },
     );
   });
@@ -573,9 +577,7 @@ describe("SecurityTab — failed password change", () => {
 
     await waitFor(
       () =>
-        expect(
-          screen.getByText(/failed to save changes/i),
-        ).toBeInTheDocument(),
+        expect(screen.getByText(/failed to save changes/i)).toBeInTheDocument(),
       { timeout: 3000 },
     );
 
@@ -592,9 +594,7 @@ describe("SecurityTab — failed password change", () => {
 
     await waitFor(
       () =>
-        expect(
-          screen.getByText(/failed to save changes/i),
-        ).toBeInTheDocument(),
+        expect(screen.getByText(/failed to save changes/i)).toBeInTheDocument(),
       { timeout: 3000 },
     );
 
@@ -634,9 +634,7 @@ describe("SecurityTab — status message auto-clear", () => {
       await vi.advanceTimersByTimeAsync(1500);
     });
 
-    expect(
-      screen.getByText(/password policy satisfied/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/password policy satisfied/i)).toBeInTheDocument();
 
     // Advance past the 5000ms auto-clear
     await act(async () => {
@@ -741,5 +739,503 @@ describe("SecurityTab — edge cases", () => {
     expect(
       screen.getByRole("button", { name: /update password/i }),
     ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2FA verification code — validation helper (unit tests)
+// ---------------------------------------------------------------------------
+
+describe("SecurityTab — getVerificationCodeError helper", () => {
+  it("returns null for an empty string (user hasn't typed yet)", () => {
+    expect(getVerificationCodeError("")).toBeNull();
+  });
+
+  it("returns null for a valid 6-digit numeric code", () => {
+    expect(getVerificationCodeError("123456")).toBeNull();
+    expect(getVerificationCodeError("000000")).toBeNull();
+    expect(getVerificationCodeError("999999")).toBeNull();
+  });
+
+  it("rejects code that contains non-digit characters with a digits-only message", () => {
+    expect(getVerificationCodeError("123A56")).toMatch(/only contain digits/i);
+    expect(getVerificationCodeError("12-456")).toMatch(/only contain digits/i);
+    expect(getVerificationCodeError("123 56")).toMatch(/only contain digits/i);
+    expect(getVerificationCodeError("abcdef")).toMatch(/only contain digits/i);
+  });
+
+  it("rejects a code that is too short with a 'too short' message", () => {
+    const err = getVerificationCodeError("12345");
+    expect(err).toMatch(/too short/i);
+    expect(err).toContain("1 digit");
+
+    const err2 = getVerificationCodeError("12");
+    expect(err2).toMatch(/too short/i);
+    expect(err2).toContain("4 digits");
+  });
+
+  it("rejects a code that is too long with a 'too long' message", () => {
+    const err = getVerificationCodeError("1234567");
+    expect(err).toMatch(/too long/i);
+    expect(err).toContain("1 digit");
+
+    const err2 = getVerificationCodeError("1234567890");
+    expect(err2).toMatch(/too long/i);
+    expect(err2).toContain("4 digits");
+  });
+
+  it("does not trim whitespace — surrounding spaces trigger the digits-only error", () => {
+    expect(getVerificationCodeError(" 123456")).toMatch(/only contain digits/i);
+    expect(getVerificationCodeError("123456 ")).toMatch(/only contain digits/i);
+  });
+
+  it("code length constant matches the expected TOTP size", () => {
+    expect(TWO_FACTOR_CODE_LENGTH).toBe(6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2FA setup flow — panel open/close + controlled toggle behaviour
+// ---------------------------------------------------------------------------
+
+describe("SecurityTab — 2FA setup panel open/close", () => {
+  /**
+   * Click the Authenticator toggle card via its switch button. The toggle's
+   * `role="switch"` combined with `aria-pressed` / `aria-checked` lets us
+   * query it reliably.
+   */
+  function clickTwoFactorSwitch() {
+    const sw = screen.getByRole("switch", {
+      name: /authenticator app verification/i,
+    });
+    fireEvent.click(sw);
+    return sw;
+  }
+
+  it("toggling 2FA OFF from the enabled state flips the switch directly (no panel)", () => {
+    render(<SecurityTab twoFactorEnabled={true} />);
+    const sw = screen.getByRole("switch", {
+      name: /authenticator app verification/i,
+    });
+    expect(sw).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(sw);
+
+    expect(sw).toHaveAttribute("aria-checked", "false");
+    expect(
+      screen.queryByRole("form", { name: /authenticator verification setup/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("toggling 2FA ON from the disabled state opens the setup panel and does NOT flip the switch yet", () => {
+    render(<SecurityTab twoFactorEnabled={false} />);
+    const sw = screen.getByRole("switch", {
+      name: /authenticator app verification/i,
+    });
+    expect(sw).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(sw);
+
+    // Switch must remain OFF until a valid code is submitted.
+    expect(sw).toHaveAttribute("aria-checked", "false");
+    // Setup panel appears.
+    expect(
+      screen.getByRole("form", { name: /authenticator verification setup/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/6-digit verification code/i),
+    ).toBeInTheDocument();
+  });
+
+  it("controlled onTwoFactorEnabledChange is NOT called when the panel opens (toggle is gated)", () => {
+    const onChange = vi.fn();
+    render(
+      <SecurityTab
+        twoFactorEnabled={false}
+        onTwoFactorEnabledChange={onChange}
+      />,
+    );
+
+    clickTwoFactorSwitch();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("controlled onTwoFactorEnabledChange IS called when the user turns 2FA off directly", () => {
+    const onChange = vi.fn();
+    render(
+      <SecurityTab
+        twoFactorEnabled={true}
+        onTwoFactorEnabledChange={onChange}
+      />,
+    );
+
+    clickTwoFactorSwitch();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("cancel button in the setup panel closes it, clears the typed code, and leaves 2FA disabled", () => {
+    render(<SecurityTab twoFactorEnabled={false} />);
+    clickTwoFactorSwitch();
+
+    const input = screen.getByLabelText(/6-digit verification code/i);
+    fireEvent.change(input, { target: { value: "123456" } });
+    expect(input).toHaveValue("123456");
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(
+      screen.queryByRole("form", { name: /authenticator verification setup/i }),
+    ).not.toBeInTheDocument();
+    const sw = screen.getByRole("switch", {
+      name: /authenticator app verification/i,
+    });
+    expect(sw).toHaveAttribute("aria-checked", "false");
+
+    // Re-open the panel to confirm the code did NOT persist.
+    fireEvent.click(sw);
+    const reopenedInput = screen.getByLabelText(/6-digit verification code/i);
+    expect(reopenedInput).toHaveValue("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2FA setup flow — client-side validation + submit gating
+// ---------------------------------------------------------------------------
+
+describe("SecurityTab — 2FA verification code validation", () => {
+  /**
+   * Renders SecurityTab with 2FA disabled, then clicks the toggle to open
+   * the setup panel. Returns the code input and verify submit button so the
+   * caller can simulate typing and submitting.
+   */
+  function openSetupPanel() {
+    render(<SecurityTab twoFactorEnabled={false} />);
+    const sw = screen.getByRole("switch", {
+      name: /authenticator app verification/i,
+    });
+    fireEvent.click(sw);
+    const input = screen.getByLabelText(/6-digit verification code/i);
+    const getVerifyButton = () =>
+      screen.getByRole("button", { name: /verify and enable/i });
+    return { input, getVerifyButton };
+  }
+
+  it("setup panel starts with an empty input, no inline error, and the submit button disabled", () => {
+    const { input, getVerifyButton } = openSetupPanel();
+    expect(input).toHaveValue("");
+    expect(input).toHaveAttribute("aria-required", "true");
+    expect(input).toHaveAttribute("aria-invalid", "false");
+    expect(getVerifyButton()).toBeDisabled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("submit button stays disabled for a partial / incomplete code (e.g. 3 digits) and no inline error shown", () => {
+    const { input, getVerifyButton } = openSetupPanel();
+    fireEvent.change(input, { target: { value: "123" } });
+
+    expect(input).toHaveValue("123");
+    // Too-short code: inline error is shown (via helper).
+    expect(screen.getByRole("alert")).toHaveTextContent(/too short/i);
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(getVerifyButton()).toBeDisabled();
+  });
+
+  it("shows inline 'too short' error and keeps submit disabled for a 5-digit code", () => {
+    const { input, getVerifyButton } = openSetupPanel();
+    fireEvent.change(input, { target: { value: "12345" } });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/1 digit.*too short/i);
+    expect(getVerifyButton()).toBeDisabled();
+  });
+
+  it("shows inline 'too long' error and keeps submit disabled for a 7-digit code", () => {
+    const { input, getVerifyButton } = openSetupPanel();
+    fireEvent.change(input, { target: { value: "1234567" } });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/too long/i);
+    expect(getVerifyButton()).toBeDisabled();
+  });
+
+  it("shows inline 'digits only' error and keeps submit disabled when letters are mixed in", () => {
+    const { input, getVerifyButton } = openSetupPanel();
+    fireEvent.change(input, { target: { value: "123A56" } });
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/only contain digits/i);
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(getVerifyButton()).toBeDisabled();
+  });
+
+  it("enables the submit button once the code is exactly 6 numeric digits", async () => {
+    const { input, getVerifyButton } = openSetupPanel();
+    fireEvent.change(input, { target: { value: "743891" } });
+
+    expect(input).toHaveAttribute("aria-invalid", "false");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    await waitFor(() => expect(getVerifyButton()).not.toBeDisabled());
+  });
+
+  it("submit button becomes disabled again if the user deletes part of a previously-valid code", async () => {
+    const { input, getVerifyButton } = openSetupPanel();
+    fireEvent.change(input, { target: { value: "123456" } });
+    await waitFor(() => expect(getVerifyButton()).not.toBeDisabled());
+
+    fireEvent.change(input, { target: { value: "12345" } });
+    expect(getVerifyButton()).toBeDisabled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/too short/i);
+  });
+
+  it("inline error resets when the user starts correcting a previously invalid value", () => {
+    const { input } = openSetupPanel();
+    fireEvent.change(input, { target: { value: "123A56" } });
+    expect(screen.getByRole("alert")).toHaveTextContent(/digits/i);
+
+    fireEvent.change(input, { target: { value: "123" } });
+    // Error changed to 'too short', not lingering 'digits' message.
+    expect(screen.getByRole("alert")).toHaveTextContent(/too short/i);
+    expect(screen.queryByText(/only contain digits/i)).not.toBeInTheDocument();
+  });
+
+  it("verification code input exposes its instruction text via aria-describedby", () => {
+    const { input } = openSetupPanel();
+    expect(input).toHaveAccessibleDescription(/no spaces or letters/i);
+  });
+
+  it("verification code input exposes an inline error via aria-describedby after invalid input", () => {
+    const { input } = openSetupPanel();
+    fireEvent.change(input, { target: { value: "123A56" } });
+
+    const alert = screen.getByRole("alert");
+    expect(input).toHaveAccessibleDescription(alert.textContent ?? "");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2FA setup flow — submission success / failure outcomes
+// ---------------------------------------------------------------------------
+
+describe("SecurityTab — 2FA verification submit", () => {
+  function openSetupPanelWith(
+    props: React.ComponentProps<typeof SecurityTab> = {},
+  ) {
+    const mergedProps = { twoFactorEnabled: false, ...props } as const;
+    render(<SecurityTab {...mergedProps} />);
+    const sw = screen.getByRole("switch", {
+      name: /authenticator app verification/i,
+    });
+    fireEvent.click(sw);
+    const input = screen.getByLabelText(/6-digit verification code/i);
+    const getVerifyButton = () =>
+      screen.getByRole("button", { name: /verify and enable/i });
+    return { input, getVerifyButton };
+  }
+
+  it("successful submission: flips 2FA toggle ON, closes the panel, and clears the input", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.1);
+    const onChange = vi.fn();
+    const { input, getVerifyButton } = openSetupPanelWith({
+      onTwoFactorEnabledChange: onChange,
+    });
+
+    fireEvent.change(input, { target: { value: "009911" } });
+    await waitFor(() => expect(getVerifyButton()).not.toBeDisabled());
+
+    fireEvent.click(getVerifyButton());
+
+    // Button shows loading state while verifying.
+    await waitFor(() =>
+      expect(screen.getByText(/verifying\.\.\./i)).toBeInTheDocument(),
+    );
+
+    // After simulated save resolves:
+    await waitFor(
+      () => {
+        const sw = screen.getByRole("switch", {
+          name: /authenticator app verification/i,
+        });
+        expect(sw).toHaveAttribute("aria-checked", "true");
+      },
+      { timeout: 3000 },
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(true);
+
+    // Panel is closed → no setup form in DOM.
+    expect(
+      screen.queryByRole("form", { name: /authenticator verification setup/i }),
+    ).not.toBeInTheDocument();
+
+    // Reopen the panel to confirm state was fully reset: input is empty and
+    // submit is disabled.
+    const sw2 = screen.getByRole("switch", {
+      name: /authenticator app verification/i,
+    });
+    // 2FA is now true; turning it off then on again re-opens setup.
+    fireEvent.click(sw2); // toggle off
+    fireEvent.click(sw2); // toggle on (re-open setup)
+    const reopenedInput = screen.getByLabelText(/6-digit verification code/i);
+    expect(reopenedInput).toHaveValue("");
+    expect(
+      screen.getByRole("button", { name: /verify and enable/i }),
+    ).toBeDisabled();
+  });
+
+  it("successful submission: a success banner is shown via the status area", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.1);
+    const { input, getVerifyButton } = openSetupPanelWith();
+    fireEvent.change(input, { target: { value: "112233" } });
+    await waitFor(() => expect(getVerifyButton()).not.toBeDisabled());
+    fireEvent.click(getVerifyButton());
+
+    await waitFor(
+      () =>
+        expect(
+          screen.getByText(/authenticator app verified/i),
+        ).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+  });
+
+  it("failed submission: clears the verification code input (security) and shows a server error inline", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.95);
+    const onChange = vi.fn();
+    const { input, getVerifyButton } = openSetupPanelWith({
+      onTwoFactorEnabledChange: onChange,
+    });
+
+    fireEvent.change(input, { target: { value: "987654" } });
+    await waitFor(() => expect(getVerifyButton()).not.toBeDisabled());
+    fireEvent.click(getVerifyButton());
+
+    await waitFor(
+      () => {
+        // 2FA toggle never flipped.
+        const sw = screen.getByRole("switch", {
+          name: /authenticator app verification/i,
+        });
+        expect(sw).toHaveAttribute("aria-checked", "false");
+        // Input was cleared after failure.
+        expect(input).toHaveValue("");
+        // Error surfaced inline.
+        const alert = screen.getByRole("alert");
+        expect(alert).toHaveTextContent(/didn't work.*try again/i);
+      },
+      { timeout: 3000 },
+    );
+
+    expect(onChange).not.toHaveBeenCalled();
+    // Because the input is now empty the submit button must be disabled again.
+    expect(getVerifyButton()).toBeDisabled();
+  });
+
+  it("failed submission: after the input is cleared, re-typing a valid code re-enables submit", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.95);
+    const { input, getVerifyButton } = openSetupPanelWith();
+
+    fireEvent.change(input, { target: { value: "121212" } });
+    await waitFor(() => expect(getVerifyButton()).not.toBeDisabled());
+    fireEvent.click(getVerifyButton());
+
+    // Wait for failure → input cleared.
+    await waitFor(() => expect(input).toHaveValue(""), { timeout: 3000 });
+
+    // Re-type a valid code and confirm submit is enabled once more.
+    fireEvent.change(input, { target: { value: "555444" } });
+    await waitFor(() => expect(getVerifyButton()).not.toBeDisabled());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2FA setup flow — security properties
+// ---------------------------------------------------------------------------
+
+describe("SecurityTab — 2FA verification security", () => {
+  it("never logs the actual verification code to console during a failed submit", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.95);
+    const consoleSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => void 0);
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => void 0);
+
+    render(<SecurityTab twoFactorEnabled={false} />);
+    const sw = screen.getByRole("switch", {
+      name: /authenticator app verification/i,
+    });
+    fireEvent.click(sw);
+    const input = screen.getByLabelText(/6-digit verification code/i);
+    const submit = screen.getByRole("button", { name: /verify and enable/i });
+
+    const secretCode = "773311";
+    fireEvent.change(input, { target: { value: secretCode } });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    fireEvent.click(submit);
+
+    await waitFor(
+      () =>
+        expect(screen.getByRole("alert")).toHaveTextContent(
+          /didn't work.*try again/i,
+        ),
+      { timeout: 3000 },
+    );
+
+    const allLogged = [
+      ...consoleSpy.mock.calls.flat(),
+      ...consoleErrorSpy.mock.calls.flat(),
+    ]
+      .map(String)
+      .join(" ");
+    expect(allLogged).not.toContain(secretCode);
+  });
+
+  it("never logs the actual verification code to console during a successful submit", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.05);
+    const consoleSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => void 0);
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => void 0);
+
+    render(<SecurityTab twoFactorEnabled={false} />);
+    const sw = screen.getByRole("switch", {
+      name: /authenticator app verification/i,
+    });
+    fireEvent.click(sw);
+    const input = screen.getByLabelText(/6-digit verification code/i);
+    const submit = screen.getByRole("button", { name: /verify and enable/i });
+
+    const secretCode = "228844";
+    fireEvent.change(input, { target: { value: secretCode } });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    fireEvent.click(submit);
+
+    await waitFor(
+      () =>
+        expect(
+          screen.getByText(/authenticator app verified/i),
+        ).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+
+    const allLogged = [
+      ...consoleSpy.mock.calls.flat(),
+      ...consoleErrorSpy.mock.calls.flat(),
+    ]
+      .map(String)
+      .join(" ");
+    expect(allLogged).not.toContain(secretCode);
+  });
+
+  it("server error text does not include the user's previously typed code even when it matches a 'too long' description", () => {
+    // Regression: ensure no leaked code fragment in error text.
+    const err = getVerificationCodeError("12345678");
+    expect(err).not.toContain("12345678");
+    expect(err).not.toContain("12345");
   });
 });

--- a/app/settings/preferences/components/security-tab.tsx
+++ b/app/settings/preferences/components/security-tab.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
+  AlertCircle,
   CheckCircle2,
   KeyRound,
   Monitor,
@@ -23,6 +24,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Form } from "@/components/ui/form";
 import { FormFieldPassword } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
 import { changePasswordSchema, ChangePasswordFormValues } from "@/types/auth";
 import { checkPasswordRequirements } from "@/utils/authUtils";
 import DestructiveActionDialog from "./destructive-action-dialog";
@@ -51,6 +53,12 @@ interface StatusState {
 /** Default two-factor state, exported so a parent can own the same initial value. */
 export const DEFAULT_TWO_FACTOR_ENABLED = true;
 
+/**
+ * The exact length a TOTP/authenticator-app verification code must be to pass
+ * client-side validation in the two-factor setup panel.
+ */
+export const TWO_FACTOR_CODE_LENGTH = 6;
+
 interface SecurityTabProps {
   /**
    * Controlled two-factor state. When provided the component renders this value
@@ -62,33 +70,76 @@ interface SecurityTabProps {
 }
 
 /**
- * SecurityTab — password change, verification controls, and active sessions.
+ * Client-side validation for a 2FA/authenticator verification code.
  *
- * ## Password-change validation flow
+ * Rejects anything that isn't exactly {@link TWO_FACTOR_CODE_LENGTH} ASCII
+ * digits — whitespace, letters, separators (e.g. `-`), partial lengths, and
+ * over-length values all produce a distinct, user-actionable message so a
+ * silent failure can never occur before the network is hit.
  *
- * The form is backed by {@link changePasswordSchema} via `zodResolver`, which
- * enforces the same policy as sign-up:
- * - Minimum 8 characters
- * - At least one uppercase letter
- * - At least one special character (`@!#%$^&*()_+...`)
- * - New password and confirmation must match (cross-field refinement)
+ * @security The raw value is never logged; it is only inspected in-memory and
+ *   the returned string intentionally contains only user-facing guidance text
+ *   (never a substring of the typed code).
  *
- * Validation mode is `"onTouched"`: errors surface on the first blur then
- * update on every subsequent keystroke, so the UI stays quiet while the user
- * is still composing their password. Each field drives `aria-invalid` through
- * `FormControl → Input`, and `FormMessage` surfaces the zod error text inline
- * below the field.
+ * @param value - The raw typed value (never trimmed — a leading/trailing space
+ *   is considered an explicit mismatch the user must fix).
+ * @returns An inline error string when the value is invalid, or `null` when
+ *   the value is acceptable: empty ("user hasn't typed yet") → null; valid
+ *   6-digit numeric code → null.
+ */
+export function getVerificationCodeError(value: string): string | null {
+  if (value.length === 0) {
+    return null;
+  }
+
+  if (!/^\d+$/.test(value)) {
+    return `Code can only contain digits. Type the ${TWO_FACTOR_CODE_LENGTH}-digit code from your app.`;
+  }
+
+  if (value.length < TWO_FACTOR_CODE_LENGTH) {
+    const missing = TWO_FACTOR_CODE_LENGTH - value.length;
+    return `Code is ${missing} digit${missing === 1 ? "" : "s"} too short.`;
+  }
+
+  if (value.length > TWO_FACTOR_CODE_LENGTH) {
+    const extra = value.length - TWO_FACTOR_CODE_LENGTH;
+    return `Code is ${extra} digit${extra === 1 ? "" : "s"} too long.`;
+  }
+
+  return null;
+}
+
+/**
+ * SecurityTab — password change, two-factor verification setup, and active sessions.
  *
- * The submit button is disabled until `form.formState.isValid` is `true`
- * **and** both fields contain text, so an initially-empty form can never be
- * submitted accidentally. While the async save is in-flight the button shows a
- * spinner and is disabled; the form re-enables when the promise resolves.
+ * ## Two-factor setup flow (verification code validation)
  *
- * @security Password values are never logged, printed, or stored outside the
- *   react-hook-form internal state. The `handleSaveChanges` callback receives
- *   the validated `ChangePasswordFormValues` but ignores all field values —
- *   the parameter is prefixed with `_` to make the intent explicit. The form
- *   is reset to empty strings on success to prevent values lingering in state.
+ * When the user toggles the "Authenticator app verification" switch **on** and
+ * 2FA is not yet enabled, the component refuses to flip the toggle directly.
+ * Instead, it opens a gated setup panel where the user must type a 6-digit
+ * numeric TOTP code. Validation layers:
+ *
+ * 1. **Client-side, on every keystroke** — {@link getVerificationCodeError}
+ *    rejects non-digits, partial codes, and over-length codes immediately with
+ *    a distinct inline error. `aria-invalid` and `aria-describedby` are wired
+ *    to the input so the error is announced.
+ * 2. **Submit gate** — the "Verify and enable" button is disabled until the
+ *    typed value is a valid 6-digit numeric code AND the async submit is not
+ *    in flight.
+ * 3. **Second client-side check at submit time** — `handleVerifyTwoFactor`
+ *    re-runs `getVerificationCodeError` just before the simulated fetch, so
+ *    calling the handler programmatically (or a stale React state) can never
+ *    bypass validation.
+ *
+ * Security behaviour for the verification code:
+ * - Input is **cleared immediately** after a failed submit so a code cannot be
+ *   re-submitted accidentally or left on-screen.
+ * - Input is also cleared after a successful submit (together with the form
+ *   state being reset).
+ * - The code is never passed to `console.log`, errors, or any `StatusState`
+ *   message; only the validation *pattern* is surfaced.
+ *
+ * @see {@link getVerificationCodeError} for the inline validation rules.
  */
 export default function SecurityTab({
   twoFactorEnabled: controlledTwoFactor,
@@ -112,6 +163,109 @@ export default function SecurityTab({
     type: null,
   });
   const [isSaving, setIsSaving] = useState(false);
+
+  // --- Two-factor setup panel state ---------------------------------------
+  const [isTwoFactorSetupOpen, setIsTwoFactorSetupOpen] = useState(false);
+  const [twoFactorCode, setTwoFactorCode] = useState("");
+  const [twoFactorSetupInlineError, setTwoFactorSetupInlineError] = useState<
+    string | null
+  >(null);
+  const [twoFactorSubmitting, setTwoFactorSubmitting] = useState(false);
+
+  const twoFactorCodeError = useMemo(
+    () => getVerificationCodeError(twoFactorCode),
+    [twoFactorCode],
+  );
+
+  /**
+   * Whether the typed verification code is valid for submit:
+   * - Exactly {@link TWO_FACTOR_CODE_LENGTH} digits
+   * - No inline validation error
+   * - Async submit not in flight
+   *
+   * This is the single source of truth for the submit button's `disabled`
+   * prop so the form cannot accidentally be submitted with a partial or
+   * malformed code.
+   */
+  const twoFactorCanVerify =
+    !twoFactorSubmitting &&
+    twoFactorCode.length === TWO_FACTOR_CODE_LENGTH &&
+    twoFactorCodeError === null;
+
+  const closeTwoFactorSetup = () => {
+    setIsTwoFactorSetupOpen(false);
+    setTwoFactorCode("");
+    setTwoFactorSetupInlineError(null);
+  };
+
+  /**
+   * Called when the "Authenticator app verification" ToggleCard is clicked.
+   *
+   * - If the user is turning 2FA **off** → allow it directly (no code needed;
+   *   destructive action flow would be a separate concern, out of scope here).
+   * - If the user is turning 2FA **on** → open the gated verification panel
+   *   so a code must be typed before the state flips.
+   */
+  const handleTwoFactorToggleRequest = (nextRequested: boolean) => {
+    if (!nextRequested) {
+      setTwoFactorEnabled(false);
+      closeTwoFactorSetup();
+      return;
+    }
+    setIsTwoFactorSetupOpen(true);
+    setTwoFactorCode("");
+    setTwoFactorSetupInlineError(null);
+  };
+
+  /**
+   * Validates + submits the 2FA verification code.
+   *
+   * @security Re-checks {@link getVerificationCodeError} synchronously before
+   *   any awaits so a stale prop/programmatic call cannot skip validation.
+   *   After a failed submit the code input is cleared so the value never
+   *   lingers in the DOM. After success the code is also cleared + the panel
+   *   is closed and the 2FA toggle is flipped on.
+   */
+  const handleVerifyTwoFactor = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const syncError = getVerificationCodeError(twoFactorCode);
+    if (syncError) {
+      setTwoFactorSetupInlineError(syncError);
+      return;
+    }
+
+    setTwoFactorSetupInlineError(null);
+    setTwoFactorSubmitting(true);
+    try {
+      await new Promise<void>((resolve, reject) =>
+        setTimeout(() => {
+          if (Math.random() > 0.8) {
+            reject(new Error("Verification failed"));
+          } else {
+            resolve();
+          }
+        }, 1200),
+      );
+
+      setTwoFactorEnabled(true);
+      closeTwoFactorSetup();
+      setStatus({
+        message:
+          "Authenticator app verified. Two-factor is now enabled for this account.",
+        type: "success",
+      });
+      setTimeout(() => setStatus({ message: "", type: null }), 5000);
+    } catch {
+      // Security: clear the failed code immediately so the user must re-type.
+      setTwoFactorCode("");
+      setTwoFactorSetupInlineError(
+        "That code didn't work. Check your authenticator app and try again.",
+      );
+    } finally {
+      setTwoFactorSubmitting(false);
+    }
+  };
 
   const form = useForm<ChangePasswordFormValues>({
     resolver: zodResolver(changePasswordSchema),
@@ -227,10 +381,7 @@ export default function SecurityTab({
                   label="One special character"
                   met={passwordRequirements.specialChar}
                 />
-                <RequirementItem
-                  label="Passwords match"
-                  met={passwordsMatch}
-                />
+                <RequirementItem label="Passwords match" met={passwordsMatch} />
               </div>
 
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -238,10 +389,7 @@ export default function SecurityTab({
                   Recovery methods stay hidden until needed to keep the primary
                   path calm.
                 </p>
-                <Button
-                  type="submit"
-                  disabled={!canSubmit || isSaving}
-                >
+                <Button type="submit" disabled={!canSubmit || isSaving}>
                   {isSaving ? (
                     <>
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -315,8 +463,110 @@ export default function SecurityTab({
               description="Require a second factor for password resets and critical profile changes."
               badge="Recommended"
               enabled={twoFactorEnabled}
-              onToggle={setTwoFactorEnabled}
+              onToggle={handleTwoFactorToggleRequest}
             />
+
+            {isTwoFactorSetupOpen && (
+              <form
+                onSubmit={handleVerifyTwoFactor}
+                className="rounded-2xl border border-sky-500/20 bg-sky-500/5 p-4"
+                aria-label="Authenticator verification setup"
+              >
+                <div className="space-y-3">
+                  <p className="flex gap-2 text-sm font-medium text-zinc-900 dark:text-white">
+                    <AlertCircle className="mt-0.5 h-4 w-4 text-sky-600 dark:text-sky-300" />
+                    Enter the code displayed in your authenticator app to finish
+                    enabling 2FA.
+                  </p>
+
+                  <div className="space-y-2">
+                    <label
+                      htmlFor="two-factor-verification-code"
+                      className="text-sm font-medium text-zinc-900 dark:text-white"
+                    >
+                      {`${TWO_FACTOR_CODE_LENGTH}-digit verification code`}
+                    </label>
+                    <p
+                      id="two-factor-code-instruction"
+                      className="text-xs text-zinc-600 dark:text-zinc-400"
+                    >
+                      Type the code exactly as shown — no spaces or letters.
+                    </p>
+                    <Input
+                      id="two-factor-verification-code"
+                      type="text"
+                      inputMode="numeric"
+                      autoComplete="one-time-code"
+                      placeholder={`${"0".repeat(TWO_FACTOR_CODE_LENGTH)}`}
+                      value={twoFactorCode}
+                      onChange={(event) => {
+                        setTwoFactorCode(event.target.value);
+                        if (twoFactorSetupInlineError) {
+                          setTwoFactorSetupInlineError(null);
+                        }
+                      }}
+                      maxLength={TWO_FACTOR_CODE_LENGTH + 4}
+                      disabled={twoFactorSubmitting}
+                      error={Boolean(
+                        twoFactorCodeError ?? twoFactorSetupInlineError,
+                      )}
+                      aria-required
+                      aria-describedby={
+                        [
+                          "two-factor-code-instruction",
+                          twoFactorCodeError || twoFactorSetupInlineError
+                            ? "two-factor-code-error"
+                            : undefined,
+                        ]
+                          .filter(Boolean)
+                          .join(" ") || undefined
+                      }
+                      className="tracking-[0.35em] font-mono text-base text-center"
+                    />
+                    {(twoFactorCodeError ?? twoFactorSetupInlineError) && (
+                      <p
+                        id="two-factor-code-error"
+                        role="alert"
+                        aria-live="polite"
+                        className="flex items-center gap-1.5 text-xs font-medium text-red-500"
+                      >
+                        <AlertCircle className="h-3.5 w-3.5" />
+                        {twoFactorCodeError ?? twoFactorSetupInlineError}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={closeTwoFactorSetup}
+                      disabled={twoFactorSubmitting}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      type="submit"
+                      disabled={!twoFactorCanVerify}
+                      className="gap-2"
+                    >
+                      {twoFactorSubmitting ? (
+                        <>
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          Verifying...
+                        </>
+                      ) : (
+                        <>
+                          <CheckCircle2 className="h-4 w-4" />
+                          Verify and enable
+                        </>
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              </form>
+            )}
+
             <ToggleCard
               title="New device approval"
               description="Challenge sign-ins from browsers or devices you have not approved yet."


### PR DESCRIPTION
# feat(settings): add 2FA verification code setup flow with client-side validation (#621)

Adds a gated authenticator-app verification setup flow to
`app/settings/preferences/components/security-tab.tsx` and comprehensive
validation tests for incomplete, malformed, incorrect-length, valid,
success, and failure (input-cleared-for-security) paths.

## What changed

### Component (`security-tab.tsx`)

**1. Pure validation helper — `getVerificationCodeError`**
- Exported from the component so tests (and future callers) can exercise it
  in isolation.
- Produces distinct, actionable inline error messages for:
  - non-digit characters (letters, spaces, dashes → "Code can only contain
    digits...")
  - too-short codes ("Code is N digit(s) too short")
  - too-long codes ("Code is N digit(s) too long")
  - empty input → `null` (no false-positive error before the user types)
- Whitespace is **never** trimmed — a leading/trailing space triggers the
  "digits only" error instead of silently passing.
- No typed value fragment is ever echoed back in a returned error string
  (security: prevents shoulder-surf / screenshot leakage of partial codes).

**2. Toggle gating**
- Clicking the "Authenticator app verification" ToggleCard `switch` to turn
  2FA ON when it is currently OFF no longer flips the toggle immediately.
  Instead it opens a dedicated verification-code setup panel below the
  toggles. `onTwoFactorEnabledChange` is deliberately NOT called at this
  point (asserted by tests).
- Clicking to turn 2FA OFF still works directly (destructive confirmation
  for that path is a separate concern and out of scope for this issue).

**3. Setup panel UI — gated, accessible, secure**
- Controlled `<Input>` with `inputMode="numeric"`,
  `autoComplete="one-time-code"`, `aria-required`, and
  `aria-describedby="instruction-id [error-id]"` so both the hint text and
  any live validation error are announced together.
- Inline errors render with `role="alert"` + `aria-live="polite"` and are
  driven by `getVerificationCodeError`.
- **Submit gating (single source of truth):** `twoFactorCanVerify` is true
  only when `!submitting && code.length === 6 && error === null`. The
  "Verify and enable" button is disabled otherwise.
- **Second submit-time check:** `handleVerifyTwoFactor` re-runs
  `getVerificationCodeError` synchronously *before* any `await` so stale
  state / programmatic calls cannot bypass the validation.
- **Cancel button**: closes the panel, clears all state (code + inline
  error), and leaves the 2FA switch OFF — reopening the panel afterwards
  starts from a clean slate.

**4. Security behaviour — the verification code is treated as a short-lived
credential:**
- On a simulated-network **failure**:
  - Input is cleared *immediately* (`setTwoFactorCode("")`) so it cannot
    linger on-screen, be re-submitted accidentally, or be captured by a
    subsequent auto-fill bug.
  - A generic "That code didn't work. Check your authenticator app and try
    again." inline error is shown — it contains no fragment of the code the
    user typed.
  - `onTwoFactorEnabledChange` is never called; the switch stays OFF.
- On a simulated-network **success**:
  - Panel closes, input + error state reset, `twoFactorEnabled` flips ON,
    controlled `onTwoFactorEnabledChange(true)` fires once, and a success
    banner (`role="status"` + `aria-live="polite"`) is auto-cleared after
    5 s via the existing shared status surface.
- At no point is the code value passed to `console.log` /
  `console.error`, written to a `StatusState` message, or echoed inside a
  validation-error string — tests assert this end-to-end.

### Tests (`security-tab.test.tsx`)

All ~30 existing password / status / edge-case tests are preserved and
continue to pass unchanged. Six new `describe` blocks were appended:

1. `getVerificationCodeError helper` — pure-fn unit tests for empty,
   valid, non-digit, too-short (exact counts), too-long (exact counts),
   whitespace-sensitive-no-trim, length constant.
2. `2FA setup panel open/close` — OFF→ON gating (no toggle flip until
   verified), ON→OFF direct, controlled callback NOT called on open, IS
   called on direct OFF, Cancel closes + clears + re-open confirms empty.
3. `2FA verification code validation` — initial state (empty, disabled,
   no alert), incomplete 3-digit shows too-short, 5-digit too-short with
   exact-1-digit wording, 7-digit too-long, letters → digits-only +
   aria-invalid true, valid 6-digit enables submit w/ aria-invalid false
   and no alert, partial-delete of valid code disables + correct error,
   error transitions don't linger stale messages, aria-describedby
   exposes instruction + error.
4. `2FA verification submit — success` — controlled callback called once
   w/ true, switch aria-checked=true, loading state shown, success banner
   appears, panel closes, panel state fully reset on reopen (empty input +
   disabled submit).
5. `2FA verification submit — failure` — input cleared, inline server
   error, switch stays OFF, controlled callback NOT called, submit
   disabled again because input is empty, re-typing valid code re-enables
   submit so retries work.
6. `2FA verification security` — console.log/error never contain the
   typed code after a FAIL submit, same assertion after a SUCCESS submit,
   `getVerificationCodeError` error strings never echo the raw input
   (even for too-long / digit-pattern inputs).

## Acceptance criteria (#621)

- ✅ **Incomplete/malformed code is rejected client-side with a clear
  message before hitting the network.** `getVerificationCodeError` +
  `twoFactorCanVerify` both gate at the UI layer, and a synchronous
  re-check at submit time is the final belt-and-braces guard.
- ✅ **Successful submission resets form state appropriately.** Panel
  closes, input clears, error state cleared, submit re-disabled on
  re-open, 2FA switch flipped, success banner shown.
- ✅ **Tests cover incomplete, malformed, and successful submission
  paths.** Unit-level helper tests plus component-level tests for
  incomplete (too-short), malformed (non-digits / too-long), valid
  submit success, plus failure path for security behaviour.
- ✅ **Verification code input is cleared after a failed attempt.**
  Explicitly implemented and tested. Also verified: codes are never
  logged and error messages never contain the typed value.

Closes #621 