### PR TITLE
feat: add unread-count badge to dashboard navbar bell icon

### DIFF
--- a/components/dashboard/dashboard-navbar.test.tsx
+++ b/components/dashboard/dashboard-navbar.test.tsx
@@ -11,7 +11,7 @@
  * - Body scroll is locked when drawer is open.
  */
 import React from "react";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent, act, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import DashboardNavbar from "./dashboard-navbar";
 
@@ -246,5 +246,71 @@ describe("DashboardNavbar mobile drawer focus trap", () => {
   it("hamburger button has aria-controls pointing to the drawer", () => {
     render(<DashboardNavbar />);
     expect(getMenuButton()).toHaveAttribute("aria-controls", "dashboard-mobile-drawer");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unread notification badge
+// ---------------------------------------------------------------------------
+
+describe("DashboardNavbar – unread notification badge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function getDesktopNotificationBtn() {
+    return screen.getByRole("button", { name: /notifications/i });
+  }
+
+  it("does not render a badge when unreadCount is 0", () => {
+    render(<DashboardNavbar unreadCount={0} />);
+    const btn = getDesktopNotificationBtn();
+    expect(btn.querySelector(".bg-red-500")).toBeNull();
+  });
+
+  it("renders a badge with the unread count when unreadCount > 0", () => {
+    render(<DashboardNavbar unreadCount={5} />);
+    const btn = getDesktopNotificationBtn();
+    expect(btn.querySelector(".bg-red-500")).toHaveTextContent("5");
+  });
+
+  it("caps the badge at 9+ when unreadCount exceeds 9", () => {
+    render(<DashboardNavbar unreadCount={15} />);
+    const btn = getDesktopNotificationBtn();
+    expect(btn.querySelector(".bg-red-500")).toHaveTextContent("9+");
+  });
+
+  it("includes unread count in aria-label on desktop", () => {
+    render(<DashboardNavbar unreadCount={3} />);
+    expect(getDesktopNotificationBtn()).toHaveAttribute(
+      "aria-label",
+      "Notifications, 3 unread",
+    );
+  });
+
+  it("uses default aria-label when unreadCount is 0", () => {
+    render(<DashboardNavbar unreadCount={0} />);
+    expect(getDesktopNotificationBtn()).toHaveAttribute(
+      "aria-label",
+      "Notifications",
+    );
+  });
+
+  it("renders mobile notification button with badge when open", () => {
+    render(<DashboardNavbar unreadCount={7} />);
+
+    const menuBtn = screen.getByRole("button", { name: /open navigation menu/i });
+    fireEvent.click(menuBtn);
+
+    const drawer = screen.getByRole("dialog", { name: /mobile navigation menu/i });
+    const mobileNotifBtns = within(drawer).getAllByRole("button", { name: "Notifications, 7 unread" });
+    expect(mobileNotifBtns.length).toBeGreaterThanOrEqual(1);
+    expect(mobileNotifBtns[0].querySelector(".bg-red-500")).toHaveTextContent("7");
+  });
+
+  it("defaults to no badge when unreadCount is not provided", () => {
+    render(<DashboardNavbar />);
+    const btn = getDesktopNotificationBtn();
+    expect(btn.querySelector(".bg-red-500")).toBeNull();
   });
 });

--- a/components/dashboard/dashboard-navbar.tsx
+++ b/components/dashboard/dashboard-navbar.tsx
@@ -18,7 +18,14 @@ const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(", ");
 
-export default function DashboardNavbar() {
+interface DashboardNavbarProps {
+  /** Number of unread notifications; hides the badge when 0. */
+  unreadCount?: number;
+}
+
+export default function DashboardNavbar({
+  unreadCount = 0,
+}: DashboardNavbarProps) {
   const { theme, resolvedTheme, toggleTheme } = useTheme();
   const { address, isConnected, connect, disconnect } = useWallet();
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
@@ -131,11 +138,15 @@ export default function DashboardNavbar() {
           </div>
 
           <button
-            aria-label="Notifications"
+            aria-label={`Notifications${unreadCount > 0 ? `, ${unreadCount > 9 ? "9+" : unreadCount} unread` : ""}`}
             className="relative p-2 rounded-lg text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors hidden sm:block cursor-pointer"
           >
             <Bell size={20} strokeWidth={2} />
-            <span className="absolute top-2 right-2.5 w-2 h-2 bg-red-500 rounded-full border-2 border-white dark:border-[#0D0D0D]" />
+            {unreadCount > 0 && (
+              <span className="absolute -top-0.5 -right-0.5 flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-bold leading-none text-white bg-red-500 rounded-full border-2 border-white dark:border-[#0D0D0D]">
+                {unreadCount > 9 ? "9+" : unreadCount}
+              </span>
+            )}
           </button>
 
           <button
@@ -263,14 +274,20 @@ export default function DashboardNavbar() {
             {/* Notifications & Settings row */}
             <div className="flex items-center gap-4">
               <button
-                aria-label="Notifications"
+                aria-label={`Notifications${unreadCount > 0 ? `, ${unreadCount > 9 ? "9+" : unreadCount} unread` : ""}`}
                 className="flex items-center gap-3 p-3 rounded-lg text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer w-full"
               >
-                <Bell size={20} strokeWidth={2} />
+                <div className="relative">
+                  <Bell size={20} strokeWidth={2} />
+                  {unreadCount > 0 && (
+                    <span className="absolute -top-1.5 -right-1.5 flex items-center justify-center min-w-[16px] h-[16px] px-[3px] text-[9px] font-bold leading-none text-white bg-red-500 rounded-full">
+                      {unreadCount > 9 ? "9+" : unreadCount}
+                    </span>
+                  )}
+                </div>
                 <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
                   Notifications
                 </span>
-                <span className="ml-auto w-2 h-2 bg-red-500 rounded-full" />
               </button>
 
               <button

--- a/design/dashboard-redesign.md
+++ b/design/dashboard-redesign.md
@@ -50,6 +50,37 @@ As a stopgap that doesn't invent a new CSS variable, this PR uses the existing `
 
 The obvious "one step down from full text" token is `--muted-foreground`, but at `oklch(55.553%)` (light) it produces roughly a 4:1 contrast ratio against the card background — below the 4.5:1 AA threshold for normal (non-large) 14px text such as the dropdown trigger label and "View All". To avoid regressing contrast, this text was mapped to `text-foreground` instead, which keeps the original ~10:1+ contrast the `zinc-700`/`zinc-900` values had. `text-muted-foreground` remains reserved for decorative, non-text-bearing elements (chevrons) where the WCAG 1.4.11 non-text 3:1 threshold applies instead.
 
+## Dashboard Navbar Unread Notification Badge (#714)
+
+### Overview
+The notification bell in `components/dashboard/dashboard-navbar.tsx` previously showed only a static red dot with no indication of how many notifications were unread. Now it displays a numeric badge reflecting the `unreadCount` prop, with the count capped at "9+" for double-digit values.
+
+### Component Changes
+
+#### `components/dashboard/dashboard-navbar.tsx`
+- Added `unreadCount` prop (optional, defaults to 0)
+- Replaced the static red dot on the desktop bell icon with a numeric badge showing `unreadCount` (or "9+" if > 9)
+- Updated `aria-label` to announce unread count (e.g. "Notifications, 3 unread")
+- Added matching badge to the mobile drawer notification button
+- Badge is hidden entirely when `unreadCount` is 0
+
+### Accessibility (WCAG 2.1 AA)
+- `aria-label` on the notification button includes the unread count so screen reader users hear "Notifications, 3 unread" rather than navigating blindly
+- Badge is visually hidden from the accessibility tree when count is 0 (no redundant "0" announced)
+- Badge colour (red-500 on white) exceeds the 3:1 non-text contrast threshold
+
+### Usage
+```tsx
+<DashboardNavbar unreadCount={unreadNotifications.length} />
+```
+
+### Files changed
+| File | Changes |
+|------|---------|
+| `components/dashboard/dashboard-navbar.tsx` | Added `unreadCount` prop, numeric badge on desktop + mobile bell buttons, updated aria-label |
+| `components/dashboard/dashboard-navbar.test.tsx` | Added tests for badge rendering, capping, aria-label, mobile drawer badge, default state |
+| `design/dashboard-redesign.md` | This section |
+
 ### Out of scope: non-`zinc-*` hardcoded colors
 
 The file also hardcodes non-token hex values that are **not** `zinc-*` utilities and were left untouched per this issue's scope (e.g. `bg-white dark:bg-[#111111]`, `bg-[#0D0D0D80]`, `border-[#2D2D2D]`, `bg-[#121212]`). These represent the same class of design-token debt and would be a reasonable follow-up issue, but reconciling them changes a much larger surface area of the component (including the non-`showNotifications` dark-card visual treatment) than a zinc-vs-token audit calls for.


### PR DESCRIPTION
Closes #714

## Summary
Added an unread-count badge to the notification bell icon in `components/dashboard/dashboard-navbar.tsx`. The badge shows the number of unread notifications (capped at `9+`), updates the `aria-label` to announce the count to screen readers, and hides entirely when the count is zero.

### Changes
- `components/dashboard/dashboard-navbar.tsx`: Added optional `unreadCount` prop (defaults to 0); replaced static red dot on desktop bell with numeric badge; added badge to mobile drawer notification button; updated `aria-label` to include unread count
- `components/dashboard/dashboard-navbar.test.tsx`: Added 7 tests covering badge rendering, capping at 9+, aria-label updates, mobile drawer badge, and default state
- `design/dashboard-redesign.md`: Added documentation section for the unread badge

### Accessibility (WCAG 2.1 AA)
- `aria-label` on notification buttons includes unread count (e.g. "Notifications, 3 unread")
- Badge hidden from accessibility tree when count is 0 (no redundant "0" announced)
- Badge color (red-500 on white) exceeds 3:1 non-text contrast threshold