### PR TITLE
fix: add focus trap and Escape handling to the mobile nav drawer

### DIFF
--- a/components/dashboard/dashboard-navbar.test.tsx
+++ b/components/dashboard/dashboard-navbar.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * Tests for the focus-trap in the mobile drawer of
+ * components/dashboard/dashboard-navbar.tsx.
+ *
+ * Covers:
+ * - Drawer opens / closes via the hamburger toggle button.
+ * - While the drawer is open, Tab / Shift+Tab cycles only within it.
+ * - Escape closes the drawer and returns focus to the trigger button.
+ * - Focus returns to the trigger button when the drawer closes.
+ * - Drawer has correct ARIA attributes (aria-modal, role="dialog").
+ * - Body scroll is locked when drawer is open.
+ */
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import DashboardNavbar from "./dashboard-navbar";
+
+// ── Mock external dependencies ────────────────────────────────────────────────
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+    "aria-label": ariaLabel,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    "aria-label"?: string;
+  }) => (
+    <a href={href} className={className} aria-label={ariaLabel}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/context/theme-context", () => ({
+  useTheme: () => ({
+    theme: "light",
+    resolvedTheme: "light",
+    toggleTheme: vi.fn(),
+  }),
+}));
+
+vi.mock("@/context/wallet-context", () => ({
+  useWallet: () => ({
+    address: null,
+    isConnected: false,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }),
+  formatAddress: (addr: string | null) => (addr ? `${addr.slice(0, 4)}...${addr.slice(-4)}` : ""),
+}));
+
+vi.mock("@/components/common/network-switcher", () => ({
+  default: () => <div data-testid="network-switcher" />,
+}));
+
+vi.mock("@/public/svg/svg", () => ({
+  StellOpayLogo: () => <svg data-testid="stellopay-logo" />,
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getMenuButton() {
+  return screen.getByRole("button", { name: /open navigation menu|close navigation menu/i });
+}
+
+function openMenu() {
+  fireEvent.click(getMenuButton());
+}
+
+function getDrawer() {
+  return screen.queryByRole("dialog", { name: /mobile navigation menu/i });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("DashboardNavbar mobile drawer focus trap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the hamburger toggle button and the drawer is initially closed", () => {
+    render(<DashboardNavbar />);
+    expect(getMenuButton()).toBeInTheDocument();
+    expect(getDrawer()).toBeNull();
+  });
+
+  it("opens the drawer when the hamburger toggle is clicked", () => {
+    render(<DashboardNavbar />);
+    openMenu();
+    expect(getDrawer()).toBeInTheDocument();
+    expect(getMenuButton()).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("closes the drawer when the hamburger toggle is clicked again", () => {
+    render(<DashboardNavbar />);
+    openMenu();
+    fireEvent.click(getMenuButton()); // close
+    expect(getDrawer()).toBeNull();
+    expect(getMenuButton()).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("closes the drawer when the backdrop overlay is clicked", () => {
+    render(<DashboardNavbar />);
+    openMenu();
+    expect(getDrawer()).toBeInTheDocument();
+
+    // Click the backdrop overlay (div with aria-hidden, not SVG icons)
+    const overlay = document.querySelector('div[aria-hidden="true"]');
+    expect(overlay).toBeInTheDocument();
+    if (overlay) {
+      fireEvent.click(overlay);
+    }
+    expect(getDrawer()).toBeNull();
+  });
+
+  it("closes the drawer when Escape is pressed", () => {
+    render(<DashboardNavbar />);
+    openMenu();
+    expect(getDrawer()).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(getDrawer()).toBeNull();
+  });
+
+  it("drawer has aria-modal=true while open", () => {
+    render(<DashboardNavbar />);
+    openMenu();
+    const drawer = getDrawer();
+    expect(drawer).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("drawer has role='dialog' while open", () => {
+    render(<DashboardNavbar />);
+    openMenu();
+    const drawer = getDrawer();
+    expect(drawer).toHaveAttribute("role", "dialog");
+  });
+
+  it("Tab wraps from last focusable element to first inside the drawer", () => {
+    render(<DashboardNavbar />);
+    openMenu();
+
+    const drawer = getDrawer()!;
+    const focusableEls = Array.from(
+      drawer.querySelectorAll<HTMLElement>(
+        "a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex='-1'])",
+      ),
+    );
+
+    expect(focusableEls.length).toBeGreaterThan(1);
+
+    const last = focusableEls[focusableEls.length - 1];
+    const first = focusableEls[0];
+
+    act(() => last.focus());
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: false });
+
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("Shift+Tab wraps from first focusable element to last inside the drawer", () => {
+    render(<DashboardNavbar />);
+    openMenu();
+
+    const drawer = getDrawer()!;
+    const focusableEls = Array.from(
+      drawer.querySelectorAll<HTMLElement>(
+        "a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex='-1'])",
+      ),
+    );
+
+    const first = focusableEls[0];
+    const last = focusableEls[focusableEls.length - 1];
+
+    act(() => first.focus());
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+
+    expect(document.activeElement).toBe(last);
+  });
+
+  it("focus returns to the trigger button after closing via Escape", () => {
+    render(<DashboardNavbar />);
+    const btn = getMenuButton();
+
+    openMenu();
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it("focus returns to the trigger button after closing via button click", () => {
+    render(<DashboardNavbar />);
+    const btn = getMenuButton();
+
+    openMenu();
+    fireEvent.click(btn); // close
+
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it("focus returns to the trigger button after closing via overlay click", () => {
+    render(<DashboardNavbar />);
+    const btn = getMenuButton();
+
+    openMenu();
+    const overlay = document.querySelector('div[aria-hidden="true"]');
+    if (overlay) {
+      fireEvent.click(overlay);
+    }
+
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it("body scroll is locked when drawer is open", () => {
+    render(<DashboardNavbar />);
+    expect(document.body.style.overflow).toBe("");
+
+    openMenu();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    fireEvent.click(getMenuButton()); // close
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("body scroll lock is cleaned up on unmount while drawer is open", () => {
+    const { unmount } = render(<DashboardNavbar />);
+    openMenu();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("hamburger button becomes an X icon when drawer is open", () => {
+    render(<DashboardNavbar />);
+    openMenu();
+
+    // The aria-label should indicate "Close navigation menu" when open
+    expect(getMenuButton()).toHaveAttribute("aria-label", "Close navigation menu");
+  });
+
+  it("hamburger button has aria-controls pointing to the drawer", () => {
+    render(<DashboardNavbar />);
+    expect(getMenuButton()).toHaveAttribute("aria-controls", "dashboard-mobile-drawer");
+  });
+});

--- a/components/dashboard/dashboard-navbar.tsx
+++ b/components/dashboard/dashboard-navbar.tsx
@@ -1,125 +1,296 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { Bell, Moon, Search, Settings, Sun } from "lucide-react";
+import { Bell, Moon, Search, Settings, Sun, X, Menu } from "lucide-react";
 import { useTheme } from "@/context/theme-context";
 import { formatAddress, useWallet } from "@/context/wallet-context";
 import NetworkSwitcher from "@/components/common/network-switcher";
 import { StellOpayLogo } from "@/public/svg/svg";
 
+/** CSS selector that matches all natively focusable elements. */
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
 export default function DashboardNavbar() {
   const { theme, resolvedTheme, toggleTheme } = useTheme();
   const { address, isConnected, connect, disconnect } = useWallet();
+  const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
+
+  /** Ref on the hamburger/close button — focus returns here when drawer closes. */
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  /** Ref on the mobile drawer — used to query focusable children. */
+  const drawerRef = useRef<HTMLElement>(null);
+
+  // ── Focus trap ─────────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!mobileDrawerOpen) return;
+
+    // Move initial focus into the drawer on open.
+    const drawer = drawerRef.current;
+    if (drawer) {
+      const firstFocusable = drawer.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+      firstFocusable?.focus();
+    }
+
+    /** Trap Tab/Shift+Tab within the drawer; close on Escape. */
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setMobileDrawerOpen(false);
+        return;
+      }
+
+      if (e.key !== "Tab" || !drawer) return;
+
+      const focusableEls = Array.from(
+        drawer.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => !el.closest("[hidden]") && el.tabIndex !== -1);
+
+      if (focusableEls.length === 0) return;
+
+      const first = focusableEls[0];
+      const last = focusableEls[focusableEls.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [mobileDrawerOpen]);
+
+  // ── Return focus to the trigger button when the drawer closes ─────────────
+  const prevMobileDrawerOpen = useRef(mobileDrawerOpen);
+  useEffect(() => {
+    if (prevMobileDrawerOpen.current && !mobileDrawerOpen) {
+      menuButtonRef.current?.focus();
+    }
+    prevMobileDrawerOpen.current = mobileDrawerOpen;
+  }, [mobileDrawerOpen]);
+
+  // ── Lock body scroll when drawer is open ───────────────────────────────────
+  useEffect(() => {
+    if (mobileDrawerOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [mobileDrawerOpen]);
 
   return (
-    <nav className="w-full h-20 px-6 lg:px-10 border-b border-zinc-200 dark:border-zinc-800 flex items-center justify-between bg-white dark:bg-[#0D0D0D] transition-colors duration-200 sticky top-0 z-50">
-      <div className="flex items-center gap-8 flex-1">
-        <Link
-          href="/"
-          aria-label="StelloPay home"
-          className="flex items-center gap-2 text-zinc-900 dark:text-white transition-colors duration-200"
-        >
-          <StellOpayLogo />
-        </Link>
-
-        <div className="relative max-w-md w-full hidden md:block">
-          <Search
-            size={20}
-            strokeWidth={2}
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400"
-          />
-          <input
-            type="text"
-            placeholder="Search transactions, contracts..."
-            className="w-full h-10 pl-10 pr-4 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 transition-all"
-          />
-        </div>
-      </div>
-
-      <div className="flex items-center gap-2 sm:gap-4">
-        <div className="hidden sm:flex">
-          {/* Drives the shared wallet network through WalletProvider. */}
-          <NetworkSwitcher variant="dashboard" />
-        </div>
-
-        <button
-          aria-label="Notifications"
-          className="relative p-2 rounded-lg text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
-        >
-          <Bell size={20} strokeWidth={2} />
-          <span className="absolute top-2 right-2.5 w-2 h-2 bg-red-500 rounded-full border-2 border-white dark:border-[#0D0D0D]" />
-        </button>
-
-        <button
-          aria-label="Settings"
-          className="p-2 rounded-lg text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors hidden sm:block cursor-pointer"
-        >
-          <Settings size={20} strokeWidth={2} />
-        </button>
-
-        <button
-          onClick={toggleTheme}
-          aria-label={
-            theme === "light"
-              ? "Switch to dark mode"
-              : theme === "dark"
-                ? "Switch to system mode"
-                : "Switch to light mode"
-          }
-          className="p-2 rounded-lg text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
-        >
-          {resolvedTheme === "dark" ? (
-            <Sun size={20} strokeWidth={2} />
-          ) : (
-            <Moon size={20} strokeWidth={2} />
-          )}
-        </button>
-
-        {isConnected ? (
-          <button
-            type="button"
-            onClick={disconnect}
-            data-testid="dashboard-navbar-disconnect"
-            aria-label={`Disconnect wallet ${formatAddress(address)}`}
-            className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 hover:opacity-90 transition-opacity cursor-pointer"
+    <>
+      <nav
+        className="w-full h-20 px-6 lg:px-10 border-b border-zinc-200 dark:border-zinc-800 flex items-center justify-between bg-white dark:bg-[#0D0D0D] transition-colors duration-200 sticky top-0 z-50"
+        aria-label={mobileDrawerOpen ? "Main navigation, mobile drawer open" : "Main navigation"}
+      >
+        <div className="flex items-center gap-8 flex-1">
+          <Link
+            href="/"
+            aria-label="StelloPay home"
+            className="flex items-center gap-2 text-zinc-900 dark:text-white transition-colors duration-200"
           >
-            <div className="w-5 h-5 rounded-md bg-zinc-800 dark:bg-zinc-100 flex items-center justify-center">
-              <svg
-                width="12"
-                height="12"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M20 12V8H6a2 2 0 0 1-2-2c0-1.1.9-2 2-2h12v4" />
-                <path d="M4 6v12c0 1.1.9 2 2 2h14v-4" />
-                <path d="M18 12a2 2 0 0 0-2 2c0 1.1.9 2 2 2h4v-4h-4z" />
-              </svg>
-            </div>
-            <span
-              className="text-sm font-medium tracking-tight font-mono"
-              data-testid="dashboard-navbar-address"
+            <StellOpayLogo />
+          </Link>
+
+          <div className="relative max-w-md w-full hidden md:block">
+            <Search
+              size={20}
+              strokeWidth={2}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400"
+            />
+            <input
+              type="text"
+              placeholder="Search transactions, contracts..."
+              className="w-full h-10 pl-10 pr-4 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 transition-all"
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 sm:gap-4">
+          <div className="hidden sm:flex">
+            {/* Drives the shared wallet network through WalletProvider. */}
+            <NetworkSwitcher variant="dashboard" />
+          </div>
+
+          <button
+            aria-label="Notifications"
+            className="relative p-2 rounded-lg text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors hidden sm:block cursor-pointer"
+          >
+            <Bell size={20} strokeWidth={2} />
+            <span className="absolute top-2 right-2.5 w-2 h-2 bg-red-500 rounded-full border-2 border-white dark:border-[#0D0D0D]" />
+          </button>
+
+          <button
+            aria-label="Settings"
+            className="p-2 rounded-lg text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors hidden sm:block cursor-pointer"
+          >
+            <Settings size={20} strokeWidth={2} />
+          </button>
+
+          <button
+            onClick={toggleTheme}
+            aria-label={
+              theme === "light"
+                ? "Switch to dark mode"
+                : theme === "dark"
+                  ? "Switch to system mode"
+                  : "Switch to light mode"
+            }
+            className="p-2 rounded-lg text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+          >
+            {resolvedTheme === "dark" ? (
+              <Sun size={20} strokeWidth={2} />
+            ) : (
+              <Moon size={20} strokeWidth={2} />
+            )}
+          </button>
+
+          {isConnected ? (
+            <button
+              type="button"
+              onClick={disconnect}
+              data-testid="dashboard-navbar-disconnect"
+              aria-label={`Disconnect wallet ${formatAddress(address)}`}
+              className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 hover:opacity-90 transition-opacity cursor-pointer"
             >
-              {formatAddress(address)}
-            </span>
-          </button>
-        ) : (
+              <div className="w-5 h-5 rounded-md bg-zinc-800 dark:bg-zinc-100 flex items-center justify-center">
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M20 12V8H6a2 2 0 0 1-2-2c0-1.1.9-2 2-2h12v4" />
+                  <path d="M4 6v12c0 1.1.9 2 2 2h14v-4" />
+                  <path d="M18 12a2 2 0 0 0-2 2c0 1.1.9 2 2 2h4v-4h-4z" />
+                </svg>
+              </div>
+              <span
+                className="text-sm font-medium tracking-tight font-mono"
+                data-testid="dashboard-navbar-address"
+              >
+                {formatAddress(address)}
+              </span>
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => connect()}
+              data-testid="dashboard-navbar-connect"
+              className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 hover:opacity-90 transition-opacity cursor-pointer"
+            >
+              <span className="text-sm font-medium tracking-tight">
+                Connect Wallet
+              </span>
+            </button>
+          )}
+
+          {/* Hamburger toggle — visible only below sm breakpoint */}
           <button
+            ref={menuButtonRef}
             type="button"
-            onClick={() => connect()}
-            data-testid="dashboard-navbar-connect"
-            className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 hover:opacity-90 transition-opacity cursor-pointer"
+            className="sm:hidden p-2 rounded-lg text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+            aria-label={mobileDrawerOpen ? "Close navigation menu" : "Open navigation menu"}
+            aria-expanded={mobileDrawerOpen}
+            aria-controls="dashboard-mobile-drawer"
+            onClick={() => setMobileDrawerOpen((s) => !s)}
           >
-            <span className="text-sm font-medium tracking-tight">
-              Connect Wallet
-            </span>
+            {mobileDrawerOpen ? (
+              <X size={22} strokeWidth={2} />
+            ) : (
+              <Menu size={22} strokeWidth={2} />
+            )}
           </button>
-        )}
-      </div>
-    </nav>
+        </div>
+      </nav>
+
+      {/* Mobile drawer overlay */}
+      {mobileDrawerOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 sm:hidden"
+          aria-hidden="true"
+          onClick={() => setMobileDrawerOpen(false)}
+        />
+      )}
+
+      {/* Mobile drawer */}
+      {mobileDrawerOpen && (
+        <nav
+          id="dashboard-mobile-drawer"
+          ref={drawerRef}
+          className="fixed top-20 left-0 right-0 z-40 sm:hidden"
+          aria-label="Mobile navigation menu"
+          aria-modal="true"
+          role="dialog"
+        >
+          <div className="bg-white dark:bg-[#0D0D0D] border-b border-zinc-200 dark:border-zinc-800 shadow-lg px-6 py-6 space-y-6">
+            {/* Search */}
+            <div className="relative w-full">
+              <Search
+                size={20}
+                strokeWidth={2}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400"
+              />
+              <input
+                type="text"
+                placeholder="Search transactions, contracts..."
+                className="w-full h-10 pl-10 pr-4 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 transition-all"
+              />
+            </div>
+
+            {/* Notifications & Settings row */}
+            <div className="flex items-center gap-4">
+              <button
+                aria-label="Notifications"
+                className="flex items-center gap-3 p-3 rounded-lg text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer w-full"
+              >
+                <Bell size={20} strokeWidth={2} />
+                <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                  Notifications
+                </span>
+                <span className="ml-auto w-2 h-2 bg-red-500 rounded-full" />
+              </button>
+
+              <button
+                aria-label="Settings"
+                className="flex items-center gap-3 p-3 rounded-lg text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer w-full"
+              >
+                <Settings size={20} strokeWidth={2} />
+                <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                  Settings
+                </span>
+              </button>
+            </div>
+
+            {/* Network switcher */}
+            <div className="flex justify-start">
+              <NetworkSwitcher variant="dashboard" />
+            </div>
+          </div>
+        </nav>
+      )}
+    </>
   );
 }

--- a/design/a11y-checklist.md
+++ b/design/a11y-checklist.md
@@ -2,3 +2,35 @@
 
 ## Overview
 This checklist defines the mandatory accessibility requirements (targeting WCAG 2.1 AA compliance) for all components and views in the Stellopay frontend.
+
+---
+
+## Dashboard Navbar Mobile Drawer
+
+### Component
+`components/dashboard/dashboard-navbar.tsx`
+
+### Requirements covered
+| Requirement | WCAG Criterion | Implementation |
+|---|---|---|
+| **Focus trap** — Tab/Shift+Tab cycles within the open drawer | WCAG 2.1.2 (No Keyboard Trap) | `useEffect` listens for `keydown` events. Tab from last element wraps to first; Shift+Tab from first wraps to last. |
+| **Escape to close** — pressing Escape closes the drawer | WCAG 2.1.2 (No Keyboard Trap) | `handleKeyDown` checks `e.key === "Escape"` and closes the drawer. |
+| **Focus return** — focus returns to the hamburger trigger on close | WCAG 2.4.3 (Focus Order) | A `useRef`-based effect compares previous open state; when transitioning from open → closed, `menuButtonRef.current?.focus()` is called. |
+| **Initial focus** — focus moves into the drawer on open | WCAG 2.4.3 (Focus Order) | On open, the first focusable element inside the drawer receives focus. |
+| **ARIA attributes** — `role="dialog"`, `aria-modal="true"`, `aria-label`, `aria-expanded`, `aria-controls` | WCAG 4.1.2 (Name, Role, Value) | Drawer has `role="dialog"` and `aria-modal="true"`; trigger has `aria-expanded` and `aria-controls` pointing to the drawer id. |
+| **Backdrop / overlay** — clicking outside closes the drawer | WCAG 2.1.1 (Keyboard) | An overlay div with `aria-hidden="true"` covers the viewport and calls `setMobileDrawerOpen(false)` on click. |
+| **Body scroll lock** — background content does not scroll while drawer is open | WCAG 2.4.7 (Focus Visible) | `document.body.style.overflow = "hidden"` is set when open and restored on close/unmount. |
+| **Responsive visibility** — drawer only appears below `sm` breakpoint | WCAG 1.4.10 (Reflow) | The hamburger toggle is hidden above `sm` (`sm:hidden`), and the drawer itself uses `sm:hidden` to only render on mobile. |
+
+### Test coverage
+Tests are in `components/dashboard/dashboard-navbar.test.tsx` and cover:
+- Drawer open/close via toggle button
+- Escape key closes the drawer
+- Tab focus cycling (forward and backward)
+- Shift+Tab focus cycling
+- Focus returns to trigger on close (Escape, button click, overlay click)
+- `aria-modal`, `role="dialog"`, `aria-expanded`, `aria-controls` presence
+- Body scroll lock and cleanup on unmount
+- Icon toggle (hamburger → X)
+
+---


### PR DESCRIPTION
Closes #787 

# fix: add focus trap and Escape handling to the mobile nav drawer (#787)

Closes #787

## Summary

Adds a fully accessible hamburger-triggered mobile drawer to the dashboard navbar with focus trapping, Escape-to-close, body scroll lock, and proper ARIA attributes — meeting WCAG 2.1 AA baseline expectations for any modal-style overlay.

## Demo

### Before
The `components/dashboard/dashboard-navbar.tsx` had no mobile drawer at all. On small screens (`< sm` breakpoint), the search bar, network switcher, notifications, and settings buttons were simply hidden (`hidden md:block`, `hidden sm:flex`, `hidden sm:block`), leaving mobile users with no access to those controls.

### After
- A **hamburger (`Menu`) toggle button** appears below the `sm` breakpoint.
- Clicking it opens a **full-width drawer** containing the mobile-accessible versions of the hidden elements:
  - Search input
  - Notifications button
  - Settings button
  - Network Switcher
- A semi-transparent **backdrop overlay** covers the viewport; clicking it closes the drawer.
- The trigger button **morphs from a hamburger icon to an X icon** when the drawer is open.
- Tab/Shift+Tab focus is trapped within the drawer; **Escape** closes it and returns focus to the trigger.

## Changes

### Modified Files

#### `components/dashboard/dashboard-navbar.tsx`

**Structural changes:**
- Added `useState`, `useRef`, `useEffect` imports from React and `X`, `Menu` from `lucide-react`.
- Added a **hamburger toggle button** (`hidden sm:block` → `sm:hidden`) with:
  - `aria-label` that dynamically reads "Open navigation menu" / "Close navigation menu"
  - `aria-expanded` reflecting the drawer state
  - `aria-controls="dashboard-mobile-drawer"` linking to the drawer id
- Added a **backdrop overlay** (`<div>` with `aria-hidden="true"`) that closes the drawer on click.
- Added the **mobile drawer** (`<nav>` with `role="dialog"`, `aria-modal="true"`) containing search, notifications, settings, and network switcher.
- The main `<nav>` now has a dynamic `aria-label` that appends ", mobile drawer open" when the drawer is active.

**Focus trap implementation** (matching the established pattern in `components/landing/navbar.tsx`):
- `FOCUSABLE_SELECTOR` constant matching all naturally focusable elements.
- `useEffect` on `mobileDrawerOpen`:
  - Moves initial focus to the first focusable element inside the drawer on open.
  - Listens for `keydown` on `document`:
    - **Escape** → closes the drawer.
    - **Tab** → wraps last→first; **Shift+Tab** → wraps first→last.
  - Cleans up the listener on close/unmount.
- `useEffect` with a `useRef` tracking the previous open state → returns focus to the hamburger trigger on close.
- `useEffect` locking `document.body.style.overflow = "hidden"` while open, with cleanup.

#### `design/a11y-checklist.md`
- Added a dedicated **Dashboard Navbar Mobile Drawer** section documenting all WCAG criteria met, their implementation details, and the test coverage.

### New Files

| File | Purpose |
|------|---------|
| `components/dashboard/dashboard-navbar.test.tsx` | 16 unit tests covering focus trap, Escape, ARIA, scroll lock, and edge cases |

## Accessibility (WCAG 2.1 AA)

| Requirement | WCAG Criterion | Implementation |
|---|---|---|
| **Focus trap** — Tab/Shift+Tab cycles within the open drawer | [2.1.2 No Keyboard Trap](https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap.html) | `keydown` listener on `document` wraps last→first (Tab) and first→last (Shift+Tab) |
| **Escape to close** | [2.1.2 No Keyboard Trap](https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap.html) | `e.key === "Escape"` closes the drawer |
| **Focus return** — focus returns to trigger on close | [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html) | `useRef` tracks previous state; `menuButtonRef.current?.focus()` on close |
| **Initial focus** — focus moves into drawer on open | [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html) | First focusable child receives focus immediately on open |
| **ARIA attributes** | [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html) | `role="dialog"`, `aria-modal="true"`, `aria-label`, `aria-expanded`, `aria-controls` |
| **Backdrop overlay** — clicking outside closes | [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html) | Overlay `<div>` with `aria-hidden="true"` fires `setMobileDrawerOpen(false)` on click |
| **Body scroll lock** — background doesn't scroll | [2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html) | `overflow: hidden` set on `document.body` while open; restored on close and unmount |
| **Responsive visibility** | [1.4.10 Reflow](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html) | Hamburger toggle hidden above `sm` (`sm:hidden`); drawer only renders on mobile |

## Responsive Behavior

| Element | Breakpoint | Behavior |
|---------|------------|----------|
| Hamburger toggle | `< 640px` (sm) | Visible; shows `Menu` icon when closed, `X` icon when open |
| Desktop controls | `≥ 640px` (sm) | Search (`md`), notifications & settings (`sm`), network switcher (`sm`) are visible inline |
| Desktop controls | `< 640px` (sm) | Hidden inline; accessible inside the mobile drawer |
| Drawer | `< 640px` (sm) | Full-width panel below the navbar |
| Drawer | `≥ 640px` (sm) | Not rendered |
| Backdrop | `< 640px` (sm) | Full-screen overlay with `bg-black/50` |

## Testing

```bash
pnpm test -- components/dashboard/dashboard-navbar.test.tsx
```

**Results:** 16/16 tests passing.

| Test | Status |
|------|--------|
| Renders hamburger toggle and drawer is initially closed | ✅ |
| Opens drawer on toggle click | ✅ |
| Closes drawer on second toggle click | ✅ |
| Closes drawer on backdrop overlay click | ✅ |
| Closes drawer on Escape | ✅ |
| `aria-modal="true"` while open | ✅ |
| `role="dialog"` while open | ✅ |
| Tab wraps from last → first focusable element | ✅ |
| Shift+Tab wraps from first → last focusable element | ✅ |
| Focus returns to trigger after Escape | ✅ |
| Focus returns to trigger after button click | ✅ |
| Focus returns to trigger after overlay click | ✅ |
| Body scroll locked when open | ✅ |
| Body scroll lock cleaned up on unmount | ✅ |
| Hamburger icon becomes X when open | ✅ |
| `aria-controls` points to drawer id | ✅ |

## Edge Cases Handled

| Case | Behavior |
|------|----------|
| **No focusable elements** | Focus trap gracefully returns early when `focusableEls.length === 0` |
| **Hidden focusable elements** | Elements inside `[hidden]` containers are filtered out via `el.closest("[hidden]")` |
| **`tabindex="-1"` elements** | Excluded from the focusable set even if they match the base selector |
| **Unmount while open** | Body scroll lock cleanup runs in the `useEffect` return function |
| **Rapid open/close** | Focus return effect only fires on open→close transitions (guarded by `useRef`) |
| **SSR safety** | All effects run client-side; no `window`/`document` access during SSR |

## Future Considerations

- The same `FOCUSABLE_SELECTOR` and focus trap pattern could be extracted into a shared `useFocusTrap` hook to avoid duplication with `components/landing/navbar.tsx`.
- The drawer content currently mirrors the hidden desktop elements; it could be extended with additional mobile-specific navigation items in the future.
- A CSS transition/animation could be added to the drawer's appear/disappear for smoother UX.
