### PR TITLE
fix(#646): trap focus in mobile menu overlay of landing navbar

### DIFF
--- a/components/landing/navbar.test.tsx
+++ b/components/landing/navbar.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Tests for the focus-trap in the mobile menu overlay of
+ * components/landing/navbar.tsx.
+ *
+ * Covers:
+ * - Drawer opens / closes via the toggle button.
+ * - While the drawer is open, Tab / Shift+Tab cycles only within it.
+ * - Escape closes the drawer and returns focus to the trigger button.
+ * - Focus returns to the trigger button when the drawer closes.
+ */
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Navbar from "./navbar";
+
+// ── Mock external dependencies ────────────────────────────────────────────────
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    <img {...props} />
+  ),
+}));
+
+vi.mock("@/context/theme-context", () => ({
+  useTheme: () => ({
+    theme: "light",
+    resolvedTheme: "light",
+    toggleTheme: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/common/network-switcher", () => ({
+  default: () => <div data-testid="network-switcher" />,
+}));
+
+vi.mock("@/utils/safeStorage", () => ({
+  safeStorage: {
+    getItem: vi.fn(() => null),
+    setItem: vi.fn(),
+  },
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getMenuButton() {
+  return screen.getByRole("button", { name: /open menu|close menu/i });
+}
+
+function openMenu() {
+  fireEvent.click(getMenuButton());
+}
+
+function getDrawer() {
+  return screen.queryByRole("dialog", { name: /mobile navigation menu/i });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("Navbar mobile menu focus trap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the toggle button and the drawer is initially closed", () => {
+    render(<Navbar />);
+    expect(getMenuButton()).toBeInTheDocument();
+    expect(getDrawer()).toBeNull();
+  });
+
+  it("opens the drawer when the toggle button is clicked", () => {
+    render(<Navbar />);
+    openMenu();
+    expect(getDrawer()).toBeInTheDocument();
+    expect(getMenuButton()).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("closes the drawer when the toggle button is clicked again", () => {
+    render(<Navbar />);
+    openMenu();
+    fireEvent.click(getMenuButton()); // close
+    expect(getDrawer()).toBeNull();
+    expect(getMenuButton()).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("closes the drawer when Escape is pressed", () => {
+    render(<Navbar />);
+    openMenu();
+    expect(getDrawer()).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(getDrawer()).toBeNull();
+  });
+
+  it("drawer has aria-modal=true while open", () => {
+    render(<Navbar />);
+    openMenu();
+    const drawer = getDrawer();
+    expect(drawer).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("Tab wraps from last focusable element to first inside the drawer", () => {
+    render(<Navbar />);
+    openMenu();
+
+    const drawer = getDrawer()!;
+    const focusableEls = Array.from(
+      drawer.querySelectorAll<HTMLElement>(
+        "a[href], button:not([disabled]), [tabindex]:not([tabindex='-1'])",
+      ),
+    );
+
+    expect(focusableEls.length).toBeGreaterThan(1);
+
+    const last = focusableEls[focusableEls.length - 1];
+    const first = focusableEls[0];
+
+    act(() => last.focus());
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: false });
+
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("Shift+Tab wraps from first focusable element to last inside the drawer", () => {
+    render(<Navbar />);
+    openMenu();
+
+    const drawer = getDrawer()!;
+    const focusableEls = Array.from(
+      drawer.querySelectorAll<HTMLElement>(
+        "a[href], button:not([disabled]), [tabindex]:not([tabindex='-1'])",
+      ),
+    );
+
+    const first = focusableEls[0];
+    const last = focusableEls[focusableEls.length - 1];
+
+    act(() => first.focus());
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+
+    expect(document.activeElement).toBe(last);
+  });
+
+  it("focus returns to the trigger button after closing via Escape", () => {
+    render(<Navbar />);
+    const btn = getMenuButton();
+
+    openMenu();
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it("focus returns to the trigger button after closing via button click", () => {
+    render(<Navbar />);
+    const btn = getMenuButton();
+
+    openMenu();
+    fireEvent.click(btn); // close
+
+    expect(document.activeElement).toBe(btn);
+  });
+});

--- a/components/landing/navbar.tsx
+++ b/components/landing/navbar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
@@ -17,11 +17,26 @@ const navLinks = [
 ];
 const MOBILE_NAV_STORAGE_KEY = "landingMobileNavOpen";
 
+/** CSS selector that matches all natively focusable elements. */
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
 export default function Navbar() {
   const pathname = usePathname() || "/";
   const { theme, resolvedTheme, toggleTheme } = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [hasHydratedMobileNav, setHasHydratedMobileNav] = useState(false);
+
+  /** Ref on the hamburger/close button — focus returns here when drawer closes. */
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  /** Ref on the mobile drawer — used to query focusable children. */
+  const drawerRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     const storedState = safeStorage.getItem(MOBILE_NAV_STORAGE_KEY);
@@ -34,9 +49,63 @@ export default function Navbar() {
   useEffect(() => {
     // Avoid replacing a saved preference with the SSR-safe default before it restores.
     if (!hasHydratedMobileNav) return;
-
     safeStorage.setItem(MOBILE_NAV_STORAGE_KEY, mobileOpen.toString());
   }, [hasHydratedMobileNav, mobileOpen]);
+
+  // ── Focus trap ─────────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!mobileOpen) return;
+
+    // Move initial focus into the drawer on open.
+    const drawer = drawerRef.current;
+    if (drawer) {
+      const firstFocusable = drawer.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+      firstFocusable?.focus();
+    }
+
+    /** Trap Tab/Shift+Tab within the drawer; close on Escape. */
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setMobileOpen(false);
+        return;
+      }
+
+      if (e.key !== "Tab" || !drawer) return;
+
+      const focusableEls = Array.from(
+        drawer.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => !el.closest("[hidden]") && el.tabIndex !== -1);
+
+      if (focusableEls.length === 0) return;
+
+      const first = focusableEls[0];
+      const last = focusableEls[focusableEls.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [mobileOpen]);
+
+  // Return focus to the trigger button when the drawer closes.
+  const prevMobileOpen = useRef(mobileOpen);
+  useEffect(() => {
+    if (prevMobileOpen.current && !mobileOpen) {
+      menuButtonRef.current?.focus();
+    }
+    prevMobileOpen.current = mobileOpen;
+  }, [mobileOpen]);
 
   const handleConnect = () => {
     // TODO: integrate wallet modal/connector here.
@@ -144,6 +213,7 @@ export default function Navbar() {
               </button>
 
               <button
+                ref={menuButtonRef}
                 className="xl:hidden p-2 rounded-md hover:bg-gray-100 dark:hover:bg-white/5"
                 aria-label={mobileOpen ? "Close menu" : "Open menu"}
                 aria-expanded={mobileOpen}
@@ -193,8 +263,11 @@ export default function Navbar() {
       {mobileOpen && (
         <nav
           id="mobile-nav"
+          ref={drawerRef}
           className="xl:hidden absolute left-0 right-0 top-full z-40 mt-2"
           aria-label="Mobile navigation menu"
+          aria-modal="true"
+          role="dialog"
         >
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="bg-white dark:bg-[#0b0b0b] border-b border-[#E4E4E7] dark:border-[#27272A] rounded-b-2xl py-4 space-y-2 px-4">


### PR DESCRIPTION
## Summary

Resolves #646.

Implements a focus trap in the mobile menu overlay of `components/landing/navbar.tsx`.

## Changes

- Added `menuButtonRef` on the hamburger/close toggle button so focus returns to it when the drawer closes.
- Added `drawerRef` on the mobile nav `<nav>` element.
- On **open**: moves initial focus to the first focusable element inside the drawer and attaches a `document` keydown listener that:
  - Traps **Tab** / **Shift+Tab** within the drawer's focusable elements.
  - Closes the drawer on **Escape**.
- On **close**: returns focus to the trigger button via a `prevMobileOpen` ref.
- Added `aria-modal="true"` and `role="dialog"` to the drawer for correct assistive-technology semantics.

## Tests

Added `components/landing/navbar.test.tsx` covering:

- Drawer opens/closes via the toggle button
- `aria-modal` attribute
- Tab wraps from last → first focusable element
- Shift+Tab wraps from first → last focusable element
- Escape closes and returns focus to the trigger button
- Button click closes and returns focus to the trigger button

All 9 tests pass.

## Tested

- `npm run test -- components/landing/navbar.test.tsx` — 9/9 pass