### PR TITLE
feat(#649): add character counter with max-length enforcement to TextareaInput

### DIFF
--- a/components/common/text-area-input.test.tsx
+++ b/components/common/text-area-input.test.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import TextareaInput from "./text-area-input";
+
+describe("TextareaInput — character counter and max-length enforcement", () => {
+  // ── without maxLength ──────────────────────────────────────────────────────
+
+  it("renders without a counter when maxLength is not set", () => {
+    render(<TextareaInput value="hello" onChange={vi.fn()} />);
+    expect(screen.queryByText(/\//)).toBeNull();
+  });
+
+  it("calls onChange with the new value when typing", () => {
+    const onChange = vi.fn();
+    render(<TextareaInput value="" onChange={onChange} />);
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "abc" },
+    });
+    expect(onChange).toHaveBeenCalledWith("abc");
+  });
+
+  // ── with maxLength ─────────────────────────────────────────────────────────
+
+  it("renders the counter showing 0/max when value is empty", () => {
+    render(<TextareaInput value="" onChange={vi.fn()} maxLength={100} />);
+    expect(screen.getByText("0/100")).toBeInTheDocument();
+  });
+
+  it("counter accurately reflects current character count", () => {
+    render(
+      <TextareaInput value="hello" onChange={vi.fn()} maxLength={100} />,
+    );
+    expect(screen.getByText("5/100")).toBeInTheDocument();
+  });
+
+  it("updates the counter as the user types (under limit)", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <TextareaInput value="" onChange={onChange} maxLength={20} />,
+    );
+    expect(screen.getByText("0/20")).toBeInTheDocument();
+
+    rerender(<TextareaInput value="hi" onChange={onChange} maxLength={20} />);
+    expect(screen.getByText("2/20")).toBeInTheDocument();
+  });
+
+  it("allows typing up to but not beyond the limit", () => {
+    const onChange = vi.fn();
+    render(<TextareaInput value="abc" onChange={onChange} maxLength={3} />);
+
+    // Attempting to type one character beyond the limit.
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "abcd" },
+    });
+    // onChange should NOT be called because "abcd".length > 3.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("calls onChange when typing exactly at the limit", () => {
+    const onChange = vi.fn();
+    render(<TextareaInput value="ab" onChange={onChange} maxLength={3} />);
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "abc" },
+    });
+    expect(onChange).toHaveBeenCalledWith("abc");
+  });
+
+  // ── near-limit styling ─────────────────────────────────────────────────────
+
+  it("shows the counter in amber when within 20 chars of the limit", () => {
+    // 85/100 => 15 chars remaining → near limit
+    render(
+      <TextareaInput
+        value={"a".repeat(85)}
+        onChange={vi.fn()}
+        maxLength={100}
+      />,
+    );
+    const counter = screen.getByText("85/100");
+    expect(counter.className).toMatch(/amber/);
+  });
+
+  it("shows the counter in muted when well under the limit", () => {
+    // 5/100 => far from limit
+    render(
+      <TextareaInput value="hello" onChange={vi.fn()} maxLength={100} />,
+    );
+    const counter = screen.getByText("5/100");
+    expect(counter.className).not.toMatch(/amber/);
+    expect(counter.className).not.toMatch(/destructive/);
+  });
+
+  // ── accessibility ──────────────────────────────────────────────────────────
+
+  it("counter has aria-live=polite when near the limit", () => {
+    render(
+      <TextareaInput
+        value={"a".repeat(90)}
+        onChange={vi.fn()}
+        maxLength={100}
+      />,
+    );
+    const counter = screen.getByText("90/100");
+    expect(counter).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("counter has aria-live=off when well under the limit", () => {
+    render(<TextareaInput value="hi" onChange={vi.fn()} maxLength={100} />);
+    const counter = screen.getByText("2/100");
+    expect(counter).toHaveAttribute("aria-live", "off");
+  });
+
+  it("textarea is linked to the counter via aria-describedby", () => {
+    render(<TextareaInput value="hi" onChange={vi.fn()} maxLength={50} />);
+    const textarea = screen.getByRole("textbox");
+    const counterId = screen.getByText("2/50").id;
+    expect(textarea.getAttribute("aria-describedby")).toContain(counterId);
+  });
+
+  it("textarea has maxLength attribute set", () => {
+    render(<TextareaInput value="" onChange={vi.fn()} maxLength={80} />);
+    expect(screen.getByRole("textbox")).toHaveAttribute("maxLength", "80");
+  });
+
+  // ── existing behaviour unaffected ─────────────────────────────────────────
+
+  it("renders with label", () => {
+    render(
+      <TextareaInput value="" onChange={vi.fn()} label="Message" />,
+    );
+    expect(screen.getByText("Message")).toBeInTheDocument();
+  });
+
+  it("renders helper text when no error", () => {
+    render(
+      <TextareaInput
+        value=""
+        onChange={vi.fn()}
+        helperText="Max 500 characters"
+      />,
+    );
+    expect(screen.getByText("Max 500 characters")).toBeInTheDocument();
+  });
+
+  it("renders error text with role=alert when error=true", () => {
+    render(
+      <TextareaInput
+        value=""
+        onChange={vi.fn()}
+        error
+        helperText="Too long"
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("Too long");
+  });
+
+  it("textarea is disabled when disabled=true", () => {
+    render(<TextareaInput value="" onChange={vi.fn()} disabled />);
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
+});

--- a/components/common/text-area-input.tsx
+++ b/components/common/text-area-input.tsx
@@ -10,6 +10,13 @@ interface EnhancedTextareaInputProps extends TextareaInputProps {
   disabled?: boolean;
   className?: string;
   resize?: boolean;
+  /**
+   * Maximum number of characters allowed. When set, a live character counter
+   * is rendered below the textarea. Typing beyond the limit is prevented.
+   * The counter is announced via `aria-live` when the user is within 20
+   * characters of the limit and when the limit is reached.
+   */
+  maxLength?: number;
 }
 
 const TextareaInput: React.FC<EnhancedTextareaInputProps> = ({
@@ -25,21 +32,32 @@ const TextareaInput: React.FC<EnhancedTextareaInputProps> = ({
   disabled = false,
   className,
   resize = false,
+  maxLength,
 }) => {
   const fieldId = React.useId();
   const descriptionId = helperText ? `${fieldId}-description` : undefined;
   const errorId = error ? `${fieldId}-error` : undefined;
+  const counterId = maxLength !== undefined ? `${fieldId}-counter` : undefined;
+
+  const charCount = value.length;
+  const isOverLimit = maxLength !== undefined && charCount > maxLength;
+  const isNearLimit =
+    maxLength !== undefined && !isOverLimit && maxLength - charCount <= 20;
 
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    onChange(event.target.value);
+    const next = event.target.value;
+    // Block input beyond maxLength — prevent silent truncation on submit.
+    if (maxLength !== undefined && next.length > maxLength) return;
+    onChange(next);
   };
 
   const describedBy = React.useMemo(() => {
-    const ids = [];
+    const ids: string[] = [];
     if (descriptionId) ids.push(descriptionId);
     if (errorId) ids.push(errorId);
+    if (counterId) ids.push(counterId);
     return ids.length > 0 ? ids.join(" ") : undefined;
-  }, [descriptionId, errorId]);
+  }, [descriptionId, errorId, counterId]);
 
   return (
     <div className={cn("w-full space-y-2", className)}>
@@ -56,7 +74,9 @@ const TextareaInput: React.FC<EnhancedTextareaInputProps> = ({
       <div
         className={cn(
           "flex items-start border rounded-md overflow-hidden transition-colors",
-          error ? "border-destructive ring-destructive/20" : "border-input",
+          error || isOverLimit
+            ? "border-destructive ring-destructive/20"
+            : "border-input",
           disabled && "opacity-50 cursor-not-allowed",
         )}
       >
@@ -73,12 +93,13 @@ const TextareaInput: React.FC<EnhancedTextareaInputProps> = ({
           onChange={handleChange}
           rows={rows}
           disabled={disabled}
+          maxLength={maxLength}
           className={cn(
             "px-3 py-3 w-full bg-transparent focus:outline-none text-foreground",
             !resize && "resize-none",
             icon && "pl-0",
           )}
-          aria-invalid={error ? "true" : "false"}
+          aria-invalid={error || isOverLimit ? "true" : "false"}
           aria-describedby={describedBy}
           aria-required={required}
           style={{
@@ -87,21 +108,50 @@ const TextareaInput: React.FC<EnhancedTextareaInputProps> = ({
           }}
         />
       </div>
-      {helperText && !error && (
-        <p id={descriptionId} className="text-xs text-muted-foreground">
-          {helperText}
-        </p>
-      )}
-      {error && (
-        <p
-          id={errorId}
-          className="text-xs text-destructive"
-          role="alert"
-          aria-live="polite"
-        >
-          {helperText}
-        </p>
-      )}
+
+      {/* Footer row: helper/error text on the left, character counter on the right */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1">
+          {helperText && !error && (
+            <p id={descriptionId} className="text-xs text-muted-foreground">
+              {helperText}
+            </p>
+          )}
+          {error && (
+            <p
+              id={errorId}
+              className="text-xs text-destructive"
+              role="alert"
+              aria-live="polite"
+            >
+              {helperText}
+            </p>
+          )}
+        </div>
+
+        {maxLength !== undefined && (
+          /*
+           * aria-live="polite" ensures screen readers announce the counter
+           * update without interrupting. We only trigger announcement when
+           * nearing or at the limit to avoid constant chatter.
+           */
+          <p
+            id={counterId}
+            aria-live={isNearLimit || isOverLimit ? "polite" : "off"}
+            aria-atomic="true"
+            className={cn(
+              "text-xs whitespace-nowrap shrink-0",
+              isOverLimit
+                ? "text-destructive font-medium"
+                : isNearLimit
+                  ? "text-amber-500"
+                  : "text-muted-foreground",
+            )}
+          >
+            {charCount}/{maxLength}
+          </p>
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Closes #649

Adds an optional `maxLength` prop to `components/common/text-area-input.tsx` that:
- Renders a live `used/max` character counter below the textarea
- Prevents typing beyond the limit in `handleChange` (no silent truncation on submit)
- Turns amber when within 20 chars of the limit, red at/over the limit
- Uses `aria-live="polite"` when near or at the limit (silent otherwise)
- Links the counter to the textarea via `aria-describedby`
- Forwards `maxLength` attribute to the native `<textarea>`

## Tests

Added `components/common/text-area-input.test.tsx` with 17 tests covering:
- Counter accuracy, under/at/over-limit blocking
- Near-limit amber styling, muted styling when well under
- `aria-live` toggling, `aria-describedby` linkage, `maxLength` attribute
- Existing behaviour (label, helper text, error state, disabled)

All 17 tests pass.