### PR TITLE
UI/transactions table fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,13 @@ and debugging stay frictionless.
 
 We expect all new utility functions and business logic to have **minimum 95% test coverage**.
 
+### Testing Hydration Guards and Dynamic Imports
+
+When writing client-side hydration guards (`isMounted` patterns) or using `next/dynamic` for heavy components, ensure they are fully tested:
+- Use `renderToString` from `react-dom/server` to test the initial `isMounted=false` SSR state.
+- Test loading and skeleton states independently of the mount state (e.g., passing `isLoading=true`).
+- Ensure fallback skeletons use accessible markup (`aria-busy="true"`, `role="status"`).
+
 ### Test Commands
 
 - **Unit Tests (Vitest):**

--- a/components/analytics/client-analytics-view.test.tsx
+++ b/components/analytics/client-analytics-view.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { expect, test, describe, vi } from "vitest";
+import { axe } from "vitest-axe";
+import ClientAnalyticsView from "./client-analytics-view";
+
+vi.mock("next/dynamic", () => {
+  return {
+    default: () => {
+      const DynamicComponent = () => <div data-testid="analytics-view-mock">Analytics View</div>;
+      return DynamicComponent;
+    },
+  };
+});
+
+describe("ClientAnalyticsView", () => {
+  test("isMounted=false initial render matches the skeleton snapshot", () => {
+    // renderToString simulates the initial SSR pass where useEffect hasn't fired
+    const html = renderToString(<ClientAnalyticsView isLoading={false} />);
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toMatchSnapshot();
+  });
+
+  test("renders skeleton when isLoading is true independent of mount state", () => {
+    render(<ClientAnalyticsView isLoading={true} />);
+    expect(screen.getByRole("status", { busy: true })).toBeInTheDocument();
+    expect(screen.getByText("Loading analytics views chart...")).toBeInTheDocument();
+    expect(screen.queryByTestId("analytics-view-mock")).not.toBeInTheDocument();
+  });
+
+  test("renders skeleton with notifications layout when isLoading=true and showNotifications=true", () => {
+    render(<ClientAnalyticsView isLoading={true} showNotifications={true} />);
+    expect(screen.getByRole("status", { busy: true })).toBeInTheDocument();
+    expect(screen.getByText("Loading analytics...")).toBeInTheDocument();
+  });
+
+  test("renders actual component when isLoading is false and component is mounted", () => {
+    render(<ClientAnalyticsView isLoading={false} />);
+    // In @testing-library/react, useEffect runs synchronously so isMounted flips to true
+    expect(screen.getByTestId("analytics-view-mock")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  test("is accessible when loading", async () => {
+    const { container } = render(<ClientAnalyticsView isLoading={true} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("is accessible when mounted", async () => {
+    const { container } = render(<ClientAnalyticsView isLoading={false} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/components/transactions/transactions-table.test.tsx
+++ b/components/transactions/transactions-table.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TransactionsTable } from "./transactions-table";
+
+const mockTransactions = [
+  {
+    id: "1",
+    type: "Deposit",
+    txId: "TX123",
+    address: "0x1234567890abcdef1234567890abcdef1234567890abcdef", // Very long address
+    date: "2023-10-27",
+    time: "10:00 AM",
+    token: "ETH",
+    amount: "+1000000000000000000000000000.00", // Very long amount
+    status: "Completed" as const,
+    tokenIcon: "/icons/eth.svg",
+    statusColor: "success" as const,
+  },
+];
+
+describe("TransactionsTable", () => {
+  it("renders transactions correctly", () => {
+    render(<TransactionsTable transactions={mockTransactions} />);
+    expect(screen.getByText("Deposit")).toBeInTheDocument();
+    expect(screen.getByText("#1")).toBeInTheDocument();
+  });
+
+  it("applies tooltips for long address and amount values", () => {
+    render(<TransactionsTable transactions={mockTransactions} />);
+    
+    // Desktop View checks
+    const addressElements = screen.getAllByTitle("0x1234567890abcdef1234567890abcdef1234567890abcdef");
+    expect(addressElements.length).toBeGreaterThan(0);
+    expect(addressElements[0]).toHaveAttribute("tabIndex", "0");
+    expect(addressElements[0]).toHaveClass("truncate");
+
+    const amountElements = screen.getAllByTitle("+1000000000000000000000000000.00");
+    expect(amountElements.length).toBeGreaterThan(0);
+    expect(amountElements[0]).toHaveAttribute("tabIndex", "0");
+    expect(amountElements[0]).toHaveClass("truncate");
+  });
+});

--- a/components/transactions/transactions-table.tsx
+++ b/components/transactions/transactions-table.tsx
@@ -121,8 +121,14 @@ export function TransactionsTable({
                     <span className="text-[#D7E0EF]">{transaction.type}</span>
                     <p>#{transaction.id}</p>
                   </TableCell>
-                  <TableCell className="border border-[#2D2D2D] py-4 px-6">
-                    {transaction.address}
+                  <TableCell className="border border-[#2D2D2D] py-4 px-6 max-w-[200px]">
+                    <span
+                      className="block truncate cursor-help focus:outline-none focus:ring-2 focus:ring-[#D7E0EF] rounded px-1 -ml-1"
+                      title={transaction.address}
+                      tabIndex={0}
+                    >
+                      {transaction.address}
+                    </span>
                   </TableCell>
                   <TableCell className="border border-[#2D2D2D] py-4 px-6">
                     <time dateTime={transaction.date}>
@@ -138,8 +144,14 @@ export function TransactionsTable({
                     />
                     <span>{transaction.token}</span>
                   </TableCell>
-                  <TableCell className="border border-[#2D2D2D] py-4 px-6 ">
-                    {transaction.amount}
+                  <TableCell className="border border-[#2D2D2D] py-4 px-6 max-w-[150px]">
+                    <span
+                      className="block truncate cursor-help focus:outline-none focus:ring-2 focus:ring-[#D7E0EF] rounded px-1 -ml-1"
+                      title={transaction.amount}
+                      tabIndex={0}
+                    >
+                      {transaction.amount}
+                    </span>
                   </TableCell>
                   <TableCell className="py-4 px-6">
                     <Badge
@@ -198,7 +210,11 @@ export function TransactionsTable({
                   <p className="font-medium">
                     {transaction.type} #{transaction.id}
                   </p>
-                  <p className="text-sm text-muted-foreground">
+                  <p 
+                    className="text-sm text-muted-foreground block truncate max-w-[180px] cursor-help focus:outline-none focus:ring-2 focus:ring-[#D7E0EF] rounded px-1 -ml-1"
+                    title={transaction.address}
+                    tabIndex={0}
+                  >
                     {transaction.address}
                   </p>
                 </div>
@@ -225,14 +241,16 @@ export function TransactionsTable({
                   <p className="text-sm text-muted-foreground">Token</p>
                   <p>{transaction.token}</p>
                 </div>
-                <div>
+                <div className="min-w-0">
                   <p className="text-sm text-muted-foreground">Amount</p>
                   <p
-                    className={
+                    className={`block truncate max-w-[120px] cursor-help focus:outline-none focus:ring-2 focus:ring-[#D7E0EF] rounded px-1 -ml-1 ${
                       transaction.amount.startsWith("+")
                         ? "text-green-500"
                         : "text-red-500"
-                    }
+                    }`}
+                    title={transaction.amount}
+                    tabIndex={0}
                   >
                     {transaction.amount}
                   </p>

--- a/design/a11y-checklist.md
+++ b/design/a11y-checklist.md
@@ -267,3 +267,8 @@
 | `components/transactions/transactions-table.tsx`  | `<caption>`, `scope="col"`, aria-label on badges, aria-hidden on icons, `<time>` element |
 | `components/common/side-bar.tsx`                  | aria-label, aria-expanded, aria-hidden icons, focus rings                                |
 | `design/a11y-checklist.md`                        | This document                                                                            |
+
+### Transaction Table Tooltips
+- **Contrast**: Focus ring (ocus:ring-[#D7E0EF]) provides clear 3:1 contrast against dark background.
+- **Keyboard Nav**: 	abIndex={0} makes truncated addresses and amounts focusable, revealing the 	itle tooltip.
+- **ARIA**: Screen readers read the full content within the span natively, while sighted users see tooltips on hover/focus.


### PR DESCRIPTION
Closes #736 

## Description
Fixes an issue where long memo text (addresses) and unusually large formatted amounts in the TransactionsTable wrapped awkwardly or were clipped, breaking row height consistency and making the full values inaccessible.

## Changes Made
- **Applied Consistent Truncation:** Added truncate, max-w-*, and block styling to ensure cell heights remain consistent and uniform across both desktop and mobile views.
- **Added Accessible Tooltips:** Added a native title attribute to the truncated values, revealing the full text on hover.
- **Keyboard Navigation (WCAG 2.1 AA):** Added tabIndex={0} and distinct focus:ring states to ensure the truncated fields are focusable, making the tooltip accessible via keyboard navigation.
- **Test Coverage:** Added components/transactions/transactions-table.test.tsx to verify the presence and properties of the tooltip fallbacks on the truncated fields.
- **Accessibility Documentation:** Documented the new contrast, keyboard navigation, and ARIA updates in design/a11y-checklist.md.