### PR TITLE
docs: document AbortSignal cancellation semantics in the transactions…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -42,9 +42,9 @@
 
 ## Step 4: Documentation
 
-- [ ] Add TSDoc comments documenting cancellation semantics
+- [x] Add TSDoc comments documenting cancellation semantics
 
 ## Step 5: Run & verify
 
-- [ ] Run `npm run test`
-- [ ] Confirm Vitest coverage thresholds pass
+- [x] Run `npm run test`
+- [x] Confirm Vitest coverage thresholds pass

--- a/hooks/useTransactions.ts
+++ b/hooks/useTransactions.ts
@@ -25,9 +25,71 @@ interface UseTransactionsResult {
 }
 
 /**
- * Hook to fetch transactions with filters, pagination, and loading/error states.
+ * Fetch paginated, filtered transactions with full AbortController-based
+ * cancellation to prevent stale async responses from corrupting UI state.
  *
- * @param options - filters, page, and pageSize
+ * ---
+ *
+ * ### Cancellation lifecycle (per-effect AbortController)
+ *
+ * Every time the effect re-runs (when `filters`, `page`, `pageSize`, or the
+ * internal `tick` counter changes) a **new** `AbortController` is created for
+ * that request. The effect's cleanup function calls `controller.abort()`,
+ * which means:
+ *
+ * - **Filter / page change** — React runs the previous effect's cleanup
+ *   *before* executing the new effect, so the in-flight request for the old
+ *   parameters is aborted before the new one starts.
+ * - **Component unmount** — React runs the cleanup on unmount, aborting any
+ *   pending request so no `setState` call can fire on an unmounted component.
+ * - **`refetch()` call** — increments `tick`, which is in the dependency
+ *   array, triggering the same cleanup-then-rerun cycle.
+ *
+ * ### Request-identity guard (`requestId`)
+ *
+ * In addition to the abort signal, each effect run captures a unique
+ * `Symbol("useTransactions-request")` as `requestId`. Both `.then()` and
+ * `.catch()` callbacks compare the captured `requestId` against
+ * `latestRequestId` before committing any state. This is a belt-and-suspenders
+ * defence: even if an aborted promise somehow resolves instead of rejecting
+ * (which can happen with some polyfills or test doubles), the stale result
+ * cannot overwrite the data from a later request.
+ *
+ * ### AbortError swallowing
+ *
+ * `getTransactions` rejects with a `DOMException` whose `.name` is
+ * `"AbortError"` when the signal fires. This rejection is **not** surfaced to
+ * the caller via the `error` field — it is the expected outcome of the
+ * cancellation lifecycle. The hook detects an AbortError by checking
+ * `err.name === "AbortError"` rather than `instanceof DOMException` because
+ * jsdom's `DOMException` is a cross-realm object that fails `instanceof`
+ * checks in tests.
+ *
+ * ### `refetch` reference stability
+ *
+ * `refetch` is wrapped in `useCallback` with an empty dependency array, so
+ * its reference is stable across renders. It is safe to pass to memoized
+ * child components and dependency arrays without causing extra re-renders.
+ *
+ * @example
+ * ```tsx
+ * function TransactionList() {
+ *   const { data, isLoading, error, refetch } = useTransactions({
+ *     filters: { searchQuery: 'stellar' },
+ *     page: 1,
+ *     pageSize: 10,
+ *   });
+ *
+ *   if (isLoading) return <Spinner />;
+ *   if (error)     return <ErrorBanner message={error} onRetry={refetch} />;
+ *   return <Table rows={data?.data} />;
+ * }
+ * ```
+ *
+ * @param options - Optional filters, page index (1-based), and page size.
+ *   Defaults to `{ page: 1, pageSize: 6 }` with no filters.
+ * @returns `{ data, isLoading, error, refetch }` — current result state and
+ *   a stable callback to manually re-trigger the request.
  */
 export function useTransactions(
   options: UseTransactionsOptions = {},

--- a/lib/api/transactions.ts
+++ b/lib/api/transactions.ts
@@ -84,10 +84,67 @@ const normalizeDateFilter = (
  *
  * Today returns mock data; swap the body for a fetch() when the backend is ready.
  *
+ * ---
+ *
+ * ### AbortSignal / cancellation contract
+ *
+ * The caller is responsible for creating and owning the `AbortController`.
+ * Pass `controller.signal` as the second argument and call `controller.abort()`
+ * whenever the result is no longer needed (e.g. on React effect cleanup, route
+ * change, or component unmount).
+ *
+ * **When abort fires:**
+ *
+ * - *During the dev-mode delay* — the internal `setTimeout` is cleared and the
+ *   delay promise rejects with `new DOMException("Aborted", "AbortError")`,
+ *   which propagates out of `getTransactions` immediately.
+ * - *After the delay, before the synchronous computation begins* — the
+ *   `signal.aborted` guard at the top of the synchronous section throws
+ *   `new DOMException("Aborted", "AbortError")` before any filtering or
+ *   sorting work is performed.
+ * - *In production (no delay)* — only the post-delay `signal.aborted` guard
+ *   applies; when wired to a real `fetch()`, pass the signal directly to
+ *   `fetch()` so the network request is cancelled by the browser as well.
+ *
+ * **What the caller receives on abort:**
+ *
+ * The returned `Promise` rejects with a `DOMException` whose `.name` is
+ * `"AbortError"`. Callers **must not** surface this to the user — it is a
+ * normal part of the cancellation lifecycle. Check `err.name === "AbortError"`
+ * (or `signal.aborted`) and silently discard the rejection.
+ *
+ * **When no signal is provided:**
+ *
+ * The `signal` parameter is optional. Omitting it disables cancellation
+ * support; the promise will always run to completion. This is safe for
+ * one-off, non-reactive call sites.
+ *
+ * @example
+ * ```ts
+ * // React effect — cancel when filters change or component unmounts
+ * useEffect(() => {
+ *   const controller = new AbortController();
+ *
+ *   getTransactions({ filters, page, pageSize }, controller.signal)
+ *     .then(setData)
+ *     .catch((err) => {
+ *       if (err?.name === "AbortError") return; // expected; discard
+ *       setError(err.message);
+ *     });
+ *
+ *   return () => controller.abort();
+ * }, [filters, page, pageSize]);
+ * ```
+ *
  * @param params - Optional transaction filters and pagination values.
+ * @param signal - Optional `AbortSignal` from an `AbortController` owned by
+ *   the caller. When the signal fires, the function rejects with a
+ *   `DOMException` whose `.name` is `"AbortError"`.
  * @returns The validated page of transactions with pagination metadata.
- * @throws RangeError When `filters.fromDate` or `filters.toDate` is non-empty
- * and cannot be parsed as a valid date.
+ * @throws {RangeError} When `filters.fromDate` or `filters.toDate` is
+ *   non-empty and cannot be parsed as a valid date.
+ * @throws {DOMException} With `.name === "AbortError"` when the provided
+ *   `signal` is aborted before or during execution.
  */
 export async function getTransactions(
   params: GetTransactionsParams = {},


### PR DESCRIPTION
… data layer

lib/api/transactions.ts — getTransactions:
- Expand JSDoc to a full TSDoc block describing the AbortSignal contract:
  * Caller owns the AbortController; pass controller.signal as 2nd arg
  * Three abort scenarios: during dev-mode delay, after delay/pre-computation, and in production (via real fetch signal pass-through)
  * Rejection value: DOMException with .name === 'AbortError'
  * Guidance for callers: swallow AbortError, never surface it to the user
  * Behaviour when signal is omitted (cancellation disabled, safe for one-off call sites)
- Add @param signal, @throws {DOMException} tags and a usage example showing the canonical React-effect pattern with cleanup

hooks/useTransactions.ts — useTransactions:
- Replace one-liner JSDoc with comprehensive TSDoc covering:
  * Per-effect AbortController ownership and lifecycle (filter/page change, component unmount, refetch)
  * requestId guard rationale (belt-and-suspenders against polyfill edge cases where an aborted promise resolves instead of rejecting)
  * AbortError swallowing and why .name check is used instead of instanceof (cross-realm DOMException in jsdom fails instanceof)
  * refetch reference stability via useCallback with empty dep array
- Add @param options and @returns tags with a usage example

TODO.md:
- Check off Step 4 (Documentation) and Step 5 (Run & verify)

Closes #836

## Description

<!-- Briefly describe the changes introduced in this pull request. -->

## Related Issue

<!-- Link to the issue(s) this pull request addresses, if any. -->

## Checklist

- [ ] I have tested the changes locally.
- [ ] I have added/updated documentation as needed.
- [ ] I have reviewed the code and ensured it follows the project guidelines.
- [ ] I have added necessary tests.


