### PR TITLE
feat: add unsupported-network warning banner to NetworkSwitcher

### DIFF
--- a/components/common/network-switcher.test.tsx
+++ b/components/common/network-switcher.test.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect } from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  WalletProvider,
+  useWallet,
+  SUPPORTED_NETWORKS,
+} from "@/context/wallet-context";
+import NetworkSwitcher from "./network-switcher";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Renders `NetworkSwitcher` inside a default `WalletProvider`. */
+function renderDefault() {
+  return render(
+    <WalletProvider>
+      <NetworkSwitcher />
+    </WalletProvider>,
+  );
+}
+
+/**
+ * Renders `NetworkSwitcher` inside a `WalletProvider` that immediately
+ * switches to an unsupported network via `setNetwork` in an effect.
+ */
+function renderUnsupported() {
+  function Harness() {
+    const { setNetwork } = useWallet();
+    useEffect(() => {
+      setNetwork({ id: "unsupported", name: "Unsupported Chain" });
+    }, [setNetwork]);
+    return <NetworkSwitcher />;
+  }
+  return render(
+    <WalletProvider>
+      <Harness />
+    </WalletProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("NetworkSwitcher – unsupported-network banner", () => {
+  it("does not show the banner when on a supported network", () => {
+    renderDefault();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("shows the banner when the wallet is on an unsupported network", async () => {
+    renderUnsupported();
+    const alert = await screen.findByRole("alert");
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent(/unsupported network detected/i);
+  });
+
+  it("includes a CTA button that names the first supported network", async () => {
+    renderUnsupported();
+    const cta = await screen.findByTestId("switch-to-supported");
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveTextContent(`Switch to ${SUPPORTED_NETWORKS[0].name}`);
+  });
+
+  it("switching via CTA dismisses the banner and clears the unsupported flag", async () => {
+    renderUnsupported();
+
+    const cta = await screen.findByTestId("switch-to-supported");
+    fireEvent.click(cta);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+
+  it("can be dismissed with the close button", async () => {
+    renderUnsupported();
+
+    const dismiss = await screen.findByRole("button", {
+      name: /dismiss unsupported network warning/i,
+    });
+    fireEvent.click(dismiss);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+
+  it("reappears on remount (dismissal is not persisted)", () => {
+    const { unmount } = renderUnsupported();
+
+    // Dismiss
+    const dismiss = screen.getByRole("button", {
+      name: /dismiss unsupported network warning/i,
+    });
+    fireEvent.click(dismiss);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    // Unmount
+    unmount();
+
+    // Re-mount – banner should be back
+    renderUnsupported();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+});
+
+describe("NetworkSwitcher – controlled mode (props)", () => {
+  it("still shows unsupported banner when context is unsupported", async () => {
+    function Harness() {
+      const { setNetwork } = useWallet();
+      useEffect(() => {
+        setNetwork({ id: "unsupported", name: "Unsupported Chain" });
+      }, [setNetwork]);
+      return (
+        <NetworkSwitcher
+          networks={SUPPORTED_NETWORKS}
+          selectedNetwork={SUPPORTED_NETWORKS[0]}
+          onNetworkChange={() => {}}
+        />
+      );
+    }
+    render(
+      <WalletProvider>
+        <Harness />
+      </WalletProvider>,
+    );
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toBeInTheDocument();
+  });
+});

--- a/components/common/network-switcher.tsx
+++ b/components/common/network-switcher.tsx
@@ -24,6 +24,18 @@
  * - Target network name is wrapped in `<strong>` for semantic emphasis.
  * - Focus returns to the DropdownMenuTrigger when the dialog closes
  *   (either Cancel or Escape).
+ *
+ * Unsupported-network banner (issue #XYZ):
+ * - When {@link WalletContextValue.isUnsupportedNetwork} is `true` a
+ *   warning banner is rendered below the dropdown trigger with a CTA
+ *   to switch to the first supported network.
+ * - The banner is **dismissible**: clicking the close button hides it
+ *   for the current component lifetime (i.e. until navigation or page
+ *   reload).  It is intentionally not persisted to storage — the warning
+ *   should reappear when the user comes back while still on an unsupported
+ *   network.
+ * - The CTA reuses the same `wallet.setNetwork` / `onNetworkChange`
+ *   paths that the confirmation dialog uses.
  */
 
 import React, { useRef, useState } from "react";
@@ -42,7 +54,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, X } from "lucide-react";
 import { cn } from "@/utils/commonUtils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StellarIcon } from "@/public/svg/svg";
@@ -106,6 +118,20 @@ export default function NetworkSwitcher({
 
   const isDashboard = variant === "dashboard";
 
+  // ── Unsupported-network banner state ────────────────────────────────
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+  const showUnsupportedBanner = wallet.isUnsupportedNetwork && !bannerDismissed;
+
+  const handleSwitchToSupported = () => {
+    if (!resolvedNetworks.length) return;
+    const target = resolvedNetworks[0];
+    if (!selectedNetwork) {
+      wallet.setNetwork(target);
+    }
+    onNetworkChange?.(target);
+    setBannerDismissed(true);
+  };
+
   const handleNetworkSelect = (network: Network) => {
     if (network.id === currentNetwork.id) return;
     setPendingNetwork(network);
@@ -139,6 +165,47 @@ export default function NetworkSwitcher({
 
   return (
     <>
+      {/* ── Unsupported-network warning banner ────────────────────────── */}
+      {/*
+       * Shown when the wallet reports a network outside
+       * SUPPORTED_NETWORKS.  Dismissed via the close button; reappears on
+       * page reload.
+       *
+       * The CTA calls handleSwitchToSupported which reuses the same
+       * setNetwork / onNetworkChange paths as the confirmation dialog.
+       */}
+      {showUnsupportedBanner && (
+        <div
+          role="alert"
+          className={cn(
+            "flex items-center gap-3 px-4 py-3 rounded-md border mb-3",
+            isDashboard
+              ? "bg-amber-500/10 border-amber-500/30"
+              : "bg-amber-500/10 border-amber-500/30",
+          )}
+        >
+          <span className="text-sm text-amber-400 leading-tight">
+            Unsupported network detected. Switch to a supported network to
+            continue.
+          </span>
+          <Button
+            onClick={handleSwitchToSupported}
+            size="sm"
+            className="shrink-0 bg-amber-500 text-black hover:bg-amber-400 font-semibold"
+            data-testid="switch-to-supported"
+          >
+            Switch to {resolvedNetworks[0]?.name}
+          </Button>
+          <button
+            onClick={() => setBannerDismissed(true)}
+            aria-label="Dismiss unsupported network warning"
+            className="shrink-0 text-amber-400 hover:text-amber-300 transition-colors"
+          >
+            <X className="w-4 h-4" aria-hidden="true" />
+          </button>
+        </div>
+      )}
+
       {/* ── Dropdown ─────────────────────────────────────────────────── */}
       {/* ref wrapper lets us locate the trigger button for focus-return (issue #343) */}
       <div ref={triggerWrapperRef} style={{ display: "contents" }}>

--- a/tests/network-switcher.spec.ts
+++ b/tests/network-switcher.spec.ts
@@ -381,6 +381,27 @@ test.describe.skip("NetworkSwitcher — dialog ARIA labels (issue #343)", () => 
   });
 });
 
+// ─── Unsupported-network warning banner ──────────────────────────────────
+//
+// The unsupported-network banner is triggered when
+// WalletContextValue.isUnsupportedNetwork is true.  Since the app currently
+// only has Stellar in SUPPORTED_NETWORKS, there is no UI path to set the
+// wallet to an unsupported network.  The unit tests in
+// components/common/network-switcher.test.tsx verify the banner logic
+// directly by calling setNetwork with an unsupported network id from inside
+// a WalletProvider-wrapped test harness.
+//
+// The supported-network case (no banner) is tested below.  Once a wallet
+// SDK integration (Freighter, WalletConnect) is wired, the banner E2E
+// coverage can be reinstated with real unsupported-network scenarios.
+test.describe("NetworkSwitcher — unsupported-network banner", () => {
+  test("supported-network state shows no banner", async ({ page }) => {
+    await page.goto(LANDING_URL);
+    const banner = page.locator('[role="alert"]');
+    await expect(banner).toHaveCount(0);
+  });
+});
+
 test.describe("Performance & Trace Validation", () => {
   test("main pages load and have no major layout shift or console errors", async ({ page, context }) => {
     // Start tracing before navigating

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
         "components/analytics/client-analytics-view.tsx",
         "components/common/notification-panel.tsx",
         "components/common/app-layout.tsx",
+        "components/common/network-switcher.tsx",
         "components/ui/pagination.tsx",
       ],
       exclude: [


### PR DESCRIPTION
When the wallet is connected to a network not in SUPPORTED_NETWORKS, a dismissible amber warning banner now appears with a CTA to switch to the first supported network. The CTA reuses the existing setNetwork/onNetworkChange paths.

- Banner with role='alert', amber styling, close button
- CTA button switches to SUPPORTED_NETWORKS[0]
- 7 unit tests covering supported/unsupported/dismiss/remount/controlled
- E2E test verifying supported-network state shows no banner
- network-switcher.tsx added to vitest coverage config




## Checklist

- [ ] I have tested the changes locally.
- [ ] I have added/updated documentation as needed.
- [ ] I have reviewed the code and ensured it follows the project guidelines.
- [ ] I have added necessary tests.

closes #604


