### PR TITLE
feat: add avatar crop zoom, pan, and rotate controls

### DIFF
--- a/app/settings/preferences/components/account-section.test.tsx
+++ b/app/settings/preferences/components/account-section.test.tsx
@@ -9,7 +9,12 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import AccountSection from "./account-section";
+import AccountSection, {
+  AVATAR_CROP_OUTPUT_SIZE,
+  AVATAR_PAN_KEYBOARD_STEP,
+  AVATAR_ZOOM_MAX,
+  AVATAR_ZOOM_MIN,
+} from "./account-section";
 
 vi.mock("next/image", () => ({
   default: ({
@@ -35,6 +40,189 @@ vi.mock("@/components/ui/form", () => ({
 const getEmailInput = () => screen.getByLabelText("Email address");
 const getSaveButton = () =>
   screen.getByRole("button", { name: /save account changes/i });
+
+function openAvatarDialog() {
+  render(<AccountSection />);
+  fireEvent.click(screen.getByRole("button", { name: /change photo/i }));
+}
+
+function uploadAvatar(
+  file = new File(["avatar"], "avatar.png", { type: "image/png" }),
+) {
+  fireEvent.change(screen.getByLabelText("Photo"), {
+    target: { files: [file] },
+  });
+}
+
+describe("AccountSection avatar crop controls", () => {
+  beforeEach(() => {
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:avatar-preview"),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("opens the crop dialog with upload guidance and fixed square output copy", () => {
+    openAvatarDialog();
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Crop profile photo")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `Output is saved as a fixed square crop at ${AVATAR_CROP_OUTPUT_SIZE} x ${AVATAR_CROP_OUTPUT_SIZE}.`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("disables crop controls until an image is uploaded", () => {
+    openAvatarDialog();
+
+    expect(screen.getByLabelText("Zoom")).toBeDisabled();
+    expect(screen.getByRole("button", { name: /zoom in/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /pan left/i })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /rotate right/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /save cropped photo/i }),
+    ).toBeDisabled();
+  });
+
+  it("rejects non-image uploads with an accessible error", () => {
+    openAvatarDialog();
+    uploadAvatar(new File(["notes"], "notes.txt", { type: "text/plain" }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/choose an image/i);
+    expect(screen.getByLabelText("Photo")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+
+  it("uploads an image and enables zoom, pan, rotate, and save controls", () => {
+    openAvatarDialog();
+    uploadAvatar();
+
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(
+      screen.getByAltText(/crop preview for avatar.png/i),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Zoom")).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: /zoom in/i })).not.toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /pan right/i }),
+    ).not.toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /rotate right/i }),
+    ).not.toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /save cropped photo/i }),
+    ).not.toBeDisabled();
+  });
+
+  it("supports zoom with both buttons and the keyboard-operable range input", () => {
+    openAvatarDialog();
+    uploadAvatar();
+
+    const zoom = screen.getByLabelText("Zoom");
+    expect(zoom).toHaveValue(String(AVATAR_ZOOM_MIN));
+
+    fireEvent.click(screen.getByRole("button", { name: /zoom in/i }));
+    expect(zoom).toHaveValue("1.1");
+
+    fireEvent.change(zoom, { target: { value: "2.4" } });
+    expect(screen.getByText("240%")).toBeInTheDocument();
+
+    fireEvent.change(zoom, { target: { value: String(AVATAR_ZOOM_MAX) } });
+    fireEvent.click(screen.getByRole("button", { name: /zoom in/i }));
+    expect(zoom).toHaveValue(String(AVATAR_ZOOM_MAX));
+  });
+
+  it("supports keyboard and button panning while keeping values bounded", () => {
+    openAvatarDialog();
+    uploadAvatar();
+
+    const preview = screen.getByTestId("avatar-crop-preview");
+
+    fireEvent.keyDown(preview, { key: "ArrowRight" });
+    expect(
+      screen.getByText(`${AVATAR_PAN_KEYBOARD_STEP}px`),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /pan down/i }));
+    expect(screen.getAllByText(`${AVATAR_PAN_KEYBOARD_STEP}px`)).toHaveLength(
+      2,
+    );
+
+    fireEvent.keyDown(preview, { key: "ArrowLeft", shiftKey: true });
+    expect(
+      screen.getByText(`-${AVATAR_PAN_KEYBOARD_STEP}px`),
+    ).toBeInTheDocument();
+  });
+
+  it("supports pointer dragging to pan the crop image", () => {
+    openAvatarDialog();
+    uploadAvatar();
+
+    const preview = screen.getByTestId("avatar-crop-preview");
+    preview.setPointerCapture = vi.fn();
+
+    fireEvent.pointerDown(preview, {
+      pointerId: 1,
+      clientX: 100,
+      clientY: 100,
+    });
+    fireEvent.pointerMove(preview, {
+      pointerId: 1,
+      clientX: 124,
+      clientY: 132,
+    });
+    fireEvent.pointerUp(preview, { pointerId: 1 });
+
+    expect(screen.getByText("24px")).toBeInTheDocument();
+    expect(screen.getByText("32px")).toBeInTheDocument();
+  });
+
+  it("rotates in 90-degree increments in both directions", () => {
+    openAvatarDialog();
+    uploadAvatar();
+
+    fireEvent.click(screen.getByRole("button", { name: /rotate right/i }));
+    expect(screen.getByText("90 deg")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /rotate left/i }));
+    expect(screen.getByText("0 deg")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /rotate left/i }));
+    expect(screen.getByText("270 deg")).toBeInTheDocument();
+  });
+
+  it("saves the cropped avatar and announces the fixed output resolution", async () => {
+    openAvatarDialog();
+    uploadAvatar();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /save cropped photo/i }),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByAltText("Profile photo")).toHaveAttribute(
+      "src",
+      "blob:avatar-preview",
+    );
+    expect(
+      screen.getByText(
+        `Profile photo crop saved at ${AVATAR_CROP_OUTPUT_SIZE} x ${AVATAR_CROP_OUTPUT_SIZE}.`,
+      ),
+    ).toBeInTheDocument();
+  });
+});
 
 describe("AccountSection email validation", () => {
   afterEach(() => {

--- a/app/settings/preferences/components/account-section.tsx
+++ b/app/settings/preferences/components/account-section.tsx
@@ -2,7 +2,18 @@
 
 import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
-import { Camera, Loader2 } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  Camera,
+  Loader2,
+  Minus,
+  Plus,
+  RotateCcw,
+  RotateCw,
+} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,6 +23,14 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import DestructiveActionDialog from "./destructive-action-dialog";
@@ -49,6 +68,27 @@ const SAMPLE_DATE = new Date("2026-07-29T14:30:00Z");
 /** Fixed reference amount used for the currency preview. */
 const SAMPLE_AMOUNT = 1250.5;
 
+export const AVATAR_CROP_OUTPUT_SIZE = 512;
+export const AVATAR_ZOOM_MIN = 1;
+export const AVATAR_ZOOM_MAX = 3;
+export const AVATAR_ZOOM_STEP = 0.1;
+export const AVATAR_PAN_LIMIT = 80;
+export const AVATAR_PAN_KEYBOARD_STEP = 8;
+
+interface AvatarCropTransform {
+  zoom: number;
+  panX: number;
+  panY: number;
+  rotation: number;
+}
+
+const DEFAULT_AVATAR_CROP: AvatarCropTransform = {
+  zoom: 1,
+  panX: 0,
+  panY: 0,
+  rotation: 0,
+};
+
 /** Number of profile fields that have a non-empty value. */
 export function countCompletedProfileFields(profile: ProfileState): number {
   return (Object.values(profile) as string[]).filter(
@@ -64,6 +104,10 @@ export function totalProfileFields(profile: ProfileState): number {
 /** A profile is "complete" once every tracked field is filled in. */
 export function isProfileComplete(profile: ProfileState): boolean {
   return countCompletedProfileFields(profile) === totalProfileFields(profile);
+}
+
+export function clampAvatarCropValue(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
 }
 
 interface StatusState {
@@ -122,6 +166,21 @@ export default function AccountSection({
   });
   const [isSaving, setIsSaving] = useState(false);
   const [isEmailTouched, setIsEmailTouched] = useState(false);
+  const [avatarDialogOpen, setAvatarDialogOpen] = useState(false);
+  const [avatarPreviewSrc, setAvatarPreviewSrc] = useState("/Image.png");
+  const [avatarDraftSrc, setAvatarDraftSrc] = useState<string | null>(null);
+  const [avatarDraftName, setAvatarDraftName] = useState("");
+  const [avatarCrop, setAvatarCrop] =
+    useState<AvatarCropTransform>(DEFAULT_AVATAR_CROP);
+  const [avatarError, setAvatarError] = useState("");
+  const [isDraggingAvatar, setIsDraggingAvatar] = useState(false);
+  const avatarDragStartRef = useRef<{
+    pointerId: number;
+    clientX: number;
+    clientY: number;
+    panX: number;
+    panY: number;
+  } | null>(null);
   const statusTimeoutRef = useRef<number | null>(null);
   const isMountedRef = useRef(true);
 
@@ -137,8 +196,11 @@ export default function AccountSection({
       if (statusTimeoutRef.current) {
         window.clearTimeout(statusTimeoutRef.current);
       }
+      if (avatarDraftSrc?.startsWith("blob:")) {
+        URL.revokeObjectURL(avatarDraftSrc);
+      }
     };
-  }, []);
+  }, [avatarDraftSrc]);
 
   const clearQueuedStatusReset = () => {
     if (statusTimeoutRef.current) {
@@ -164,6 +226,152 @@ export default function AccountSection({
     } else {
       setInternalProfile(next);
     }
+  };
+
+  const updateAvatarCrop = (next: Partial<AvatarCropTransform>) => {
+    setAvatarCrop((current) => ({
+      zoom: clampAvatarCropValue(
+        next.zoom ?? current.zoom,
+        AVATAR_ZOOM_MIN,
+        AVATAR_ZOOM_MAX,
+      ),
+      panX: clampAvatarCropValue(
+        next.panX ?? current.panX,
+        -AVATAR_PAN_LIMIT,
+        AVATAR_PAN_LIMIT,
+      ),
+      panY: clampAvatarCropValue(
+        next.panY ?? current.panY,
+        -AVATAR_PAN_LIMIT,
+        AVATAR_PAN_LIMIT,
+      ),
+      rotation: next.rotation ?? current.rotation,
+    }));
+  };
+
+  const handleAvatarFileChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    if (!file.type.startsWith("image/")) {
+      setAvatarError("Choose an image file to continue.");
+      setAvatarDraftSrc(null);
+      setAvatarDraftName("");
+      return;
+    }
+
+    if (avatarDraftSrc?.startsWith("blob:")) {
+      URL.revokeObjectURL(avatarDraftSrc);
+    }
+
+    setAvatarDraftSrc(URL.createObjectURL(file));
+    setAvatarDraftName(file.name);
+    setAvatarCrop(DEFAULT_AVATAR_CROP);
+    setAvatarError("");
+  };
+
+  const handleAvatarDialogChange = (open: boolean) => {
+    setAvatarDialogOpen(open);
+    if (!open) {
+      setIsDraggingAvatar(false);
+      avatarDragStartRef.current = null;
+    }
+  };
+
+  const rotateAvatar = (direction: "left" | "right") => {
+    updateAvatarCrop({
+      rotation:
+        (avatarCrop.rotation + (direction === "right" ? 90 : -90) + 360) % 360,
+    });
+  };
+
+  const panAvatar = (deltaX: number, deltaY: number) => {
+    updateAvatarCrop({
+      panX: avatarCrop.panX + deltaX,
+      panY: avatarCrop.panY + deltaY,
+    });
+  };
+
+  const handleAvatarCropKeyDown = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+  ) => {
+    const step = event.shiftKey
+      ? AVATAR_PAN_KEYBOARD_STEP * 2
+      : AVATAR_PAN_KEYBOARD_STEP;
+
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      panAvatar(-step, 0);
+    } else if (event.key === "ArrowRight") {
+      event.preventDefault();
+      panAvatar(step, 0);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      panAvatar(0, -step);
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault();
+      panAvatar(0, step);
+    }
+  };
+
+  const handleAvatarPointerDown = (
+    event: React.PointerEvent<HTMLDivElement>,
+  ) => {
+    if (!avatarDraftSrc) {
+      return;
+    }
+
+    event.currentTarget.setPointerCapture(event.pointerId);
+    avatarDragStartRef.current = {
+      pointerId: event.pointerId,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      panX: avatarCrop.panX,
+      panY: avatarCrop.panY,
+    };
+    setIsDraggingAvatar(true);
+  };
+
+  const handleAvatarPointerMove = (
+    event: React.PointerEvent<HTMLDivElement>,
+  ) => {
+    const start = avatarDragStartRef.current;
+    if (!start || start.pointerId !== event.pointerId) {
+      return;
+    }
+
+    updateAvatarCrop({
+      panX: start.panX + event.clientX - start.clientX,
+      panY: start.panY + event.clientY - start.clientY,
+    });
+  };
+
+  const handleAvatarPointerEnd = (
+    event: React.PointerEvent<HTMLDivElement>,
+  ) => {
+    if (avatarDragStartRef.current?.pointerId === event.pointerId) {
+      avatarDragStartRef.current = null;
+      setIsDraggingAvatar(false);
+    }
+  };
+
+  const handleSaveAvatarCrop = () => {
+    if (!avatarDraftSrc) {
+      setAvatarError("Upload an image before saving the crop.");
+      return;
+    }
+
+    setAvatarPreviewSrc(avatarDraftSrc);
+    setAvatarDialogOpen(false);
+    setStatus({
+      message: `Profile photo crop saved at ${AVATAR_CROP_OUTPUT_SIZE} x ${AVATAR_CROP_OUTPUT_SIZE}.`,
+      type: "success",
+    });
+    queueStatusReset();
   };
 
   /**
@@ -243,14 +451,27 @@ export default function AccountSection({
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div className="flex items-center gap-4">
               <div className="relative">
-                <Image
-                  src="/Image.png"
-                  alt="Profile photo"
-                  width={88}
-                  height={88}
-                  className="rounded-3xl border border-zinc-200 object-cover dark:border-white/10"
-                  priority
-                />
+                <div className="h-[88px] w-[88px] overflow-hidden rounded-3xl border border-zinc-200 bg-zinc-100 dark:border-white/10 dark:bg-white/5">
+                  {avatarPreviewSrc === "/Image.png" ? (
+                    <Image
+                      src="/Image.png"
+                      alt="Profile photo"
+                      width={88}
+                      height={88}
+                      className="h-full w-full object-cover"
+                      priority
+                    />
+                  ) : (
+                    // Uploaded object URLs are runtime-only browser assets, so
+                    // they render through a native image element.
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={avatarPreviewSrc}
+                      alt="Profile photo"
+                      className="h-full w-full object-cover"
+                    />
+                  )}
+                </div>
                 <span className="absolute -bottom-1 -right-1 h-5 w-5 rounded-full border-2 border-white bg-emerald-500 dark:border-[#09090B]" />
               </div>
               <div className="space-y-1">
@@ -266,7 +487,12 @@ export default function AccountSection({
                 </CardDescription>
               </div>
             </div>
-            <Button variant="outline" className="w-full md:w-auto">
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full md:w-auto"
+              onClick={() => setAvatarDialogOpen(true)}
+            >
               <Camera className="size-4" />
               Change photo
             </Button>
@@ -420,6 +646,293 @@ export default function AccountSection({
           </details>
         </CardContent>
       </Card>
+
+      <Dialog open={avatarDialogOpen} onOpenChange={handleAvatarDialogChange}>
+        <DialogContent className="max-h-[calc(100vh-2rem)] overflow-y-auto border-zinc-200 bg-white text-zinc-900 dark:border-white/10 dark:bg-[#09090B] dark:text-white sm:max-w-2xl">
+          <DialogHeader className="space-y-2 text-left">
+            <DialogTitle>Crop profile photo</DialogTitle>
+            <DialogDescription className="text-zinc-600 dark:text-zinc-400">
+              Upload a photo, then zoom, pan, and rotate it inside the fixed
+              square crop.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-5">
+            <div className="space-y-2">
+              <Label
+                htmlFor="avatar-upload"
+                className="text-sm font-medium text-zinc-900 dark:text-white"
+              >
+                Photo
+              </Label>
+              <Input
+                id="avatar-upload"
+                type="file"
+                accept="image/*"
+                onChange={handleAvatarFileChange}
+                error={Boolean(avatarError)}
+                aria-describedby={
+                  avatarError ? "avatar-upload-error" : "avatar-upload-help"
+                }
+                className="border-zinc-200 bg-white dark:border-white/10 dark:bg-white/5"
+              />
+              <p
+                id="avatar-upload-help"
+                className="text-xs text-zinc-600 dark:text-zinc-400"
+              >
+                Output is saved as a fixed square crop at{" "}
+                {AVATAR_CROP_OUTPUT_SIZE} x {AVATAR_CROP_OUTPUT_SIZE}.
+              </p>
+              {avatarError && (
+                <p
+                  id="avatar-upload-error"
+                  role="alert"
+                  className="text-sm text-destructive"
+                >
+                  {avatarError}
+                </p>
+              )}
+            </div>
+
+            <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_220px]">
+              <div className="space-y-2">
+                <div
+                  role="group"
+                  aria-label="Avatar crop preview. Use arrow keys to pan the photo."
+                  tabIndex={0}
+                  onKeyDown={handleAvatarCropKeyDown}
+                  onPointerDown={handleAvatarPointerDown}
+                  onPointerMove={handleAvatarPointerMove}
+                  onPointerUp={handleAvatarPointerEnd}
+                  onPointerCancel={handleAvatarPointerEnd}
+                  className={`relative aspect-square w-full overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-100 outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-white/10 dark:bg-white/5 dark:focus-visible:ring-white dark:focus-visible:ring-offset-[#09090B] ${
+                    isDraggingAvatar ? "cursor-grabbing" : "cursor-grab"
+                  }`}
+                  data-testid="avatar-crop-preview"
+                >
+                  {avatarDraftSrc ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={avatarDraftSrc}
+                      alt={`Crop preview for ${avatarDraftName}`}
+                      draggable={false}
+                      className="absolute left-1/2 top-1/2 h-full w-full select-none object-cover"
+                      style={{
+                        transform: `translate(calc(-50% + ${avatarCrop.panX}px), calc(-50% + ${avatarCrop.panY}px)) scale(${avatarCrop.zoom}) rotate(${avatarCrop.rotation}deg)`,
+                      }}
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center px-6 text-center text-sm text-zinc-500 dark:text-zinc-400">
+                      Upload a photo to begin cropping.
+                    </div>
+                  )}
+                  <div
+                    className="pointer-events-none absolute inset-0 ring-1 ring-inset ring-black/10 dark:ring-white/20"
+                    aria-hidden="true"
+                  />
+                </div>
+                <p className="text-xs text-zinc-600 dark:text-zinc-400">
+                  Drag to pan, or focus the crop preview and use arrow keys.
+                </p>
+              </div>
+
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label
+                    htmlFor="avatar-zoom"
+                    className="text-sm font-medium text-zinc-900 dark:text-white"
+                  >
+                    Zoom
+                  </Label>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      aria-label="Zoom out"
+                      onClick={() =>
+                        updateAvatarCrop({
+                          zoom: avatarCrop.zoom - AVATAR_ZOOM_STEP,
+                        })
+                      }
+                      disabled={!avatarDraftSrc}
+                    >
+                      <Minus className="h-4 w-4" />
+                    </Button>
+                    <input
+                      id="avatar-zoom"
+                      type="range"
+                      min={AVATAR_ZOOM_MIN}
+                      max={AVATAR_ZOOM_MAX}
+                      step={AVATAR_ZOOM_STEP}
+                      value={avatarCrop.zoom}
+                      onChange={(event) =>
+                        updateAvatarCrop({
+                          zoom: Number(event.target.value),
+                        })
+                      }
+                      disabled={!avatarDraftSrc}
+                      aria-valuemin={AVATAR_ZOOM_MIN}
+                      aria-valuemax={AVATAR_ZOOM_MAX}
+                      aria-valuenow={avatarCrop.zoom}
+                      aria-valuetext={`${Math.round(avatarCrop.zoom * 100)} percent`}
+                      className="h-2 min-w-0 flex-1 cursor-pointer accent-zinc-900 disabled:cursor-not-allowed disabled:opacity-50 dark:accent-white"
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      aria-label="Zoom in"
+                      onClick={() =>
+                        updateAvatarCrop({
+                          zoom: avatarCrop.zoom + AVATAR_ZOOM_STEP,
+                        })
+                      }
+                      disabled={!avatarDraftSrc}
+                    >
+                      <Plus className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <p className="text-sm font-medium text-zinc-900 dark:text-white">
+                    Pan
+                  </p>
+                  <div
+                    className="grid grid-cols-3 gap-2"
+                    aria-label="Pan avatar"
+                  >
+                    <span />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      aria-label="Pan up"
+                      onClick={() => panAvatar(0, -AVATAR_PAN_KEYBOARD_STEP)}
+                      disabled={!avatarDraftSrc}
+                    >
+                      <ArrowUp className="h-4 w-4" />
+                    </Button>
+                    <span />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      aria-label="Pan left"
+                      onClick={() => panAvatar(-AVATAR_PAN_KEYBOARD_STEP, 0)}
+                      disabled={!avatarDraftSrc}
+                    >
+                      <ArrowLeft className="h-4 w-4" />
+                    </Button>
+                    <div
+                      className="flex h-9 items-center justify-center rounded-md border border-zinc-200 bg-zinc-50 text-xs text-zinc-500 dark:border-white/10 dark:bg-white/5 dark:text-zinc-400"
+                      aria-hidden="true"
+                    >
+                      Move
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      aria-label="Pan right"
+                      onClick={() => panAvatar(AVATAR_PAN_KEYBOARD_STEP, 0)}
+                      disabled={!avatarDraftSrc}
+                    >
+                      <ArrowRight className="h-4 w-4" />
+                    </Button>
+                    <span />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      aria-label="Pan down"
+                      onClick={() => panAvatar(0, AVATAR_PAN_KEYBOARD_STEP)}
+                      disabled={!avatarDraftSrc}
+                    >
+                      <ArrowDown className="h-4 w-4" />
+                    </Button>
+                    <span />
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <p className="text-sm font-medium text-zinc-900 dark:text-white">
+                    Rotate
+                  </p>
+                  <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => rotateAvatar("left")}
+                      disabled={!avatarDraftSrc}
+                    >
+                      <RotateCcw className="h-4 w-4" />
+                      Rotate left
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => rotateAvatar("right")}
+                      disabled={!avatarDraftSrc}
+                    >
+                      <RotateCw className="h-4 w-4" />
+                      Rotate right
+                    </Button>
+                  </div>
+                </div>
+
+                <dl
+                  className="grid grid-cols-2 gap-2 rounded-2xl border border-zinc-200 bg-zinc-50 p-3 text-xs text-zinc-600 dark:border-white/10 dark:bg-white/5 dark:text-zinc-400"
+                  aria-label="Current crop values"
+                >
+                  <div>
+                    <dt className="font-medium text-zinc-900 dark:text-white">
+                      Zoom
+                    </dt>
+                    <dd>{Math.round(avatarCrop.zoom * 100)}%</dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-zinc-900 dark:text-white">
+                      Rotate
+                    </dt>
+                    <dd>{avatarCrop.rotation} deg</dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-zinc-900 dark:text-white">
+                      Pan X
+                    </dt>
+                    <dd>{avatarCrop.panX}px</dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-zinc-900 dark:text-white">
+                      Pan Y
+                    </dt>
+                    <dd>{avatarCrop.panY}px</dd>
+                  </div>
+                </dl>
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleAvatarDialogChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSaveAvatarCrop}
+              disabled={!avatarDraftSrc}
+            >
+              Save cropped photo
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <div className="space-y-6">
         <Card className="border-zinc-200 bg-white/90 shadow-sm dark:border-white/10 dark:bg-white/5">

--- a/design/settings-ia.md
+++ b/design/settings-ia.md
@@ -59,6 +59,7 @@ This keeps destructive actions deliberate and reduces accidental activation risk
 The intended click depth from `/settings/preferences` is:
 
 - Change profile fields: 1 section tap + 1 save action
+- Change profile photo crop: 1 section tap + photo action + crop/save interaction
 - Adjust notification priorities: 1 section tap + 1 toggle
 - Change password: 1 section tap + form interaction
 - Review wallet controls: 1 section tap + 1 toggle
@@ -106,6 +107,38 @@ Generated screenshots:
 The statements change is a settings-tab addition only. Capture updated
 screenshots when the visual regression pass is run for the broader settings
 surface.
+
+## Account Avatar Crop
+
+The Account tab profile photo action opens a focused crop dialog for upload,
+crop, and save without moving users away from settings.
+
+Behavior:
+
+- The crop frame is always square and documents a fixed `512 x 512` output
+  contract for backend/image-processing wiring.
+- Users can upload an image, zoom from `100%` to `300%`, pan inside the crop
+  frame, and rotate in 90-degree increments.
+- Dragging the crop preview pans the image for pointer users.
+- The current crop values are visible for review: zoom, rotation, pan X, and
+  pan Y.
+- Non-image uploads are rejected inline before crop controls enable.
+
+Accessibility and responsive notes:
+
+- The upload field has a visible label, helper text, and `aria-invalid` error
+  state.
+- Zoom uses a native range input, so keyboard users can adjust it with standard
+  slider keys.
+- Pan is available through arrow-key handling on the focused crop preview and
+  through explicit Pan up/down/left/right buttons.
+- Rotate controls are regular buttons with visible labels and icon affordances.
+- Disabled controls remain discoverable before upload while preventing invalid
+  crop saves.
+- The dialog stacks controls below the square preview on narrow screens, then
+  shifts controls beside the preview at `lg` 1024px and wider. Long file names,
+  helper text, and crop values wrap within the dialog at `sm` 640px, `md`
+  768px, `lg` 1024px, and `xl` 1280px.
 
 ## Notes
 


### PR DESCRIPTION
Closes #906

## Summary

Adds zoom, pan, and 90-degree rotate controls to the Account tab profile photo crop step.

## What Changed

- Added a profile photo crop dialog to `account-section.tsx`
- Added image upload validation for avatar crop flow
- Added fixed square crop preview with a documented `512 x 512` output contract
- Added zoom controls:
  - native keyboard-operable range input
  - zoom in/out buttons
- Added pan controls:
  - drag-to-pan crop preview
  - arrow-key panning on the focused preview
  - explicit pan up/down/left/right buttons
- Added rotate controls:
  - rotate left/right buttons
  - 90-degree increments
- Added visible crop values for review: zoom, rotation, pan X, pan Y
- Updated `design/settings-ia.md` with behavior, accessibility, and responsive notes
- Added focused tests for upload, invalid file handling, zoom, keyboard/button pan, pointer drag pan, rotate, and save output messaging

## Accessibility Notes

- Upload field has visible label, helper copy, and `aria-invalid` error state
- Zoom uses a native range input for standard keyboard operation
- Pan works via arrow keys on the crop preview and via explicit buttons
- Rotate controls are labeled buttons with icon affordances
- Crop dialog uses the shared Radix dialog primitive for focus management
- Controls remain disabled until an image is uploaded

## Responsive Notes

- Crop preview remains square with `aspect-square`
- Dialog content scrolls within the viewport
- Controls stack below preview on smaller screens
- Controls move beside preview at `lg` and wider
- Copy and values wrap within the dialog across `sm`, `md`, `lg`, and `xl`

## Validation

Passed:

```bash
.\node_modules\.bin\vitest.cmd run app/settings/preferences/components/account-section.test.tsx