### PR TITLE
feat: support prefers-contrast: more on landing CTA buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,7 @@
 @import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));
+@custom-variant contrast-more (@media (prefers-contrast: more));
 
 html {
   scroll-behavior: smooth;

--- a/components/landing/get-started-cta.test.tsx
+++ b/components/landing/get-started-cta.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import GetStartedCTA from "./get-started-cta";
+
+describe("GetStartedCTA", () => {
+  it("renders the heading and form", () => {
+    render(<GetStartedCTA />);
+    expect(screen.getByText("Ready to revolutionize")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Enter your work email"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /get started/i })).toBeInTheDocument();
+  });
+
+  it("renders trust indicators", () => {
+    render(<GetStartedCTA />);
+    expect(screen.getByText("Free 14-day trial")).toBeInTheDocument();
+    expect(screen.getByText("No credit card required")).toBeInTheDocument();
+    expect(screen.getByText("Cancel anytime")).toBeInTheDocument();
+  });
+
+  it("has a gradient button with contrast-more fallback classes", () => {
+    render(<GetStartedCTA />);
+    const button = screen.getByRole("button", { name: /get started/i });
+    expect(button.className).toContain("bg-gradient-to-b");
+    expect(button.className).toContain("contrast-more:bg-[#5B21B6]");
+    expect(button.className).toContain("contrast-more:bg-none");
+    expect(button.className).toContain("contrast-more:shadow-none");
+  });
+});

--- a/components/landing/get-started-cta.tsx
+++ b/components/landing/get-started-cta.tsx
@@ -64,7 +64,7 @@ export default function GetStartedCTA() {
               <Button
                 type="submit"
                 size="lg"
-                className="h-12 rounded-xl bg-gradient-to-b from-[#83A7FF] to-[#8B5CF6] text-white shadow-lg shadow-indigo-500/20 hover:opacity-90 hover:shadow-indigo-500/30 dark:shadow-none font-medium font-general transition-transform active:scale-95"
+                className="h-12 rounded-xl bg-gradient-to-b from-[#83A7FF] to-[#8B5CF6] contrast-more:bg-[#5B21B6] contrast-more:bg-none text-white shadow-lg shadow-indigo-500/20 hover:opacity-90 hover:shadow-indigo-500/30 dark:shadow-none contrast-more:shadow-none font-medium font-general transition-transform active:scale-95"
               >
                 Get Started
                 <ArrowRight className="ml-2 h-4 w-4" />

--- a/components/landing/help-cta-section.test.tsx
+++ b/components/landing/help-cta-section.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import HelpCTASection from "./help-cta-section";
+
+describe("HelpCTASection", () => {
+  it("renders the heading and buttons", () => {
+    render(<HelpCTASection />);
+    expect(
+      screen.getByText("Still have questions? We're here to help"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /contact support/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /visit help center/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("has a gradient CTA button with contrast-more fallback classes", () => {
+    render(<HelpCTASection />);
+    const button = screen.getByRole("button", { name: /contact support/i });
+    expect(button.className).toContain("bg-gradient-to-r");
+    expect(button.className).toContain("contrast-more:bg-[#5B21B6]");
+    expect(button.className).toContain("contrast-more:bg-none");
+    expect(button.className).toContain("contrast-more:shadow-none");
+    expect(button.className).toContain("contrast-more:hover:opacity-100");
+  });
+
+  it("renders the outline button with link", () => {
+    render(<HelpCTASection />);
+    const link = screen.getByRole("link", { name: /visit help center/i });
+    expect(link).toHaveAttribute("href", "/help");
+  });
+});

--- a/components/landing/help-cta-section.tsx
+++ b/components/landing/help-cta-section.tsx
@@ -27,7 +27,7 @@ export default function HelpCTASection() {
           <Button
             onClick={handleContactSupport}
             size="lg"
-            className="w-full sm:w-auto min-w-[180px] h-12 rounded-xl bg-gradient-to-r from-[#93B4FF] via-[#A78BFA] to-[#7C3AED] dark:from-[#7C9EFF] dark:via-[#8B5CF6] dark:to-[#6D28D9] text-white font-semibold shadow-md hover:opacity-90 hover:shadow-lg focus-visible:ring-2 focus-visible:ring-[#7C3AED] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-[#040404] transition-all"
+            className="w-full sm:w-auto min-w-[180px] h-12 rounded-xl bg-gradient-to-r from-[#93B4FF] via-[#A78BFA] to-[#7C3AED] dark:from-[#7C9EFF] dark:via-[#8B5CF6] dark:to-[#6D28D9] contrast-more:bg-[#5B21B6] contrast-more:bg-none text-white font-semibold shadow-md hover:opacity-90 hover:shadow-lg focus-visible:ring-2 focus-visible:ring-[#7C3AED] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-[#040404] contrast-more:shadow-none contrast-more:hover:opacity-100 transition-all"
           >
             Contact Support
           </Button>


### PR DESCRIPTION
## Summary

Adds WCAG-compliant `prefers-contrast: more` support to the primary CTA buttons across the landing page. When users enable increased contrast at the OS level, gradient button backgrounds are replaced with a solid high-contrast color (`#5B21B6` / indigo-800) for maximum text legibility.

## Changes

- **`app/globals.css`** — Added a Tailwind v4 custom variant `@custom-variant contrast-more (@media (prefers-contrast: more))` enabling `contrast-more:` prefixed utilities throughout the codebase.

- **`components/landing/get-started-cta.tsx`** — The "Get Started" gradient button now applies `contrast-more:bg-[#5B21B6] contrast-more:bg-none contrast-more:shadow-none` when users enable increased contrast.

- **`components/landing/help-cta-section.tsx`** — The "Contact Support" gradient button gets the same solid-color fallback plus `contrast-more:hover:opacity-100` to prevent opacity reduction on hover.

- **`components/landing/get-started-cta.test.tsx`** (new) — 3 tests covering render, trust indicators, and contrast-more class presence.

- **`components/landing/help-cta-section.test.tsx`** (new) — 3 tests covering render, contrast-more classes, and outline link behavior.

## Design decisions

- **Solid indigo-800 (`#5B21B6`)** was chosen to match the darkest end of the existing gradient spectrum while providing a strong, flat contrast ratio against white text.
- **No shadows** in contrast mode — semi-transparent shadows interfere with the "more contrast" intent.
- **No opacity change on hover** — `hover:opacity-90` is overridden with `hover:opacity-100` so text contrast never dips.
- **Same tokens preserved** — `rounded-xl`, `h-12`, font weights, spacing, and focus-visible rings are unchanged.

## Verification

- All 28 tests pass (5 test files across landing components)
- No new TypeScript errors
- Responsive breakpoints (sm 640, md 768, lg 1024, xl 1280) unaffected — button sizing is unchanged

Closes #772