### PR TITLE
feat: add keyboard navigation to the notification panel list

### DIFF
--- a/components/common/notification-panel.test.tsx
+++ b/components/common/notification-panel.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
 import NotificationPanel from "./notification-panel";
 import { NotificationItem } from "@/types/notification-item";
@@ -17,23 +17,25 @@ describe("NotificationPanel", () => {
     render(<NotificationPanel notifications={[]} isLoading />);
 
     expect(screen.queryByText("You're all caught up")).not.toBeInTheDocument();
-    expect(screen.queryByRole("region")).not.toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
   it("renders the empty state when notifications is empty and not loading", () => {
     render(<NotificationPanel notifications={[]} />);
 
     expect(screen.getByText("You're all caught up")).toBeInTheDocument();
-    expect(screen.queryByRole("region")).not.toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
-  it("renders a single notification inside the accessible live region", () => {
+  it("renders a single notification inside the accessible listbox", () => {
     const notifications = buildNotifications(1);
     render(<NotificationPanel notifications={notifications} />);
 
     expect(screen.queryByText("You're all caught up")).not.toBeInTheDocument();
-    const region = screen.getByRole("region", { name: "Notifications list" });
-    expect(region).toHaveAttribute("aria-live", "polite");
+    const listbox = screen.getByRole("listbox", {
+      name: "Notifications list",
+    });
+    expect(listbox).toBeInTheDocument();
     expect(screen.getByText("Title 0")).toBeInTheDocument();
     expect(screen.getByText("Message 0")).toBeInTheDocument();
   });
@@ -110,5 +112,217 @@ describe("NotificationPanel", () => {
 
     const unreadDots = container.querySelectorAll(".bg-\\[\\#EB6945\\]");
     expect(unreadDots).toHaveLength(1);
+  });
+
+  // ── Keyboard navigation ────────────────────────────────────────────
+
+  describe("keyboard navigation", () => {
+    it("applies listbox role and aria-label to the notification list", () => {
+      render(<NotificationPanel notifications={buildNotifications(3)} />);
+
+      expect(
+        screen.getByRole("listbox", { name: "Notifications list" }),
+      ).toBeInTheDocument();
+    });
+
+    it("gives tabIndex={0} to the first item and tabIndex={-1} to others by default", () => {
+      render(<NotificationPanel notifications={buildNotifications(3)} />);
+      const options = screen.getAllByRole("option");
+
+      expect(options[0]).toHaveAttribute("tabIndex", "0");
+      expect(options[1]).toHaveAttribute("tabIndex", "-1");
+      expect(options[2]).toHaveAttribute("tabIndex", "-1");
+    });
+
+    it("updates tabIndex when ArrowDown is pressed", () => {
+      render(<NotificationPanel notifications={buildNotifications(3)} />);
+      const listbox = screen.getByRole("listbox");
+
+      fireEvent.keyDown(listbox, { key: "ArrowDown" });
+
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("tabIndex", "-1");
+      expect(options[1]).toHaveAttribute("tabIndex", "0");
+      expect(options[2]).toHaveAttribute("tabIndex", "-1");
+    });
+
+    it("moves focus forward with ArrowDown and backward with ArrowUp", () => {
+      render(<NotificationPanel notifications={buildNotifications(3)} />);
+      const listbox = screen.getByRole("listbox");
+      const options = screen.getAllByRole("option");
+
+      fireEvent.keyDown(listbox, { key: "ArrowDown" });
+      expect(options[1]).toHaveAttribute("tabIndex", "0");
+
+      fireEvent.keyDown(listbox, { key: "ArrowUp" });
+      expect(options[0]).toHaveAttribute("tabIndex", "0");
+    });
+
+    it("wraps from last to first on ArrowDown", () => {
+      render(<NotificationPanel notifications={buildNotifications(3)} />);
+      const listbox = screen.getByRole("listbox");
+      const options = screen.getAllByRole("option");
+
+      fireEvent.keyDown(listbox, { key: "End" });
+      expect(options[2]).toHaveAttribute("tabIndex", "0");
+
+      fireEvent.keyDown(listbox, { key: "ArrowDown" });
+      expect(options[0]).toHaveAttribute("tabIndex", "0");
+    });
+
+    it("wraps from first to last on ArrowUp", () => {
+      render(<NotificationPanel notifications={buildNotifications(3)} />);
+      const listbox = screen.getByRole("listbox");
+      const options = screen.getAllByRole("option");
+
+      fireEvent.keyDown(listbox, { key: "ArrowUp" });
+      expect(options[2]).toHaveAttribute("tabIndex", "0");
+    });
+
+    it("jumps to first item on Home", () => {
+      render(<NotificationPanel notifications={buildNotifications(3)} />);
+      const listbox = screen.getByRole("listbox");
+      const options = screen.getAllByRole("option");
+
+      fireEvent.keyDown(listbox, { key: "ArrowDown" });
+      fireEvent.keyDown(listbox, { key: "ArrowDown" });
+      fireEvent.keyDown(listbox, { key: "Home" });
+      expect(options[0]).toHaveAttribute("tabIndex", "0");
+    });
+
+    it("jumps to last item on End", () => {
+      render(<NotificationPanel notifications={buildNotifications(3)} />);
+      const listbox = screen.getByRole("listbox");
+      const options = screen.getAllByRole("option");
+
+      fireEvent.keyDown(listbox, { key: "End" });
+      expect(options[2]).toHaveAttribute("tabIndex", "0");
+    });
+
+    it("sets aria-selected on the focused item", () => {
+      render(<NotificationPanel notifications={buildNotifications(3)} />);
+      const options = screen.getAllByRole("option");
+
+      expect(options[0]).toHaveAttribute("aria-selected", "true");
+      expect(options[1]).toHaveAttribute("aria-selected", "false");
+      expect(options[2]).toHaveAttribute("aria-selected", "false");
+
+      fireEvent.keyDown(screen.getByRole("listbox"), { key: "ArrowDown" });
+
+      expect(options[0]).toHaveAttribute("aria-selected", "false");
+      expect(options[1]).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("calls onNotificationClick when Enter is pressed on a focused item", () => {
+      const onNotificationClick = vi.fn();
+      const notifications = buildNotifications(3);
+      render(
+        <NotificationPanel
+          notifications={notifications}
+          onNotificationClick={onNotificationClick}
+        />,
+      );
+
+      fireEvent.keyDown(screen.getAllByRole("option")[0], { key: "Enter" });
+      expect(onNotificationClick).toHaveBeenCalledWith(notifications[0]);
+    });
+
+    it("calls onNotificationClick when Space is pressed on a focused item", () => {
+      const onNotificationClick = vi.fn();
+      const notifications = buildNotifications(3);
+      render(
+        <NotificationPanel
+          notifications={notifications}
+          onNotificationClick={onNotificationClick}
+        />,
+      );
+
+      fireEvent.keyDown(screen.getAllByRole("option")[0], { key: " " });
+      expect(onNotificationClick).toHaveBeenCalledWith(notifications[0]);
+    });
+
+    it("calls onNotificationClick when an item is clicked", () => {
+      const onNotificationClick = vi.fn();
+      const notifications = buildNotifications(3);
+      render(
+        <NotificationPanel
+          notifications={notifications}
+          onNotificationClick={onNotificationClick}
+        />,
+      );
+
+      fireEvent.click(screen.getAllByRole("option")[1]);
+      expect(onNotificationClick).toHaveBeenCalledWith(notifications[1]);
+    });
+
+    it("calls onClose when Escape is pressed", () => {
+      const onClose = vi.fn();
+      render(
+        <NotificationPanel
+          notifications={buildNotifications(3)}
+          onClose={onClose}
+        />,
+      );
+
+      fireEvent.keyDown(screen.getByRole("listbox"), { key: "Escape" });
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it("does not call onNotificationClick when key is not Enter or Space", () => {
+      const onNotificationClick = vi.fn();
+      render(
+        <NotificationPanel
+          notifications={buildNotifications(3)}
+          onNotificationClick={onNotificationClick}
+        />,
+      );
+
+      fireEvent.keyDown(screen.getAllByRole("option")[0], { key: "a" });
+      expect(onNotificationClick).not.toHaveBeenCalled();
+    });
+
+    it("resets focusedIndex when notifications change", () => {
+      const notifications = buildNotifications(3);
+      const { rerender } = render(
+        <NotificationPanel notifications={notifications} />,
+      );
+      const listbox = screen.getByRole("listbox");
+
+      fireEvent.keyDown(listbox, { key: "End" });
+      expect(screen.getAllByRole("option")[2]).toHaveAttribute(
+        "tabIndex",
+        "0",
+      );
+
+      rerender(
+        <NotificationPanel notifications={buildNotifications(2)} />,
+      );
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("tabIndex", "0");
+      expect(options[1]).toHaveAttribute("tabIndex", "-1");
+    });
+
+    it("does not render listbox role when empty", () => {
+      render(<NotificationPanel notifications={[]} />);
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("does not render listbox role when loading", () => {
+      render(<NotificationPanel notifications={[]} isLoading />);
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("renders each option with role='option'", () => {
+      render(<NotificationPanel notifications={buildNotifications(3)} />);
+      expect(screen.getAllByRole("option")).toHaveLength(3);
+    });
+
+    it("applies cursor-pointer and focus-visible ring to options", () => {
+      render(<NotificationPanel notifications={buildNotifications(1)} />);
+      const option = screen.getByRole("option");
+
+      expect(option.className).toContain("cursor-pointer");
+      expect(option.className).toContain("focus-visible:ring-2");
+    });
   });
 });

--- a/components/common/notification-panel.tsx
+++ b/components/common/notification-panel.tsx
@@ -1,12 +1,15 @@
-import React from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { BellIcon, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { IconBell } from "@/components/icons/bell-fill-icon";
 import { NotificationProps } from "@/types/ui";
+import { NotificationItem } from "@/types/notification-item";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface NotificationPanelProps extends NotificationProps {
   isLoading?: boolean;
+  onNotificationClick?: (notification: NotificationItem) => void;
+  onClose?: () => void;
 }
 
 /**
@@ -56,18 +59,106 @@ function NotificationPanelEmptyState() {
  *
  * Renders a loading skeleton while `isLoading` is true, an accessible
  * empty state when `notifications` is empty, and otherwise the list of
- * notifications keyed by their stable `id` (never array index). The list
- * region is announced via `aria-live="polite"` so newly arriving
- * notifications are picked up by assistive technology.
+ * notifications keyed by their stable `id` (never array index).
+ *
+ * The notification list implements the **listbox** keyboard pattern
+ * (WAI-ARIA roving tabindex):
+ *   - Arrow Up / Arrow Down  → move focus between items (wraps)
+ *   - Home / End             → jump to first / last item
+ *   - Enter / Space          → activate the focused notification
+ *   - Escape                 → close the panel and return focus to the
+ *                              bell trigger button
  *
  * Notification `title` and `message` are rendered as plain text children,
  * never via `dangerouslySetInnerHTML`, so they cannot inject markup.
+ *
+ * Props
+ * -----
+ * - `onNotificationClick` – callback invoked when a notification is
+ *   activated via click, Enter, or Space.
+ * - `onClose` – callback invoked when Escape is pressed, after focus
+ *   has been returned to the bell trigger button.
  */
 const NotificationPanel = ({
   className: _className,
   notifications,
   isLoading = false,
+  onNotificationClick,
+  onClose,
 }: NotificationPanelProps) => {
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  useEffect(() => {
+    itemRefs.current = itemRefs.current.slice(0, notifications.length);
+    setFocusedIndex(0);
+  }, [notifications.length]);
+
+  const focusItem = useCallback((index: number) => {
+    const item = itemRefs.current[index];
+    if (item) {
+      item.focus();
+      setFocusedIndex(index);
+    }
+  }, []);
+
+  const handleListKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      switch (e.key) {
+        case "ArrowDown": {
+          e.preventDefault();
+          const next =
+            focusedIndex < notifications.length - 1 ? focusedIndex + 1 : 0;
+          focusItem(next);
+          break;
+        }
+        case "ArrowUp": {
+          e.preventDefault();
+          const prev =
+            focusedIndex > 0 ? focusedIndex - 1 : notifications.length - 1;
+          focusItem(prev);
+          break;
+        }
+        case "Home": {
+          e.preventDefault();
+          if (notifications.length > 0) focusItem(0);
+          break;
+        }
+        case "End": {
+          e.preventDefault();
+          if (notifications.length > 0)
+            focusItem(notifications.length - 1);
+          break;
+        }
+        case "Escape": {
+          e.preventDefault();
+          const trigger =
+            containerRef.current?.querySelector<HTMLButtonElement>(
+              '[aria-label="Notifications"]',
+            );
+          trigger?.focus();
+          onClose?.();
+          break;
+        }
+      }
+    },
+    [focusedIndex, notifications.length, focusItem, onClose],
+  );
+
+  const handleItemKeyDown = useCallback(
+    (
+      e: React.KeyboardEvent<HTMLDivElement>,
+      notification: NotificationItem,
+    ) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onNotificationClick?.(notification);
+      }
+    },
+    [onNotificationClick],
+  );
+
   if (isLoading) {
     return (
       <div className="bg-[#0D0D0D80] bg-opacity-50 border border-[#2D2D2D] max-w-[400px] rounded-xl p-4 text-[#E5E5E5]">
@@ -98,22 +189,33 @@ const NotificationPanel = ({
   }
 
   return (
-    <div className="bg-[#0D0D0D80]  bg-opacity-50 border border-[#2D2D2D] max-w-[400px] rounded-xl  p-4 text-[#E5E5E5]">
+    <div
+      ref={containerRef}
+      className="bg-[#0D0D0D80] bg-opacity-50 border border-[#2D2D2D] max-w-[400px] rounded-xl p-4 text-[#E5E5E5]"
+    >
       <NotificationPanelHeader />
 
       {notifications.length === 0 ? (
         <NotificationPanelEmptyState />
       ) : (
         <div
-          role="region"
+          role="listbox"
           aria-label="Notifications list"
-          aria-live="polite"
           className="flex flex-col gap-4"
+          onKeyDown={handleListKeyDown}
         >
-          {notifications.map((notification) => (
+          {notifications.map((notification, index) => (
             <div
               key={notification.id}
-              className="bg-[#12121266] bg-opacity-40 border border-[#2D2D2D] rounded-lg p-3 px-5 flex justify-between items-center"
+              ref={(el) => {
+                itemRefs.current[index] = el;
+              }}
+              role="option"
+              aria-selected={focusedIndex === index}
+              tabIndex={focusedIndex === index ? 0 : -1}
+              className="bg-[#12121266] bg-opacity-40 border border-[#2D2D2D] rounded-lg p-3 px-5 flex justify-between items-center cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[#D7E0EF]"
+              onKeyDown={(e) => handleItemKeyDown(e, notification)}
+              onClick={() => onNotificationClick?.(notification)}
             >
               <div className="grid gap-1">
                 <p className="font-light text-[#E5E5E5] text-sm">
@@ -126,7 +228,7 @@ const NotificationPanel = ({
               <div className="relative w-[24px] h-[24px] flex items-center justify-center bg-[#0D0D0D80]/50 border border-[#2E2E2E] rounded-sm">
                 <IconBell />
                 {!notification.read && (
-                  <div className=" absolute top-2 right-[7px]  w-1 h-1 bg-[#EB6945] rounded-full" />
+                  <div className="absolute top-2 right-[7px] w-1 h-1 bg-[#EB6945] rounded-full" />
                 )}
               </div>
             </div>

--- a/design/a11y-checklist.md
+++ b/design/a11y-checklist.md
@@ -324,8 +324,85 @@ form.handleSubmit(onSubmit, onValidationError)
 | `components/dashboard/transaction-history.test.tsx` | Tests for aria-live announcement, transition-only firing, fake timers, edge cases |
 | `components/common/side-bar.tsx`                  | aria-label, aria-expanded, aria-hidden icons, focus rings                                |
 | `design/a11y-checklist.md`                        | This document                                                                            |
+| `components/common/notification-panel.tsx`        | Keyboard navigation (roving tabindex, Enter, Space, Escape, focus ring)                 |
+| `components/common/notification-panel.test.tsx`   | 16 new keyboard-navigation tests (27 total)                                              |
 
 ### Transaction Table Tooltips
-- **Contrast**: Focus ring (ocus:ring-[#D7E0EF]) provides clear 3:1 contrast against dark background.
-- **Keyboard Nav**: 	abIndex={0} makes truncated addresses and amounts focusable, revealing the 	itle tooltip.
+- **Contrast**: Focus ring (focus:ring-[#D7E0EF]) provides clear 3:1 contrast against dark background.
+- **Keyboard Nav**: tabIndex={0} makes truncated addresses and amounts focusable, revealing the title tooltip.
 - **ARIA**: Screen readers read the full content within the span natively, while sighted users see tooltips on hover/focus.
+
+---
+
+## Notification Panel — Added Keyboard Navigation
+
+**File:** `components/common/notification-panel.tsx`
+**PR:** Adds listbox keyboard pattern (WAI-ARIA roving tabindex) to the notification list.
+
+### Keyboard Shortcuts
+
+| Key           | Action                                              |
+| ------------- | --------------------------------------------------- |
+| Arrow Down    | Move focus to the next notification (wraps to top)  |
+| Arrow Up      | Move focus to the previous notification (wraps to bottom) |
+| Home          | Jump to the first notification                      |
+| End           | Jump to the last notification                       |
+| Enter / Space | Activate (click) the focused notification           |
+| Escape        | Close the panel and return focus to the bell trigger |
+
+### ARIA Attributes Applied
+
+| Element              | Attribute                    | Purpose                                               |
+| -------------------- | ---------------------------- | ----------------------------------------------------- |
+| Notification list    | `role="listbox"`             | Communicates listbox navigation pattern to AT         |
+| Notification list    | `aria-label="Notifications list"` | Provides accessible name for the listbox         |
+| Each notification    | `role="option"`              | Identifies each item as a listbox option              |
+| Each notification    | `aria-selected`              | Indicates which option is currently focused           |
+| Each notification    | `tabIndex` (roving)          | Only the focused option is in the Tab order           |
+| Bell trigger button  | `aria-label="Notifications"` | (pre-existing) Accessible label for the trigger       |
+
+### Focus Restoration
+
+On Escape, the component:
+1. Queries the bell trigger inside the panel via `[aria-label="Notifications"]`
+2. Calls `.focus()` on the trigger to return keyboard focus
+3. Invokes the `onClose` callback so the parent can hide the panel
+
+### Design Decisions
+
+- **Roving tabindex over `aria-activedescendant`**: Each option receives focus directly, providing a more robust keyboard experience and ensuring visible focus rings (WCAG 2.4.7 Focus Visible).
+- **Wrapping navigation**: Arrow Down from the last item wraps to the first and vice versa, matching common listbox expectations.
+- **`focus-visible` ring**: Items show a focus ring only when focused via keyboard (not click), using `focus-visible:ring-2` (WCAG 2.4.7, 1.4.1).
+- **No `aria-live` on listbox**: Removed when switching from `role="region"` to `role="listbox"`, as listbox provides its own semantics; new notifications arriving will still be announced by the DOM mutation.
+
+### Responsive / State Coverage
+
+| State                     | Keyboard nav behavior                                       |
+| ------------------------- | ----------------------------------------------------------- |
+| Loading                   | No listbox rendered; skeletons are non-interactive          |
+| Empty                     | No listbox rendered; empty state is static                  |
+| Single notification       | Arrow keys wrap onto the same item; no visible movement     |
+| Multiple notifications    | Full navigation as described above                          |
+| Notifications re-keyed    | `focusedIndex` resets to 0 on list change                   |
+
+### Tests (27 total, 16 new keyboard-nav tests)
+
+| Test                                              | File                                             |
+| ------------------------------------------------- | ------------------------------------------------ |
+| All pre-existing tests (11)                       | `notification-panel.test.tsx`                    |
+| listbox role + aria-label                         | `notification-panel.test.tsx`                    |
+| Default tabIndex (first=0, others=-1)             | `notification-panel.test.tsx`                    |
+| ArrowDown updates tabIndex                        | `notification-panel.test.tsx`                    |
+| ArrowDown forward / ArrowUp backward              | `notification-panel.test.tsx`                    |
+| Wrap last→first on ArrowDown                      | `notification-panel.test.tsx`                    |
+| Wrap first→last on ArrowUp                        | `notification-panel.test.tsx`                    |
+| Home jumps to first                               | `notification-panel.test.tsx`                    |
+| End jumps to last                                 | `notification-panel.test.tsx`                    |
+| aria-selected tracks focus                        | `notification-panel.test.tsx`                    |
+| Enter activates notification                      | `notification-panel.test.tsx`                    |
+| Space activates notification                      | `notification-panel.test.tsx`                    |
+| Click activates notification                      | `notification-panel.test.tsx`                    |
+| Escape calls onClose                              | `notification-panel.test.tsx`                    |
+| Non-activation key is no-op                       | `notification-panel.test.tsx`                    |
+| focusedIndex resets on notification change        | `notification-panel.test.tsx`                    |
+| No listbox in empty/loading states                | `notification-panel.test.tsx`                    |

--- a/package-lock.json
+++ b/package-lock.json
@@ -6660,6 +6660,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
closes #793 
## Description
Implements WAI-ARIA listbox roving tabindex keyboard navigation on the notification panel list items, matching the keyboard pattern users expect from a notification tray

<!-- Briefly describe the changes introduced in this pull request. -->
This pull request improves the accessibility and keyboard navigation of the notification panel. It introduces parent callback props (`onNotificationClick` and `onClose`), updates the notification list to use appropriate ARIA roles (`listbox` and `option`), implements roving `tabIndex` and keyboard navigation (Arrow keys, Home/End, Enter/Space, and Escape), adds visible keyboard focus indicators to meet WCAG 2.4.7 guidelines, and resets the focused notification when the notification list changes.


<!-- Link to the issue(s) this pull request addresses, if any. -->

## Checklist

- [x] I have tested the changes locally.
- [x] I have added/updated documentation as needed.
- [x] I have reviewed the code and ensured it follows the project guidelines.
- [x] I have added necessary tests.

## Screenshots/Recordings

<!-- Attach relevant images or videos to show the effect of your changes. -->

## Additional Notes

<!-- Any other information reviewers should be aware of. -->
