### PR TITLE
perf: add lazy loading and priority hints to feature images

### DIFF
--- a/components/landing/feature-card.tsx
+++ b/components/landing/feature-card.tsx
@@ -2,10 +2,11 @@ import Image from "next/image";
 import { FC } from "react";
 import { FeatureCardProps } from "@/types/landing";
 
-export const FeatureCard: FC<FeatureCardProps> = ({
+export const FeatureCard: FC<FeatureCardProps & { priority?: boolean }> = ({
   imageSrc,
   title,
   description,
+  priority = false,
 }) => {
   return (
     <div
@@ -33,6 +34,8 @@ export const FeatureCard: FC<FeatureCardProps> = ({
         width={400}
         height={200}
         className="rounded-md object-cover h-[200px] w-full"
+        loading={priority ? undefined : "lazy"}
+        priority={priority}
       />
       <h3 className="text-xl font-semibold text-black mt-4">{title}</h3>
       <p className="text-sm text-black mt-2 flex-grow">{description}</p>

--- a/components/landing/key-features.tsx
+++ b/components/landing/key-features.tsx
@@ -42,8 +42,8 @@ export const KeyFeatures = () => {
           security.
         </p>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 justify-center items-start mx-auto">
-          {features.map((feature) => (
-            <FeatureCard key={feature.title} {...feature} />
+          {features.map((feature, index) => (
+            <FeatureCard key={feature.title} {...feature} priority={index === 0} />
           ))}
         </div>
       </div>


### PR DESCRIPTION
Closes #694

## Note on scope
The issue names `components/landing/features-grid.tsx`, but that file
renders lucide icons only — no raw `<img>` tags or references to
`feature1.svg`–`feature4.svg`. Those SVGs are actually rendered by
`components/landing/key-features.tsx` → `components/landing/feature-card.tsx`,
which already uses `next/image` with explicit `width`/`height` (400×200).
Scoped this PR to the real location of the described problem.

## Changes
- `feature-card.tsx`: accepts an optional `priority` prop; when false
  (default), the image gets `loading="lazy"`; when true, `priority`
  is passed instead (Next.js disallows combining `loading` with
  `priority`)
- `key-features.tsx`: passes `priority={true}` only to the first card
  in the grid so it preloads, the remaining 3 lazy-load

## Testing
`npx tsc --noEmit` — no new errors from these 2 files (44 pre-existing
errors across 8 unrelated files already on `main`, untouched here)

## Not done in this PR
- Lighthouse CLS before/after measurement — needs a running dev server
  and browser session I don't have in this environment; happy to run
  it if given access, or a maintainer can capture it in review
- WCAG audit / breakpoint testing — existing `alt={title}` and
  responsive grid classes were already in place pre-PR; no new a11y
  surface introduced by this change