### PR TITLE
feat: add jump-to-page input to transactions pagination (#592) 

### DIFF
--- a/components/transactions/transactions-pagination.test.tsx
+++ b/components/transactions/transactions-pagination.test.tsx
@@ -1,12 +1,92 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-import TransactionsPagination from "./transactions-pagination";
+import TransactionsPagination, {
+  clampPage,
+  parsePageInput,
+} from "./transactions-pagination";
 
-describe("TransactionsPagination", () => {
-  it("shows the correct partial last page when total items are not a multiple of page size", () => {
+// ---------------------------------------------------------------------------
+// Helper: default props for a 5-page scenario
+// ---------------------------------------------------------------------------
+const defaultProps = {
+  totalItems: 50,
+  currentPage: 1,
+  itemsPerPage: 10,
+  onPageChange: vi.fn(),
+};
+
+function renderPagination(
+  overrides: Partial<typeof defaultProps> = {},
+) {
+  const props = { ...defaultProps, onPageChange: vi.fn(), ...overrides };
+  return { ...render(<TransactionsPagination {...props} />), onPageChange: props.onPageChange };
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for pure helpers
+// ---------------------------------------------------------------------------
+describe("clampPage", () => {
+  it("returns the page unchanged when it is within range", () => {
+    expect(clampPage(3, 5)).toBe(3);
+  });
+
+  it("clamps to 1 when the value is below 1", () => {
+    expect(clampPage(0, 5)).toBe(1);
+    expect(clampPage(-10, 5)).toBe(1);
+  });
+
+  it("clamps to totalPages when the value exceeds totalPages", () => {
+    expect(clampPage(99, 5)).toBe(5);
+    expect(clampPage(6, 5)).toBe(5);
+  });
+
+  it("returns 1 when totalPages is 0 (no items)", () => {
+    expect(clampPage(0, 0)).toBe(1);
+    expect(clampPage(3, 0)).toBe(1);
+  });
+
+  it("handles boundary values exactly", () => {
+    expect(clampPage(1, 5)).toBe(1);
+    expect(clampPage(5, 5)).toBe(5);
+  });
+});
+
+describe("parsePageInput", () => {
+  it("parses a valid integer string", () => {
+    expect(parsePageInput("3")).toBe(3);
+    expect(parsePageInput("  3  ")).toBe(3); // tolerates surrounding whitespace
+  });
+
+  it("returns null for an empty string", () => {
+    expect(parsePageInput("")).toBeNull();
+    expect(parsePageInput("   ")).toBeNull();
+  });
+
+  it("returns null for non-numeric strings", () => {
+    expect(parsePageInput("abc")).toBeNull();
+    expect(parsePageInput("3a")).toBeNull();
+    expect(parsePageInput("!@#")).toBeNull();
+  });
+
+  it("returns null for floating-point strings (non-integer)", () => {
+    expect(parsePageInput("2.5")).toBeNull();
+    expect(parsePageInput("1.1")).toBeNull();
+  });
+
+  it("returns null for special numeric strings", () => {
+    expect(parsePageInput("Infinity")).toBeNull();
+    expect(parsePageInput("NaN")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: existing pagination behaviour
+// ---------------------------------------------------------------------------
+describe("TransactionsPagination – existing behaviour", () => {
+  it("shows correct summary when total items are not a multiple of page size", () => {
     const onPageChange = vi.fn();
-
     render(
       <TransactionsPagination
         totalItems={13}
@@ -16,9 +96,7 @@ describe("TransactionsPagination", () => {
       />,
     );
 
-    expect(
-      screen.getByText("Showing 13 to 13 of 13 items"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Showing 13 to 13 of 13 items")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Page 4" })).toHaveAttribute(
       "aria-current",
       "page",
@@ -52,5 +130,164 @@ describe("TransactionsPagination", () => {
     expect(
       screen.getByRole("button", { name: /go to next page/i }),
     ).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: jump-to-page UI rendering
+// ---------------------------------------------------------------------------
+describe("TransactionsPagination – jump-to-page rendering", () => {
+  it("renders the jump-to-page label, input and Go button", () => {
+    renderPagination();
+
+    expect(screen.getByRole("spinbutton", { name: /jump to page number/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /go to entered page/i })).toBeInTheDocument();
+    expect(screen.getByText(/go to page/i)).toBeInTheDocument();
+  });
+
+  it("renders the input with the correct type and placeholder", () => {
+    renderPagination({ currentPage: 2 });
+    const input = screen.getByRole("spinbutton", { name: /jump to page number/i });
+    expect(input).toHaveAttribute("type", "number");
+    expect(input).toHaveAttribute("placeholder", "2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: jump-to-page navigation
+// ---------------------------------------------------------------------------
+describe("TransactionsPagination – jump-to-page navigation", () => {
+  it("navigates directly to a valid page number via Go button", async () => {
+    const user = userEvent.setup();
+    const { onPageChange } = renderPagination({ currentPage: 1 });
+
+    const input = screen.getByRole("spinbutton", { name: /jump to page number/i });
+    await user.click(input);
+    await user.type(input, "3");
+    await user.click(screen.getByRole("button", { name: /go to entered page/i }));
+
+    expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+
+  it("navigates directly to a valid page number via Enter key", async () => {
+    const user = userEvent.setup();
+    const { onPageChange } = renderPagination({ currentPage: 1 });
+
+    const input = screen.getByRole("spinbutton", { name: /jump to page number/i });
+    await user.click(input);
+    await user.type(input, "4{Enter}");
+
+    expect(onPageChange).toHaveBeenCalledWith(4);
+  });
+
+  it("clamps a page number lower than 1 to page 1", async () => {
+    const user = userEvent.setup();
+    const { onPageChange } = renderPagination({ currentPage: 3 });
+
+    const input = screen.getByRole("spinbutton", { name: /jump to page number/i });
+    await user.click(input);
+    await user.type(input, "-5{Enter}");
+
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it("clamps a page number higher than totalPages to totalPages", async () => {
+    const user = userEvent.setup();
+    // 50 items / 10 per page = 5 total pages
+    const { onPageChange } = renderPagination({ currentPage: 1 });
+
+    const input = screen.getByRole("spinbutton", { name: /jump to page number/i });
+    await user.click(input);
+    await user.type(input, "999{Enter}");
+
+    expect(onPageChange).toHaveBeenCalledWith(5);
+  });
+
+  it("clamps 0 to page 1", async () => {
+    const user = userEvent.setup();
+    const { onPageChange } = renderPagination({ currentPage: 2 });
+
+    const input = screen.getByRole("spinbutton", { name: /jump to page number/i });
+    await user.click(input);
+    await user.type(input, "0{Enter}");
+
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: invalid / non-numeric input handling
+// ---------------------------------------------------------------------------
+describe("TransactionsPagination – invalid input handling", () => {
+  it("does not call onPageChange for a non-numeric value", async () => {
+    const user = userEvent.setup();
+    const { onPageChange } = renderPagination({ currentPage: 2 });
+
+    const input = screen.getByRole("spinbutton", { name: /jump to page number/i });
+    // userEvent.type on a type="number" input ignores non-numeric keystrokes,
+    // so we fall back to fireEvent / clear+type to inject the value directly.
+    await user.click(input);
+    // Simulate what happens when the input has been given a non-integer value
+    // by clearing and typing a decimal (browser may accept it as text)
+    await user.clear(input);
+    // Type letters — the native number input will ignore them, leaving an empty
+    // string, which our handler treats as invalid.
+    await user.type(input, "abc");
+    await user.click(screen.getByRole("button", { name: /go to entered page/i }));
+
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  it("does not call onPageChange for an empty input and resets to current page", async () => {
+    const user = userEvent.setup();
+    const { onPageChange } = renderPagination({ currentPage: 2 });
+
+    const input = screen.getByRole("spinbutton", { name: /jump to page number/i });
+    await user.click(input);
+    // Leave the input empty and press Go
+    await user.click(screen.getByRole("button", { name: /go to entered page/i }));
+
+    expect(onPageChange).not.toHaveBeenCalled();
+    // Input should be reset to current page
+    expect(input).toHaveValue(2);
+  });
+
+  it("marks the input as aria-invalid when an invalid value is submitted", async () => {
+    const user = userEvent.setup();
+    renderPagination({ currentPage: 2 });
+
+    const input = screen.getByRole("spinbutton", { name: /jump to page number/i });
+    await user.click(input);
+    await user.click(screen.getByRole("button", { name: /go to entered page/i }));
+
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("clears the error state when the user starts typing again after an invalid submission", async () => {
+    const user = userEvent.setup();
+    renderPagination({ currentPage: 2 });
+
+    const input = screen.getByRole("spinbutton", { name: /jump to page number/i });
+
+    // Trigger error
+    await user.click(screen.getByRole("button", { name: /go to entered page/i }));
+    expect(input).toHaveAttribute("aria-invalid", "true");
+
+    // Start typing — error should clear
+    await user.click(input);
+    await user.type(input, "3");
+    expect(input).toHaveAttribute("aria-invalid", "false");
+  });
+
+  it("renders a screen-reader alert when the input is invalid", async () => {
+    const user = userEvent.setup();
+    renderPagination({ currentPage: 2 });
+
+    // Submit empty
+    await user.click(screen.getByRole("button", { name: /go to entered page/i }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /please enter a valid page number/i,
+    );
   });
 });

--- a/components/transactions/transactions-pagination.tsx
+++ b/components/transactions/transactions-pagination.tsx
@@ -13,11 +13,13 @@
  * - Full keyboard navigation (arrow keys, Home, End)
  * - ARIA: role="navigation", aria-label, aria-current="page", aria-disabled
  * - "Showing X to Y of Z items" summary
+ * - Jump-to-page input for direct page navigation
  */
 
-import { useCallback, useId } from "react";
+import { useCallback, useId, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { TransactionsPaginationProps } from "@/types/ui";
 import {
   getStartIndex,
@@ -44,6 +46,43 @@ function buildPageRange(current: number, total: number): (number | "…")[] {
   return pages;
 }
 
+/**
+ * Clamps a raw page number to the valid range `[1, totalPages]`.
+ *
+ * @param raw        - The page number entered by the user (may be any integer).
+ * @param totalPages - The maximum valid page number (inclusive).
+ * @returns          The clamped page number, guaranteed to be ≥ 1 and ≤ totalPages.
+ *
+ * @example
+ * clampPage(0, 5)  // → 1
+ * clampPage(7, 5)  // → 5
+ * clampPage(3, 5)  // → 3
+ */
+export function clampPage(raw: number, totalPages: number): number {
+  return Math.min(Math.max(raw, 1), Math.max(totalPages, 1));
+}
+
+/**
+ * Parses a string value coming from the jump-to-page input.
+ *
+ * @param value - The raw string from the `<input>` element.
+ * @returns The parsed integer, or `null` when the string is empty,
+ *          non-numeric, or not a finite integer.
+ *
+ * @example
+ * parsePageInput("3")    // → 3
+ * parsePageInput("")     // → null
+ * parsePageInput("abc")  // → null
+ * parsePageInput("2.5")  // → null   (non-integer)
+ */
+export function parsePageInput(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || !Number.isFinite(parsed)) return null;
+  return parsed;
+}
+
 export default function TransactionsPagination({
   totalItems,
   currentPage = 1,
@@ -51,6 +90,7 @@ export default function TransactionsPagination({
   onPageChange,
 }: TransactionsPaginationProps) {
   const navId = useId();
+  const jumpInputId = useId();
   const totalPages = getTotalPages(totalItems, itemsPerPage);
 
   // Guard: clamp currentPage to valid range
@@ -62,6 +102,11 @@ export default function TransactionsPagination({
 
   const isFirstPage = safePage === 1;
   const isLastPage = safePage === totalPages || totalPages === 0;
+
+  /** Raw string value of the jump-to-page input. */
+  const [jumpValue, setJumpValue] = useState("");
+  /** Whether the current jump-to-page input value is invalid (non-numeric). */
+  const [jumpError, setJumpError] = useState(false);
 
   const go = useCallback(
     (page: number) => {
@@ -90,6 +135,39 @@ export default function TransactionsPagination({
       }
     },
     [go, safePage, totalPages],
+  );
+
+  /**
+   * Attempts to navigate to the page number currently in the jump input.
+   *
+   * - If the input is empty or non-numeric, marks the field as invalid and
+   *   resets it to the current page so the user gets immediate feedback.
+   * - Otherwise clamps the value to `[1, totalPages]` and calls `onPageChange`.
+   */
+  const handleJump = useCallback(() => {
+    const parsed = parsePageInput(jumpValue);
+
+    if (parsed === null) {
+      // Non-numeric or empty — show error state and reset to current page
+      setJumpError(true);
+      setJumpValue(String(safePage));
+      return;
+    }
+
+    setJumpError(false);
+    setJumpValue("");
+    go(clampPage(parsed, totalPages));
+  }, [jumpValue, safePage, totalPages, go]);
+
+  /** Allow submitting the jump input with the Enter key. */
+  const handleJumpKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleJump();
+      }
+    },
+    [handleJump],
   );
 
   const pageRange = buildPageRange(safePage, totalPages);
@@ -175,6 +253,56 @@ export default function TransactionsPagination({
           className="w-8 h-8 p-0 text-gray-400 hover:bg-white disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <ChevronRight className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </div>
+
+      {/* Jump-to-page controls */}
+      <div
+        className="flex items-center gap-2 order-3"
+        role="group"
+        aria-label="Jump to page"
+      >
+        <label
+          htmlFor={jumpInputId}
+          className="text-gray-400 text-sm whitespace-nowrap"
+        >
+          Go to page
+        </label>
+        <Input
+          id={jumpInputId}
+          type="number"
+          min={1}
+          max={totalPages}
+          value={jumpValue}
+          onChange={(e) => {
+            setJumpValue(e.target.value);
+            setJumpError(false);
+          }}
+          onKeyDown={handleJumpKeyDown}
+          error={jumpError}
+          aria-label="Jump to page number"
+          data-testid="jump-to-page-input"
+          aria-describedby={jumpError ? `${jumpInputId}-error` : undefined}
+          className="w-16 h-8 text-sm text-center"
+          placeholder={String(safePage)}
+        />
+        {jumpError && (
+          <span
+            id={`${jumpInputId}-error`}
+            role="alert"
+            className="sr-only"
+          >
+            Please enter a valid page number.
+          </span>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleJump}
+          aria-label="Go to entered page"
+          className="h-8 px-3 text-sm text-gray-400 hover:bg-white hover:text-black"
+        >
+          Go
         </Button>
       </div>
     </nav>


### PR DESCRIPTION
 Export clampPage and parsePageInput helpers with TSDoc comments - Add controlled numeric input with label, Go button, and Enter key support - Clamp out-of-range values: low → 1, high → totalPages - Show aria-invalid and screen-reader alert on invalid/empty submission - Reset input to current page on invalid submission - Add 24 unit tests covering helpers, rendering, navigation, and error states
Closes #592 
## Description

<!-- Briefly describe the changes introduced in this pull request. -->

## Related Issue

<!-- Link to the issue(s) this pull request addresses, if any. -->

## Checklist

- [ ] I have tested the changes locally.
- [ ] I have added/updated documentation as needed.
- [ ] I have reviewed the code and ensured it follows the project guidelines.
- [ ] I have added necessary tests.

## Screenshots/Recordings

<!-- Attach relevant images or videos to show the effect of your changes. -->

## Additional Notes

<!-- Any other information reviewers should be aware of. -->
