### PR TITLE
feat: add tax documents/statements section to settings

### DIFF
--- a/app/settings/preferences/components/settings-page-shell.test.tsx
+++ b/app/settings/preferences/components/settings-page-shell.test.tsx
@@ -4,6 +4,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
   within,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -30,9 +31,12 @@ vi.mock("next/image", () => ({
 
 /** Return the summary card element identified by its label text. */
 function summaryValue(label: string): HTMLElement {
-  const card = screen.getByText(label).closest('[data-slot="card"]');
+  const card = screen
+    .getAllByText(label)
+    .map((element) => element.closest('[data-slot="card"]'))
+    .find((element): element is HTMLElement => element !== null);
   if (!card) throw new Error(`Summary card for "${label}" not found`);
-  return card as HTMLElement;
+  return card;
 }
 
 describe("SettingsPageShell summary cards", () => {
@@ -55,6 +59,9 @@ describe("SettingsPageShell summary cards", () => {
     ).toBeInTheDocument();
     expect(
       within(summaryValue("Wallet coverage")).getByText("2 linked"),
+    ).toBeInTheDocument();
+    expect(
+      within(summaryValue("Statements")).getByText("3 ready"),
     ).toBeInTheDocument();
   });
 
@@ -82,6 +89,51 @@ describe("SettingsPageShell summary cards", () => {
   });
 });
 
+describe("SettingsPageShell statements section", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("routes statements through the settings tabs and renders downloadable documents", () => {
+    render(<SettingsPageShell initialSection="documents" />);
+
+    expect(screen.getByRole("tab", { name: /statements/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    const table = screen.getByRole("table", {
+      name: /available statements and tax documents/i,
+    });
+    expect(
+      within(table).getByRole("columnheader", { name: /period/i }),
+    ).toBeInTheDocument();
+    expect(within(table).getByText("Q2 2026")).toBeInTheDocument();
+    expect(within(table).getByText("Tax year 2025")).toBeInTheDocument();
+
+    const downloadLink = screen.getByRole("link", {
+      name: /download q2 2026 transaction statement/i,
+    });
+    expect(downloadLink).toHaveAttribute("download", "stmt-2026-q2.txt");
+    expect(downloadLink).toHaveAttribute(
+      "href",
+      expect.stringMatching(/^data:/),
+    );
+  });
+
+  it("uses the shared empty state when no statements are available", () => {
+    render(<SettingsPageShell initialSection="documents" statements={[]} />);
+
+    expect(
+      within(summaryValue("Statements")).getByText("0 ready"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /no statements available yet/i,
+    );
+  });
+});
+
 describe("SettingsPageShell keyboard tabs", () => {
   afterEach(() => {
     cleanup();
@@ -106,7 +158,7 @@ describe("SettingsPageShell keyboard tabs", () => {
       .toHaveAttribute("aria-selected", "true");
   });
 
-  it("cycles focus and active section with ArrowRight and ArrowLeft", () => {
+  it("cycles focus and active section with ArrowRight and ArrowLeft", async () => {
     render(<SettingsPageShell initialSection="notifications" />);
 
     const notificationsTab = screen.getByRole("tab", {
@@ -115,21 +167,27 @@ describe("SettingsPageShell keyboard tabs", () => {
     notificationsTab.focus();
 
     fireEvent.keyDown(notificationsTab, { key: "ArrowRight" });
-    expect(screen.getByRole("tab", { name: /security/i })).toHaveFocus();
-    expect(screen.getByRole("tab", { name: /security/i })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /security/i })).toHaveFocus();
+      expect(screen.getByRole("tab", { name: /security/i })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
 
     fireEvent.keyDown(screen.getByRole("tab", { name: /security/i }), {
       key: "ArrowLeft",
     });
-    expect(screen.getByRole("tab", { name: /notifications/i })).toHaveFocus();
-    expect(screen.getByRole("tab", { name: /notifications/i }))
-      .toHaveAttribute("aria-selected", "true");
+    await waitFor(() => {
+      expect(
+        screen.getByRole("tab", { name: /notifications/i }),
+      ).toHaveFocus();
+      expect(screen.getByRole("tab", { name: /notifications/i }))
+        .toHaveAttribute("aria-selected", "true");
+    });
   });
 
-  it("moves to the first and last settings tabs with Home and End", () => {
+  it("moves to the first and last settings tabs with Home and End", async () => {
     render(<SettingsPageShell initialSection="notifications" />);
 
     const notificationsTab = screen.getByRole("tab", {
@@ -138,19 +196,23 @@ describe("SettingsPageShell keyboard tabs", () => {
     notificationsTab.focus();
 
     fireEvent.keyDown(notificationsTab, { key: "End" });
-    expect(screen.getByRole("tab", { name: /wallets/i })).toHaveFocus();
-    expect(screen.getByRole("tab", { name: /wallets/i })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /statements/i })).toHaveFocus();
+      expect(screen.getByRole("tab", { name: /statements/i })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
 
-    fireEvent.keyDown(screen.getByRole("tab", { name: /wallets/i }), {
+    fireEvent.keyDown(screen.getByRole("tab", { name: /statements/i }), {
       key: "Home",
     });
-    expect(screen.getByRole("tab", { name: /account/i })).toHaveFocus();
-    expect(screen.getByRole("tab", { name: /account/i })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /account/i })).toHaveFocus();
+      expect(screen.getByRole("tab", { name: /account/i })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
   });
 });

--- a/app/settings/preferences/components/settings-page-shell.tsx
+++ b/app/settings/preferences/components/settings-page-shell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Bell, Shield, UserRound, Wallet } from "lucide-react";
+import { Bell, FileText, Shield, UserRound, Wallet } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import SettingsHeader, {
   SettingsHeaderSection,
@@ -26,6 +26,10 @@ import NotificationsSection, {
   countActiveNotifications,
 } from "./notifications-section";
 import SecurityTab, { DEFAULT_TWO_FACTOR_ENABLED } from "./security-tab";
+import TaxDocumentsSection, {
+  AVAILABLE_TAX_DOCUMENTS,
+  type TaxDocument,
+} from "./tax-documents-section";
 import WalletsSection from "./wallets-section";
 
 /**
@@ -35,42 +39,53 @@ import WalletsSection from "./wallets-section";
  */
 const linkedWalletCount = DEMO_WALLETS.length;
 
-const sections: SettingsHeaderSection[] = [
-  {
-    value: "account",
-    label: "Account",
-    description: "Profile, identity, and region defaults.",
-    badge: "Core",
-  },
-  {
-    value: "notifications",
-    label: "Notifications",
-    description: "Transaction alerts and delivery channels.",
-    badge: "Alerts",
-  },
-  {
-    value: "security",
-    label: "Security",
-    description: "Password, verification, and sessions.",
-    badge: "Protected",
-  },
-  {
-    value: "wallets",
-    label: "Wallets",
-    description: "Connected wallets and transfer safeguards.",
-    badge: `${linkedWalletCount} linked`,
-  },
-];
+function buildSections(statementCount: number): SettingsHeaderSection[] {
+  return [
+    {
+      value: "account",
+      label: "Account",
+      description: "Profile, identity, and region defaults.",
+      badge: "Core",
+    },
+    {
+      value: "notifications",
+      label: "Notifications",
+      description: "Transaction alerts and delivery channels.",
+      badge: "Alerts",
+    },
+    {
+      value: "security",
+      label: "Security",
+      description: "Password, verification, and sessions.",
+      badge: "Protected",
+    },
+    {
+      value: "wallets",
+      label: "Wallets",
+      description: "Connected wallets and transfer safeguards.",
+      badge: `${linkedWalletCount} linked`,
+    },
+    {
+      value: "documents",
+      label: "Statements",
+      description: "Periodic statements and tax summaries.",
+      badge: `${statementCount} ready`,
+    },
+  ];
+}
 
 interface SettingsPageShellProps {
   initialSection?: string;
+  statements?: TaxDocument[];
 }
 
 export default function SettingsPageShell({
   initialSection,
+  statements = AVAILABLE_TAX_DOCUMENTS,
 }: SettingsPageShellProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const sections = buildSections(statements.length);
   const resolvedInitialSection = sections.some(
     (section) => section.value === initialSection,
   )
@@ -98,6 +113,7 @@ export default function SettingsPageShell({
   const activeAlerts = countActiveNotifications(notificationSettings);
   const securityPosture = twoFactorEnabled ? "2-step on" : "2-step off";
   const walletCoverage = `${linkedWalletCount} linked`;
+  const statementCoverage = `${statements.length} ready`;
 
   const handleSectionChange = (nextSection: string) => {
     setActiveSection(nextSection);
@@ -122,7 +138,7 @@ export default function SettingsPageShell({
       />
 
       <div className="mx-auto flex w-full max-w-screen-xl flex-1 flex-col gap-8 px-4 py-8 md:px-6">
-        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
           <SummaryCard
             icon={UserRound}
             label="Profile readiness"
@@ -147,6 +163,12 @@ export default function SettingsPageShell({
             value={walletCoverage}
             description="Connected wallets sit next to transfer safeguards."
           />
+          <SummaryCard
+            icon={FileText}
+            label="Statements"
+            value={statementCoverage}
+            description="Tax summaries and statements stay available for export."
+          />
         </section>
 
         <TabsContent value="account" className="mt-0">
@@ -169,6 +191,10 @@ export default function SettingsPageShell({
 
         <TabsContent value="wallets" className="mt-0">
           <WalletsSection />
+        </TabsContent>
+
+        <TabsContent value="documents" className="mt-0">
+          <TaxDocumentsSection statements={statements} />
         </TabsContent>
       </div>
     </Tabs>

--- a/app/settings/preferences/components/tax-documents-section.tsx
+++ b/app/settings/preferences/components/tax-documents-section.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { Download, FileText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export interface TaxDocument {
+  id: string;
+  period: string;
+  dateRange: string;
+  type: string;
+  status: "Ready" | "Processing";
+  generatedAt: string;
+  downloadUrl: string;
+}
+
+export const AVAILABLE_TAX_DOCUMENTS: TaxDocument[] = [
+  {
+    id: "stmt-2026-q2",
+    period: "Q2 2026",
+    dateRange: "Apr 1 - Jun 30, 2026",
+    type: "Transaction statement",
+    status: "Ready",
+    generatedAt: "Jul 2, 2026",
+    downloadUrl:
+      "data:text/plain;charset=utf-8,Stellopay%20Q2%202026%20transaction%20statement",
+  },
+  {
+    id: "tax-2025",
+    period: "Tax year 2025",
+    dateRange: "Jan 1 - Dec 31, 2025",
+    type: "Tax summary",
+    status: "Ready",
+    generatedAt: "Jan 8, 2026",
+    downloadUrl:
+      "data:text/plain;charset=utf-8,Stellopay%202025%20tax%20summary",
+  },
+  {
+    id: "stmt-2025-q4",
+    period: "Q4 2025",
+    dateRange: "Oct 1 - Dec 31, 2025",
+    type: "Transaction statement",
+    status: "Ready",
+    generatedAt: "Jan 3, 2026",
+    downloadUrl:
+      "data:text/plain;charset=utf-8,Stellopay%20Q4%202025%20transaction%20statement",
+  },
+];
+
+interface TaxDocumentsSectionProps {
+  statements?: TaxDocument[];
+}
+
+export default function TaxDocumentsSection({
+  statements = AVAILABLE_TAX_DOCUMENTS,
+}: TaxDocumentsSectionProps) {
+  return (
+    <Card className="border-zinc-200 bg-white/90 shadow-sm dark:border-white/10 dark:bg-white/5">
+      <CardHeader className="border-b border-zinc-200/80 dark:border-white/10">
+        <CardTitle className="font-general text-2xl text-zinc-950 dark:text-white">
+          Statements and tax documents
+        </CardTitle>
+        <CardDescription className="text-zinc-600 dark:text-zinc-400">
+          Download periodic statements and tax-relevant transaction summaries
+          for accounting, reconciliation, and year-end reporting.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6 pt-6">
+        {statements.length > 0 ? (
+          <Table aria-label="Available statements and tax documents">
+            <TableCaption>
+              Documents are generated from completed Stellopay activity.
+            </TableCaption>
+            <TableHeader>
+              <TableRow>
+                <TableHead scope="col">Period</TableHead>
+                <TableHead scope="col">Date range</TableHead>
+                <TableHead scope="col">Document type</TableHead>
+                <TableHead scope="col">Generated</TableHead>
+                <TableHead scope="col" className="text-right">
+                  Download
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {statements.map((statement) => (
+                <TableRow key={statement.id}>
+                  <TableCell className="font-medium text-zinc-950 dark:text-white">
+                    {statement.period}
+                  </TableCell>
+                  <TableCell className="text-zinc-600 dark:text-zinc-300">
+                    {statement.dateRange}
+                  </TableCell>
+                  <TableCell className="text-zinc-600 dark:text-zinc-300">
+                    {statement.type}
+                  </TableCell>
+                  <TableCell className="text-zinc-600 dark:text-zinc-300">
+                    {statement.generatedAt}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button asChild size="sm" variant="outline">
+                      <a
+                        href={statement.downloadUrl}
+                        download={`${statement.id}.txt`}
+                        aria-label={`Download ${statement.period} ${statement.type}`}
+                      >
+                        <Download className="h-4 w-4" aria-hidden="true" />
+                        Download
+                      </a>
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <EmptyState
+            icon={<FileText className="h-10 w-10" aria-hidden="true" />}
+            title="No statements available yet"
+            description="Statements appear here after completed payment activity is ready for monthly, quarterly, or annual reporting."
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/settings-header.tsx
+++ b/components/settings-header.tsx
@@ -58,6 +58,7 @@ export default function SettingsHeader({
             <TabsTrigger
               key={section.value}
               value={section.value}
+              tabIndex={section.value === activeSection ? 0 : -1}
               className={cn(
                 "min-w-[160px] flex-none items-start rounded-2xl border border-transparent px-4 py-3 text-left data-[state=active]:border-zinc-200 data-[state=active]:bg-white data-[state=active]:text-zinc-950 dark:data-[state=active]:border-white/10 dark:data-[state=active]:bg-[#09090B] dark:data-[state=active]:text-white",
                 "focus-visible:ring-zinc-900 dark:focus-visible:ring-white",

--- a/design/settings-ia.md
+++ b/design/settings-ia.md
@@ -2,12 +2,13 @@
 
 ## Overview
 
-This pass restructures the settings surface around four primary sections:
+This pass restructures the settings surface around five primary sections:
 
 - Account
 - Notifications
 - Security
 - Wallets
+- Statements
 
 The goal is to keep frequent tasks obvious, reduce visual overload, and separate destructive actions from routine edits.
 
@@ -19,6 +20,7 @@ The goal is to keep frequent tasks obvious, reduce visual overload, and separate
 - **Notifications:** alert priorities, channel routing, and quiet hours
 - **Security:** password work, verification controls, and active sessions
 - **Wallets:** connected wallets, outbound safeguards, and destructive wallet removal
+- **Statements:** downloadable periodic statements and tax-relevant transaction summaries
 
 The top chrome now uses a persistent settings section bar built from the existing `components/ui/tabs.tsx` primitive. The active section is mirrored into the URL with `?section=...` so users can deep-link directly into a settings area without creating additional nested routes.
 
@@ -30,6 +32,7 @@ The page now exposes only high-frequency tasks by default and hides lower-freque
 - Delivery channel customization
 - Recovery methods
 - Wallet metadata and compliance checks
+- Empty statement history when no downloadable documents have been generated yet
 
 This keeps the initial scan light on both desktop and mobile while still keeping advanced controls on the same page.
 
@@ -59,9 +62,30 @@ The intended click depth from `/settings/preferences` is:
 - Adjust notification priorities: 1 section tap + 1 toggle
 - Change password: 1 section tap + form interaction
 - Review wallet controls: 1 section tap + 1 toggle
+- Download a statement or tax summary: 1 section tap + 1 download action
 - Destructive actions: 1 section tap + 1 danger-zone action + typed confirmation
 
 This keeps the overwhelming majority of settings tasks within the requested `<= 3 clicks` threshold from entry.
+
+## Statements Section
+
+The Statements tab lists generated documents by period using the shared
+`components/ui/table.tsx` primitive. Each row includes the reporting period,
+covered date range, document type, generation date, and a keyboard-focusable
+download action with an explicit accessible name such as
+`Download Q2 2026 Transaction statement`.
+
+When no documents are available, the tab renders the shared
+`components/ui/empty-state.tsx` component so the section has a clear, polite
+screen-reader announcement instead of a blank panel.
+
+Accessibility and responsive notes:
+
+- Contrast follows the existing zinc/white/dark-mode settings tokens used by the other sections.
+- The tab remains reachable through the existing Radix tabs keyboard model: arrow keys, Home, and End.
+- The document list uses semantic table headers and a horizontal overflow wrapper from the shared table component for small screens.
+- The table and empty state are designed to remain usable at `sm` 640px, `md` 768px, `lg` 1024px, and `xl` 1280px.
+- Download links include visible text, an icon marked `aria-hidden`, and a specific `aria-label` per document.
 
 ## Testing And Screenshots
 
@@ -72,11 +96,16 @@ Covered flows:
 - Desktop settings navigation across grouped sections
 - Typed-confirmation gating for account deactivation
 - Mobile visibility of the settings section navigation
+- Unit coverage in `settings-page-shell.test.tsx` for statements tab routing, downloads, and the empty state
 
 Generated screenshots:
 
 - `design/screenshots/settings-desktop.png`
 - `design/screenshots/settings-mobile.png`
+
+The statements change is a settings-tab addition only. Capture updated
+screenshots when the visual regression pass is run for the broader settings
+surface.
 
 ## Notes
 


### PR DESCRIPTION
Closes #742

## Summary
- Added a new Settings `Statements` tab routed through `SettingsPageShell`.
- Added `TaxDocumentsSection` with available statement/tax-summary rows using `components/ui/table.tsx`.
- Added per-document accessible download links with visible text, hidden icons, and specific `aria-label`s.
- Added the no-documents path using `components/ui/empty-state.tsx`.
- Updated settings summary cards and tab keyboard tests for the new section.
- Updated `design/settings-ia.md` with IA, accessibility, responsive, and handoff notes.

## Testing
- Passed: `npm.cmd exec vitest -- run app/settings/preferences/components/settings-page-shell.test.tsx --coverage.enabled false`


## Accessibility / Responsive Notes
- Uses semantic tabs, table headers, keyboard-focusable download links, and `aria-label`s per document.
- Empty state announces with the shared `role="status"` / polite live region.
- Table uses the shared horizontal overflow wrapper for small screens.
- Styling follows existing zinc/white/dark-mode settings tokens for WCAG-conscious contrast.
- Documented expected validation at sm 640, md 768, lg 1024, and xl 1280 in `design/settings-ia.md`.

