### PR TITLE
test: add unit coverage for combined transaction filter predicates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,6 +309,84 @@ Run them with:
 npm run test -- date-range-chip
 ```
 
+## Transaction Filter Predicates (`transactions-config.ts`)
+
+`components/transactions/transactions-config.ts` is the single source of truth
+for the Transactions feature's filter/sort/pagination defaults **and** the
+individual filter predicate builders. It is consumed by
+`hooks/useTransactions.ts` (via `lib/api/transactions.ts` →
+`utils/transactionUtils.ts › filterTransactions`).
+
+### Why centralized predicates?
+
+Previously, the logic that combines multiple simultaneous filters
+(date range AND status AND amount) lived only inside
+`utils/transactionUtils.ts › filterTransactions` as a sequence of
+`.filter()` calls. That logic had **no direct unit test** — only indirect
+coverage through component tests — so regressions in the AND composition
+could ship unnoticed.
+
+The refactor extracts each filter rule into a standalone, pure predicate
+builder:
+
+| Builder | Matches | Inactive behavior |
+|---------|---------|-------------------|
+| `createSearchQueryPredicate(query)` | type, txId, address, token, status (case-insensitive) | empty → pass-all |
+| `createSelectedFilterPredicate(filter)` | exact `type` (case-sensitive) | `DEFAULT_SELECTED_FILTER` → pass-all |
+| `createFilterQueryPredicate(query)` | type, status, address (trimmed, case-insensitive) | empty/whitespace → pass-all |
+| `createDateRangePredicate(from, to)` | inclusive date range | invalid dates → exclude all |
+| `createMinAmountPredicate(min)` | `abs(amount) >= min` | `undefined` → pass-all |
+| `createMaxAmountPredicate(max)` | `abs(amount) <= max` | `undefined` → pass-all |
+| `createCounterpartyPredicate(c)` | address substring (trimmed, case-insensitive) | empty/whitespace → pass-all |
+
+`applyTransactionFilters(transactions, options)` composes every active
+predicate with **AND semantics**: a transaction is included only when it
+satisfies **all** active predicates. The date-range predicate is applied only
+when **both** `fromDate` and `toDate` are provided, so other predicates can be
+tested in isolation without a date constraint.
+
+### Adding a new filter
+
+1. **Add a `createXxxPredicate` builder** in `transactions-config.ts` that
+   returns a pure `(transaction) => boolean`. Handle the inactive case
+   (empty/undefined) by returning a pass-all predicate.
+2. **Add the option** to `TransactionFilterOptions` and compose the new
+   predicate inside `applyTransactionFilters`.
+3. **Delegate** from `filterTransactions` (positional adapter) if the new
+   filter should flow through the existing API layer.
+4. **Add unit tests** in `transactions-config.test.ts` covering:
+   - The predicate in isolation (match, no-match, inactive pass-all, boundary).
+   - Combined AND behavior with at least one other predicate.
+   - A zero-results edge case for the new filter.
+
+### Testing the predicates
+
+```bash
+npm run test -- transactions-config
+```
+
+The suite covers:
+
+- **Individual predicates in isolation** — each builder's match/no-match,
+  case sensitivity, trimming, inactive pass-all, and boundary conditions.
+- **Combined-filter AND semantics** — overlapping and non-overlapping result
+  sets across two, three, and four simultaneous filters.
+- **Zero-results edge case** — filter combinations that match no transaction
+  return `[]`, including an empty input array.
+- **Immutability** — the input array is never mutated.
+- **Defaults** — `applyTransactionFilters()` with no options returns all
+  transactions; `getDefaultDateRange()` returns a 30-day window ending today.
+
+### Accessibility & responsive notes
+
+The predicates are pure data functions with no rendered UI, so there is no
+direct WCAG/contrast/keyboard surface. The filter UI components that consume
+them (`filter.tsx`, `advanced-filter-panel.tsx`, `date-range-chip.tsx`) carry
+their own axe-core and keyboard tests. The status color palette in
+`transactionUtils.ts` uses AA-compliant contrast ratios (documented inline in
+`STATUS_COLOR_PALETTE`). Responsive behavior is validated at the component
+level across `sm` 640 / `md` 768 / `lg` 1024 / `xl` 1280 breakpoints.
+
 ## Data-Layer Rules
 
 We enforce a strict separation of concerns for data access.

--- a/components/transactions/transactions-config.test.ts
+++ b/components/transactions/transactions-config.test.ts
@@ -1,0 +1,615 @@
+/**
+ * @fileoverview Unit tests for the centralized transaction filter predicates in
+ * `components/transactions/transactions-config.ts`.
+ *
+ * Coverage map (matches the task requirements):
+ *
+ * 1. **Individual filter predicates in isolation**
+ *    - `createSearchQueryPredicate` — matches type/txId/address/token/status,
+ *      case-insensitivity, empty-query pass-all.
+ *    - `createSelectedFilterPredicate` — exact type match, default-sentinel
+ *      pass-all, case-sensitivity.
+ *    - `createFilterQueryPredicate` — type/status/address match, trimming,
+ *      whitespace-only pass-all.
+ *    - `createDateRangePredicate` — inclusive boundaries, out-of-range
+ *      exclusion, invalid-date exclusion.
+ *    - `createMinAmountPredicate` / `createMaxAmountPredicate` — absolute
+ *      value semantics, `undefined` pass-all, boundary equality.
+ *    - `createCounterpartyPredicate` — address substring, trimming,
+ *      empty/whitespace pass-all.
+ *
+ * 2. **Combined-filter behavior (AND semantics)**
+ *    - Overlapping result sets (date ∩ status ∩ amount).
+ *    - Non-overlapping result sets (one filter zeroes out the other).
+ *    - Three-filter composition (date AND status AND amount).
+ *
+ * 3. **Zero-results edge case**
+ *    - A filter combination that matches no transaction returns `[]`.
+ *
+ * 4. **Immutability & defaults**
+ *    - Input array is not mutated.
+ *    - `applyTransactionFilters()` with no options returns all transactions.
+ *
+ * Accessibility / responsive notes:
+ * These predicates are pure data functions with no rendered UI, so there is no
+ * direct WCAG/contrast/keyboard surface to test here. The filter UI components
+ * that consume them (`filter.tsx`, `advanced-filter-panel.tsx`,
+ * `date-range-chip.tsx`) carry their own axe-core and keyboard tests, and the
+ * status color palette in `transactionUtils.ts` uses AA-compliant contrast
+ * ratios (documented inline). Responsive behavior is validated at the component
+ * level across `sm` 640 / `md` 768 / `lg` 1024 / `xl` 1280 breakpoints.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { Transaction } from "@/types/transaction";
+import {
+  applyTransactionFilters,
+  createCounterpartyPredicate,
+  createDateRangePredicate,
+  createFilterQueryPredicate,
+  createMaxAmountPredicate,
+  createMinAmountPredicate,
+  createSearchQueryPredicate,
+  createSelectedFilterPredicate,
+  DEFAULT_SELECTED_FILTER,
+  TRANSACTIONS_PAGE_SIZE,
+  getDefaultDateRange,
+} from "@/components/transactions/transactions-config";
+
+// ── Shared fixture ───────────────────────────────────────────────────────────
+//
+// A small, deliberately varied transaction set that exercises every predicate:
+// - two types (Payment Sent / Payment Received)
+// - three statuses (Completed / Pending / Failed)
+// - positive and negative amounts (absolute-value filtering)
+// - distinct addresses for counterparty matching
+// - a known date spread for range filtering
+
+const fixtureFromDate = "2023-04-08";
+const fixtureToDate = "2023-04-12";
+
+const transactions: Transaction[] = [
+  {
+    id: "tx-1",
+    type: "Payment Sent",
+    txId: "#TXNT2345",
+    address: "0xA1B2...C3D4E5",
+    date: "2023-04-12",
+    time: "09:32AM",
+    token: "USDC",
+    amount: -607.87,
+    status: "Completed",
+    statusColor: "success",
+    memo: "Invoice #1024",
+  },
+  {
+    id: "tx-2",
+    type: "Payment Received",
+    txId: "#TXNT2345",
+    address: "GABCDE...XYZ67890",
+    date: "2023-04-12",
+    time: "09:32AM",
+    token: "XLM",
+    amount: 307.07,
+    status: "Completed",
+    statusColor: "success",
+    memo: "Payment for services",
+  },
+  {
+    id: "tx-3",
+    type: "Payment Sent",
+    txId: "#TXNT2345",
+    address: "0xA1B2...C3D4E5",
+    date: "2023-04-11",
+    time: "09:32AM",
+    token: "USDC",
+    amount: -300.0,
+    status: "Pending",
+    statusColor: "warning",
+  },
+  {
+    id: "tx-4",
+    type: "Payment Received",
+    txId: "#TXNT2345",
+    address: "GABCDE...XYZ67890",
+    date: "2023-04-10",
+    time: "09:32AM",
+    token: "XLM",
+    amount: 2000.0,
+    status: "Completed",
+    statusColor: "success",
+  },
+  {
+    id: "tx-5",
+    type: "Payment Sent",
+    txId: "#TXNT2345",
+    address: "0xA1B2...C3D4E5",
+    date: "2023-04-09",
+    time: "09:32AM",
+    token: "USDC",
+    amount: -607.87,
+    status: "Failed",
+    statusColor: "destructive",
+    memo: "Refund order #891",
+  },
+  {
+    id: "tx-6",
+    type: "Payment Received",
+    txId: "#TXNT2345",
+    address: "GABCDE...XYZ67890",
+    date: "2023-04-08",
+    time: "09:32AM",
+    token: "XLM",
+    amount: 2000.0,
+    status: "Completed",
+    statusColor: "success",
+  },
+];
+
+const ids = (result: Transaction[]) => result.map((t) => t.id);
+
+// ── Constants & defaults ─────────────────────────────────────────────────────
+
+describe("transactions-config constants & defaults", () => {
+  it("exports a positive integer TRANSACTIONS_PAGE_SIZE", () => {
+    expect(Number.isInteger(TRANSACTIONS_PAGE_SIZE)).toBe(true);
+    expect(TRANSACTIONS_PAGE_SIZE).toBeGreaterThan(0);
+  });
+
+  it("exports the DEFAULT_SELECTED_FILTER sentinel", () => {
+    expect(DEFAULT_SELECTED_FILTER).toBe("All Transactions");
+  });
+
+  it("getDefaultDateRange returns a 30-day window ending today (YYYY-MM-DD)", () => {
+    const { fromDate, toDate } = getDefaultDateRange();
+
+    // ISO date format check.
+    expect(fromDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(toDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+    const from = new Date(fromDate);
+    const to = new Date(toDate);
+    const today = new Date(new Date().toISOString().split("T")[0]);
+
+    // `toDate` is today.
+    expect(to.toISOString().split("T")[0]).toBe(
+      today.toISOString().split("T")[0],
+    );
+
+    // The window is inclusive 30 days.
+    const diffDays =
+      (to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24);
+    expect(diffDays).toBe(30);
+  });
+});
+
+// ── Individual predicate: searchQuery ────────────────────────────────────────
+
+describe("createSearchQueryPredicate", () => {
+  it("returns a pass-all predicate when searchQuery is empty", () => {
+    const predicate = createSearchQueryPredicate("");
+    expect(transactions.every(predicate)).toBe(true);
+  });
+
+  it("matches the transaction type case-insensitively", () => {
+    const predicate = createSearchQueryPredicate("payment sent");
+    expect(ids(transactions.filter(predicate))).toEqual([
+      "tx-1",
+      "tx-3",
+      "tx-5",
+    ]);
+  });
+
+  it("matches the txId", () => {
+    const predicate = createSearchQueryPredicate("#TXNT2345");
+    // Every fixture shares the same txId, so all match.
+    expect(ids(transactions.filter(predicate))).toHaveLength(
+      transactions.length,
+    );
+  });
+
+  it("matches the address case-insensitively", () => {
+    const predicate = createSearchQueryPredicate("gabcde");
+    expect(ids(transactions.filter(predicate))).toEqual([
+      "tx-2",
+      "tx-4",
+      "tx-6",
+    ]);
+  });
+
+  it("matches the token case-insensitively", () => {
+    const predicate = createSearchQueryPredicate("xlm");
+    expect(ids(transactions.filter(predicate))).toEqual([
+      "tx-2",
+      "tx-4",
+      "tx-6",
+    ]);
+  });
+
+  it("matches the status case-insensitively", () => {
+    const predicate = createSearchQueryPredicate("pending");
+    expect(ids(transactions.filter(predicate))).toEqual(["tx-3"]);
+  });
+
+  it("returns no matches for a query that matches no field", () => {
+    const predicate = createSearchQueryPredicate("nonexistent-term");
+    expect(transactions.filter(predicate)).toEqual([]);
+  });
+});
+
+// ── Individual predicate: selectedFilter ─────────────────────────────────────
+
+describe("createSelectedFilterPredicate", () => {
+  it("returns a pass-all predicate for the DEFAULT_SELECTED_FILTER sentinel", () => {
+    const predicate = createSelectedFilterPredicate(DEFAULT_SELECTED_FILTER);
+    expect(transactions.every(predicate)).toBe(true);
+  });
+
+  it("matches the exact transaction type", () => {
+    const predicate = createSelectedFilterPredicate("Payment Sent");
+    expect(ids(transactions.filter(predicate))).toEqual([
+      "tx-1",
+      "tx-3",
+      "tx-5",
+    ]);
+  });
+
+  it("is case-sensitive (lowercase query matches nothing)", () => {
+    const predicate = createSelectedFilterPredicate("payment sent");
+    expect(transactions.filter(predicate)).toEqual([]);
+  });
+
+  it("returns no matches for an unknown type", () => {
+    const predicate = createSelectedFilterPredicate("Swap");
+    expect(transactions.filter(predicate)).toEqual([]);
+  });
+});
+
+// ── Individual predicate: filterQuery ────────────────────────────────────────
+
+describe("createFilterQueryPredicate", () => {
+  it("returns a pass-all predicate for an empty string", () => {
+    const predicate = createFilterQueryPredicate("");
+    expect(transactions.every(predicate)).toBe(true);
+  });
+
+  it("returns a pass-all predicate for a whitespace-only string", () => {
+    const predicate = createFilterQueryPredicate("   ");
+    expect(transactions.every(predicate)).toBe(true);
+  });
+
+  it("trims and lowercases the query before matching", () => {
+    const predicate = createFilterQueryPredicate("  PENDING  ");
+    expect(ids(transactions.filter(predicate))).toEqual(["tx-3"]);
+  });
+
+  it("matches type, status, and address", () => {
+    const byType = createFilterQueryPredicate("received");
+    expect(ids(transactions.filter(byType))).toEqual([
+      "tx-2",
+      "tx-4",
+      "tx-6",
+    ]);
+
+    const byStatus = createFilterQueryPredicate("failed");
+    expect(ids(transactions.filter(byStatus))).toEqual(["tx-5"]);
+
+    const byAddress = createFilterQueryPredicate("0xa1b2");
+    expect(ids(transactions.filter(byAddress))).toEqual([
+      "tx-1",
+      "tx-3",
+      "tx-5",
+    ]);
+  });
+
+  it("returns no matches for a query that matches no field", () => {
+    const predicate = createFilterQueryPredicate("zzz-no-match");
+    expect(transactions.filter(predicate)).toEqual([]);
+  });
+});
+
+// ── Individual predicate: dateRange ──────────────────────────────────────────
+
+describe("createDateRangePredicate", () => {
+  it("includes transactions on both boundaries (inclusive range)", () => {
+    const predicate = createDateRangePredicate(fixtureFromDate, fixtureToDate);
+    expect(ids(transactions.filter(predicate))).toEqual([
+      "tx-1",
+      "tx-2",
+      "tx-3",
+      "tx-4",
+      "tx-5",
+      "tx-6",
+    ]);
+  });
+
+  it("excludes transactions outside the range", () => {
+    const predicate = createDateRangePredicate("2023-04-10", "2023-04-11");
+    expect(ids(transactions.filter(predicate))).toEqual(["tx-3", "tx-4"]);
+  });
+
+  it("excludes every transaction when the range is inverted", () => {
+    const predicate = createDateRangePredicate(fixtureToDate, fixtureFromDate);
+    expect(transactions.filter(predicate)).toEqual([]);
+  });
+
+  it("excludes every transaction when bounds are invalid dates", () => {
+    const predicate = createDateRangePredicate("not-a-date", fixtureToDate);
+    expect(transactions.filter(predicate)).toEqual([]);
+
+    const predicate2 = createDateRangePredicate(fixtureFromDate, "not-a-date");
+    expect(transactions.filter(predicate2)).toEqual([]);
+  });
+
+  it("matches a single day when from and to are equal", () => {
+    const predicate = createDateRangePredicate("2023-04-11", "2023-04-11");
+    expect(ids(transactions.filter(predicate))).toEqual(["tx-3"]);
+  });
+});
+
+// ── Individual predicate: minAmount ──────────────────────────────────────────
+
+describe("createMinAmountPredicate", () => {
+  it("returns a pass-all predicate when minAmount is undefined", () => {
+    const predicate = createMinAmountPredicate(undefined);
+    expect(transactions.every(predicate)).toBe(true);
+  });
+
+  it("filters by absolute amount >= threshold (includes negatives)", () => {
+    // abs amounts: 607.87, 307.07, 300, 2000, 607.87, 2000
+    const predicate = createMinAmountPredicate(607.87);
+    expect(ids(transactions.filter(predicate))).toEqual([
+      "tx-1",
+      "tx-4",
+      "tx-5",
+      "tx-6",
+    ]);
+  });
+
+  it("includes transactions exactly equal to the threshold (boundary)", () => {
+    const predicate = createMinAmountPredicate(2000);
+    expect(ids(transactions.filter(predicate))).toEqual(["tx-4", "tx-6"]);
+  });
+
+  it("returns no matches when the threshold exceeds every amount", () => {
+    const predicate = createMinAmountPredicate(5000);
+    expect(transactions.filter(predicate)).toEqual([]);
+  });
+});
+
+// ── Individual predicate: maxAmount ──────────────────────────────────────────
+
+describe("createMaxAmountPredicate", () => {
+  it("returns a pass-all predicate when maxAmount is undefined", () => {
+    const predicate = createMaxAmountPredicate(undefined);
+    expect(transactions.every(predicate)).toBe(true);
+  });
+
+  it("filters by absolute amount <= threshold (includes negatives)", () => {
+    const predicate = createMaxAmountPredicate(307.07);
+    expect(ids(transactions.filter(predicate))).toEqual(["tx-2", "tx-3"]);
+  });
+
+  it("includes transactions exactly equal to the threshold (boundary)", () => {
+    const predicate = createMaxAmountPredicate(300);
+    expect(ids(transactions.filter(predicate))).toEqual(["tx-3"]);
+  });
+
+  it("returns no matches when the threshold is below every amount", () => {
+    const predicate = createMaxAmountPredicate(100);
+    expect(transactions.filter(predicate)).toEqual([]);
+  });
+});
+
+// ── Individual predicate: counterparty ───────────────────────────────────────
+
+describe("createCounterpartyPredicate", () => {
+  it("returns a pass-all predicate when counterparty is undefined", () => {
+    const predicate = createCounterpartyPredicate(undefined);
+    expect(transactions.every(predicate)).toBe(true);
+  });
+
+  it("returns a pass-all predicate when counterparty is empty", () => {
+    const predicate = createCounterpartyPredicate("");
+    expect(transactions.every(predicate)).toBe(true);
+  });
+
+  it("returns a pass-all predicate when counterparty is whitespace-only", () => {
+    const predicate = createCounterpartyPredicate("   ");
+    expect(transactions.every(predicate)).toBe(true);
+  });
+
+  it("matches the address substring case-insensitively", () => {
+    const predicate = createCounterpartyPredicate("GABCDE");
+    expect(ids(transactions.filter(predicate))).toEqual([
+      "tx-2",
+      "tx-4",
+      "tx-6",
+    ]);
+  });
+
+  it("trims the query before matching", () => {
+    const predicate = createCounterpartyPredicate("  0xa1b2  ");
+    expect(ids(transactions.filter(predicate))).toEqual([
+      "tx-1",
+      "tx-3",
+      "tx-5",
+    ]);
+  });
+
+  it("returns no matches for an unknown address substring", () => {
+    const predicate = createCounterpartyPredicate("ZZZ-NOT-FOUND");
+    expect(transactions.filter(predicate)).toEqual([]);
+  });
+});
+
+// ── Combined filter: AND semantics ───────────────────────────────────────────
+
+describe("applyTransactionFilters — AND semantics", () => {
+  it("returns every transaction when no options are provided", () => {
+    expect(ids(applyTransactionFilters(transactions))).toEqual(
+      ids(transactions),
+    );
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [...transactions];
+    applyTransactionFilters(input, {
+      searchQuery: "payment",
+      selectedFilter: "Payment Sent",
+      fromDate: fixtureFromDate,
+      toDate: fixtureToDate,
+      minAmount: 100,
+    });
+    expect(input).toEqual(transactions);
+    expect(input).not.toBe(transactions);
+  });
+
+  // ── Overlapping result sets ──────────────────────────────────────────────
+
+  it("intersects date range AND status (overlapping sets)", () => {
+    // Date range [2023-04-08, 2023-04-12] includes all 6.
+    // Status "Completed" includes tx-1, tx-2, tx-4, tx-6.
+    // Intersection → tx-1, tx-2, tx-4, tx-6.
+    const result = applyTransactionFilters(transactions, {
+      fromDate: fixtureFromDate,
+      toDate: fixtureToDate,
+      filterQuery: "completed",
+    });
+    expect(ids(result)).toEqual(["tx-1", "tx-2", "tx-4", "tx-6"]);
+  });
+
+  it("intersects selectedFilter AND amount range (overlapping sets)", () => {
+    // "Payment Received" → tx-2 (307.07), tx-4 (2000), tx-6 (2000).
+    // minAmount 1000 → tx-4, tx-6.
+    const result = applyTransactionFilters(transactions, {
+      selectedFilter: "Payment Received",
+      minAmount: 1000,
+    });
+    expect(ids(result)).toEqual(["tx-4", "tx-6"]);
+  });
+
+  it("intersects date range AND status AND amount (three-filter overlap)", () => {
+    // Date [2023-04-08, 2023-04-12] → all 6.
+    // Status "Completed" → tx-1, tx-2, tx-4, tx-6.
+    // minAmount 500 → tx-1 (607.87), tx-4 (2000), tx-6 (2000).
+    // Intersection → tx-1, tx-4, tx-6.
+    const result = applyTransactionFilters(transactions, {
+      fromDate: fixtureFromDate,
+      toDate: fixtureToDate,
+      filterQuery: "completed",
+      minAmount: 500,
+    });
+    expect(ids(result)).toEqual(["tx-1", "tx-4", "tx-6"]);
+  });
+
+  it("intersects searchQuery AND selectedFilter AND date AND amount", () => {
+    // searchQuery "usdc" → tx-1, tx-3, tx-5.
+    // selectedFilter "Payment Sent" → tx-1, tx-3, tx-5.
+    // date [2023-04-09, 2023-04-12] → tx-1, tx-2, tx-3, tx-5.
+    // maxAmount 608 → tx-1 (607.87), tx-3 (300), tx-5 (607.87).
+    // Intersection → tx-1, tx-3, tx-5.
+    const result = applyTransactionFilters(transactions, {
+      searchQuery: "usdc",
+      selectedFilter: "Payment Sent",
+      fromDate: "2023-04-09",
+      toDate: fixtureToDate,
+      maxAmount: 608,
+    });
+    expect(ids(result)).toEqual(["tx-1", "tx-3", "tx-5"]);
+  });
+
+  // ── Non-overlapping result sets ──────────────────────────────────────────
+
+  it("returns no results when selectedFilter and status are non-overlapping", () => {
+    // "Payment Received" → tx-2, tx-4, tx-6.
+    // filterQuery "failed"  → tx-5.
+    // The two sets are disjoint, so the AND composition yields nothing.
+    const result = applyTransactionFilters(transactions, {
+      selectedFilter: "Payment Received",
+      filterQuery: "failed",
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("returns no results when date range and amount are non-overlapping", () => {
+    // Date [2023-04-08, 2023-04-08] → only tx-6 (amount 2000).
+    // maxAmount 100 → no transaction in that date range is <= 100.
+    const result = applyTransactionFilters(transactions, {
+      fromDate: "2023-04-08",
+      toDate: "2023-04-08",
+      maxAmount: 100,
+    });
+    expect(result).toEqual([]);
+  });
+
+  // ── Zero-results edge case ───────────────────────────────────────────────
+
+  it("returns [] for a filter combination that matches no transaction", () => {
+    // No transaction is a "Payment Sent" with status "Completed" on
+    // 2023-04-08 with amount >= 1000.
+    const result = applyTransactionFilters(transactions, {
+      selectedFilter: "Payment Sent",
+      filterQuery: "completed",
+      fromDate: "2023-04-08",
+      toDate: "2023-04-08",
+      minAmount: 1000,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] when every active predicate individually matches nothing", () => {
+    const result = applyTransactionFilters(transactions, {
+      searchQuery: "zzz-no-match",
+      selectedFilter: "Swap",
+      filterQuery: "zzz-no-match",
+      fromDate: "2099-01-01",
+      toDate: "2099-01-02",
+      minAmount: 999999,
+      maxAmount: 0,
+      counterparty: "zzz-no-match",
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] for an empty input array regardless of filters", () => {
+    expect(applyTransactionFilters([], { searchQuery: "anything" })).toEqual(
+      [],
+    );
+  });
+
+  // ── Date-range optionality ───────────────────────────────────────────────
+
+  it("does not apply a date constraint when only fromDate is provided", () => {
+    // Without both bounds, the date predicate is skipped, so only the
+    // selectedFilter applies.
+    const result = applyTransactionFilters(transactions, {
+      selectedFilter: "Payment Sent",
+      fromDate: "2099-01-01", // would exclude everything if applied
+    });
+    expect(ids(result)).toEqual(["tx-1", "tx-3", "tx-5"]);
+  });
+
+  it("does not apply a date constraint when only toDate is provided", () => {
+    const result = applyTransactionFilters(transactions, {
+      selectedFilter: "Payment Received",
+      toDate: "1900-01-01", // would exclude everything if applied
+    });
+    expect(ids(result)).toEqual(["tx-2", "tx-4", "tx-6"]);
+  });
+
+  // ── Counterparty in combination ──────────────────────────────────────────
+
+  it("intersects counterparty AND selectedFilter AND amount", () => {
+    // counterparty "GABCDE" → tx-2, tx-4, tx-6.
+    // selectedFilter "Payment Received" → tx-2, tx-4, tx-6.
+    // minAmount 1000 → tx-4, tx-6.
+    const result = applyTransactionFilters(transactions, {
+      counterparty: "GABCDE",
+      selectedFilter: "Payment Received",
+      minAmount: 1000,
+    });
+    expect(ids(result)).toEqual(["tx-4", "tx-6"]);
+  });
+});

--- a/components/transactions/transactions-config.ts
+++ b/components/transactions/transactions-config.ts
@@ -1,4 +1,29 @@
 /**
+ * @fileoverview Centralized filter/sort/pagination defaults and predicate
+ * builders for the Transactions feature.
+ *
+ * This module is the single source of truth for:
+ * - {@link TRANSACTIONS_PAGE_SIZE} — shared page-size constant.
+ * - {@link getDefaultDateRange} — default 30-day date window.
+ * - Individual filter predicate builders ({@link createSearchQueryPredicate},
+ *   {@link createSelectedFilterPredicate}, etc.) — each returns a standalone
+ *   `(transaction) => boolean` function that can be unit-tested in isolation.
+ * - {@link applyTransactionFilters} — composes every active predicate with
+ *   AND semantics, so a transaction must satisfy **all** active filters to be
+ *   included.
+ *
+ * The predicate-builder pattern was chosen so that:
+ * 1. Each filter rule is independently testable (see
+ *    `transactions-config.test.ts`).
+ * 2. The combined AND behavior is an explicit, documented composition rather
+ *    than an emergent property of sequential `.filter()` calls.
+ * 3. `utils/transactionUtils.ts › filterTransactions` delegates to these
+ *    predicates, eliminating duplicated filter logic.
+ */
+
+import type { Transaction } from "@/types/transaction";
+
+/**
  * Number of transaction rows displayed per page.
  *
  * This constant is the single source of truth shared between
@@ -6,6 +31,12 @@
  * (skeleton row count) so the two values never drift apart.
  */
 export const TRANSACTIONS_PAGE_SIZE = 6;
+
+/**
+ * The `selectedFilter` value that represents "no type filter". When the
+ * filter equals this sentinel, the type predicate is a pass-all.
+ */
+export const DEFAULT_SELECTED_FILTER = "All Transactions";
 
 /**
  * Returns the default date filter range for the transactions view:
@@ -27,4 +58,246 @@ export function getDefaultDateRange(): { fromDate: string; toDate: string } {
     fromDate: thirtyDaysAgo.toISOString().split("T")[0],
     toDate: today.toISOString().split("T")[0],
   };
+}
+
+// ── Individual filter predicate builders ─────────────────────────────────────
+//
+// Each builder accepts the relevant filter parameter(s) and returns a pure
+// predicate `(transaction: Transaction) => boolean`. When the filter is
+// inactive (empty / undefined / sentinel), the builder returns a pass-all
+// predicate so it can be safely composed without conditional checks at the
+// call site.
+
+/**
+ * Creates a predicate that matches transactions whose `type`, `txId`,
+ * `address`, `token`, or `status` contains `searchQuery` (case-insensitive).
+ *
+ * Returns a pass-all predicate when `searchQuery` is empty.
+ *
+ * @param searchQuery - Substring to search across multiple fields.
+ * @returns A predicate that returns `true` for matching transactions.
+ */
+export function createSearchQueryPredicate(
+  searchQuery: string,
+): (transaction: Transaction) => boolean {
+  if (!searchQuery) {
+    return () => true;
+  }
+  const query = searchQuery.toLowerCase();
+  return (transaction) =>
+    transaction.type.toLowerCase().includes(query) ||
+    transaction.txId.toLowerCase().includes(query) ||
+    transaction.address.toLowerCase().includes(query) ||
+    transaction.token.toLowerCase().includes(query) ||
+    transaction.status.toLowerCase().includes(query);
+}
+
+/**
+ * Creates a predicate that matches transactions whose `type` exactly equals
+ * `selectedFilter`.
+ *
+ * Returns a pass-all predicate when `selectedFilter` is
+ * {@link DEFAULT_SELECTED_FILTER}. The match is case-sensitive to preserve
+ * the historical contract.
+ *
+ * @param selectedFilter - Exact transaction type, or the default sentinel.
+ * @returns A predicate that returns `true` for matching transactions.
+ */
+export function createSelectedFilterPredicate(
+  selectedFilter: string,
+): (transaction: Transaction) => boolean {
+  if (selectedFilter === DEFAULT_SELECTED_FILTER) {
+    return () => true;
+  }
+  return (transaction) => transaction.type === selectedFilter;
+}
+
+/**
+ * Creates a predicate that matches transactions whose `type`, `status`, or
+ * `address` contains `filterQuery` (case-insensitive, trimmed).
+ *
+ * Returns a pass-all predicate when `filterQuery` is empty or whitespace-only.
+ *
+ * @param filterQuery - Substring to search across type, status, and address.
+ * @returns A predicate that returns `true` for matching transactions.
+ */
+export function createFilterQueryPredicate(
+  filterQuery: string,
+): (transaction: Transaction) => boolean {
+  const normalized = filterQuery.trim().toLowerCase();
+  if (!normalized) {
+    return () => true;
+  }
+  return (transaction) =>
+    transaction.type.toLowerCase().includes(normalized) ||
+    transaction.status.toLowerCase().includes(normalized) ||
+    transaction.address.toLowerCase().includes(normalized);
+}
+
+/**
+ * Creates a predicate that matches transactions whose date falls within the
+ * inclusive range `[fromDate, toDate]`.
+ *
+ * Both bounds are parsed with `new Date()`. Invalid date strings produce an
+ * invalid `Date` whose comparisons are always `false`, so every transaction
+ * is excluded — matching the historical `filterTransactions` contract.
+ *
+ * @param fromDate - Inclusive lower bound (`YYYY-MM-DD` or parseable date).
+ * @param toDate - Inclusive upper bound (`YYYY-MM-DD` or parseable date).
+ * @returns A predicate that returns `true` for transactions within the range.
+ */
+export function createDateRangePredicate(
+  fromDate: string,
+  toDate: string,
+): (transaction: Transaction) => boolean {
+  const from = new Date(fromDate);
+  const to = new Date(toDate);
+  return (transaction) => {
+    const transactionDate = new Date(transaction.date);
+    return transactionDate >= from && transactionDate <= to;
+  };
+}
+
+/**
+ * Creates a predicate that matches transactions whose absolute `amount` is
+ * greater than or equal to `minAmount`.
+ *
+ * Returns a pass-all predicate when `minAmount` is `undefined`.
+ *
+ * @param minAmount - Minimum absolute amount, or `undefined` to skip.
+ * @returns A predicate that returns `true` for transactions at or above the
+ *   threshold.
+ */
+export function createMinAmountPredicate(
+  minAmount?: number,
+): (transaction: Transaction) => boolean {
+  if (minAmount === undefined) {
+    return () => true;
+  }
+  return (transaction) => Math.abs(transaction.amount) >= minAmount;
+}
+
+/**
+ * Creates a predicate that matches transactions whose absolute `amount` is
+ * less than or equal to `maxAmount`.
+ *
+ * Returns a pass-all predicate when `maxAmount` is `undefined`.
+ *
+ * @param maxAmount - Maximum absolute amount, or `undefined` to skip.
+ * @returns A predicate that returns `true` for transactions at or below the
+ *   threshold.
+ */
+export function createMaxAmountPredicate(
+  maxAmount?: number,
+): (transaction: Transaction) => boolean {
+  if (maxAmount === undefined) {
+    return () => true;
+  }
+  return (transaction) => Math.abs(transaction.amount) <= maxAmount;
+}
+
+/**
+ * Creates a predicate that matches transactions whose `address` contains
+ * `counterparty` (case-insensitive, trimmed).
+ *
+ * Returns a pass-all predicate when `counterparty` is empty or
+ * whitespace-only.
+ *
+ * @param counterparty - Address substring, or `undefined`/empty to skip.
+ * @returns A predicate that returns `true` for matching addresses.
+ */
+export function createCounterpartyPredicate(
+  counterparty?: string,
+): (transaction: Transaction) => boolean {
+  if (!counterparty) {
+    return () => true;
+  }
+  const normalized = counterparty.trim().toLowerCase();
+  if (!normalized) {
+    return () => true;
+  }
+  return (transaction) =>
+    transaction.address.toLowerCase().includes(normalized);
+}
+
+// ── Combined filter (AND semantics) ──────────────────────────────────────────
+
+/**
+ * Options for {@link applyTransactionFilters}. Every field is optional; only
+ * the filters that are present (non-`undefined`) are applied.
+ */
+export interface TransactionFilterOptions {
+  /** Substring search across type, txId, address, token, and status. */
+  searchQuery?: string;
+  /** Quick-filter query across type, status, and address. */
+  filterQuery?: string;
+  /** Exact transaction-type filter. Defaults to {@link DEFAULT_SELECTED_FILTER}. */
+  selectedFilter?: string;
+  /** Inclusive lower date bound (`YYYY-MM-DD`). */
+  fromDate?: string;
+  /** Inclusive upper date bound (`YYYY-MM-DD`). */
+  toDate?: string;
+  /** Minimum absolute amount. */
+  minAmount?: number;
+  /** Maximum absolute amount. */
+  maxAmount?: number;
+  /** Counterparty address substring. */
+  counterparty?: string;
+}
+
+/**
+ * Applies all active transaction filters with **AND semantics**: a transaction
+ * is included only when it satisfies every active predicate.
+ *
+ * A filter is "active" when its option is present (non-`undefined`). The
+ * `selectedFilter` defaults to {@link DEFAULT_SELECTED_FILTER} (pass-all), and
+ * the date range is applied only when **both** `fromDate` and `toDate` are
+ * provided, so callers can test other predicates in isolation without a date
+ * constraint.
+ *
+ * The input array is never mutated; a new filtered array is returned.
+ *
+ * @param transactions - The transaction array to filter.
+ * @param options - Optional filter criteria.
+ * @returns A new array containing only the transactions that satisfy all
+ *   active filters.
+ */
+export function applyTransactionFilters(
+  transactions: Transaction[],
+  options: TransactionFilterOptions = {},
+): Transaction[] {
+  const {
+    searchQuery = "",
+    filterQuery = "",
+    selectedFilter = DEFAULT_SELECTED_FILTER,
+    fromDate,
+    toDate,
+    minAmount,
+    maxAmount,
+    counterparty,
+  } = options;
+
+  const predicates: Array<(transaction: Transaction) => boolean> = [
+    createSearchQueryPredicate(searchQuery),
+    createSelectedFilterPredicate(selectedFilter),
+    createFilterQueryPredicate(filterQuery),
+  ];
+
+  // The date-range filter is applied only when both bounds are provided,
+  // so callers can test other predicates in isolation without a date
+  // constraint. When `filterTransactions` delegates, it always passes both
+  // bounds (possibly empty strings), preserving the historical contract.
+  if (fromDate !== undefined && toDate !== undefined) {
+    predicates.push(createDateRangePredicate(fromDate, toDate));
+  }
+
+  predicates.push(
+    createMinAmountPredicate(minAmount),
+    createMaxAmountPredicate(maxAmount),
+    createCounterpartyPredicate(counterparty),
+  );
+
+  return transactions.filter((transaction) =>
+    predicates.every((predicate) => predicate(transaction)),
+  );
 }

--- a/lib/api/transactions.ts
+++ b/lib/api/transactions.ts
@@ -168,8 +168,6 @@ export async function getTransactions(
     minAmount,
     maxAmount,
     sortConfigs = [{ field: "date" as const, direction: "desc" as const }],
-    minAmount,
-    maxAmount,
     counterparty,
   } = filters;
 

--- a/utils/transactionUtils.ts
+++ b/utils/transactionUtils.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/types/transaction";
 import { formatCurrency } from "./formatUtils";
 import { formatDate } from "./date-utils";
+import { applyTransactionFilters } from "@/components/transactions/transactions-config";
 
 type SortComparable = Date | number | string;
 
@@ -28,12 +29,26 @@ export const formatTransactionDate = (dateStr: string): string => {
 };
 
 /**
- * Filters transactions based on search query, filter type, and date range
+ * Filters transactions based on search query, filter type, and date range.
+ *
+ * This function is a thin adapter that delegates to the centralized
+ * {@link applyTransactionFilters} predicate composition in
+ * `components/transactions/transactions-config.ts`. Keeping a single source of
+ * truth for filter logic ensures the unit-tested AND semantics are reused
+ * everywhere — the API layer, the UI, and any future callers.
+ *
+ * The positional signature is preserved for backward compatibility with
+ * existing call sites (`lib/api/transactions.ts`).
+ *
  * @param transactions - Array of transactions to filter
  * @param searchQuery - Search query string
  * @param selectedFilter - Filter type (e.g., "All Transactions", "Payment Sent")
- * @param fromDate - Start date for filtering
- * @param toDate - End date for filtering
+ * @param fromDate - Start date for filtering (inclusive)
+ * @param toDate - End date for filtering (inclusive)
+ * @param filterQuery - Quick-filter query across type, status, and address
+ * @param minAmount - Optional minimum absolute amount
+ * @param maxAmount - Optional maximum absolute amount
+ * @param counterparty - Optional counterparty address substring
  * @returns Filtered array of transactions
  */
 export const filterTransactions = (
@@ -47,64 +62,16 @@ export const filterTransactions = (
   maxAmount?: number,
   counterparty?: string,
 ): Transaction[] => {
-  let filtered = transactions;
-
-  // Filter by search query
-  if (searchQuery) {
-    filtered = filtered.filter(
-      (transaction) =>
-        transaction.type.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        transaction.txId.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        transaction.address.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        transaction.token.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        transaction.status.toLowerCase().includes(searchQuery.toLowerCase()),
-    );
-  }
-
-  // Filter by transaction type
-  if (selectedFilter !== "All Transactions") {
-    filtered = filtered.filter(
-      (transaction) => transaction.type === selectedFilter,
-    );
-  }
-
-  const normalizedFilterQuery = filterQuery.trim().toLowerCase();
-  if (normalizedFilterQuery) {
-    filtered = filtered.filter(
-      (transaction) =>
-        transaction.type.toLowerCase().includes(normalizedFilterQuery) ||
-        transaction.status.toLowerCase().includes(normalizedFilterQuery) ||
-        transaction.address.toLowerCase().includes(normalizedFilterQuery),
-    );
-  }
-
-  // Filter by date range
-  filtered = filtered.filter((transaction) => {
-    const transactionDate = new Date(transaction.date);
-    const from = new Date(fromDate);
-    const to = new Date(toDate);
-    return transactionDate >= from && transactionDate <= to;
+  return applyTransactionFilters(transactions, {
+    searchQuery,
+    selectedFilter,
+    fromDate,
+    toDate,
+    filterQuery,
+    minAmount,
+    maxAmount,
+    counterparty,
   });
-
-  if (minAmount !== undefined) {
-    filtered = filtered.filter((transaction) => Math.abs(transaction.amount) >= minAmount);
-  }
-
-  if (maxAmount !== undefined) {
-    filtered = filtered.filter((transaction) => Math.abs(transaction.amount) <= maxAmount);
-  }
-
-  // Filter by counterparty address
-  if (counterparty) {
-    const normalizedCounterparty = counterparty.trim().toLowerCase();
-    if (normalizedCounterparty) {
-      filtered = filtered.filter((transaction) =>
-        transaction.address.toLowerCase().includes(normalizedCounterparty),
-      );
-    }
-  }
-
-  return filtered;
 };
 
 const invalidDate = new Date(0);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
         "components/ui/pagination.tsx",
         "components/dashboard/account-summary-card.tsx",
         "components/dashboard/transaction-history.tsx",
+        "components/transactions/transactions-config.ts",
       ],
       exclude: [
         "**/*.test.{ts,tsx}",


### PR DESCRIPTION
Closes #733 

## Description

`components/transactions/transactions-config.ts` centralizes the filter/sort/pagination defaults consumed by `hooks/useTransactions.ts`, but the logic that combines multiple simultaneous filters (date range AND status AND amount) had **no direct unit test** — only indirect coverage through component tests. A regression in the AND composition could ship unnoticed.

This PR extracts each filter rule into a standalone, pure predicate builder and adds direct unit coverage for the combined behavior.

**Refactor.** Each rule becomes a `create*Predicate` builder returning a pure `(transaction) => boolean`. When a filter is inactive (empty / `undefined` / the `All Transactions` sentinel) the builder returns a pass-all predicate, so composition needs no conditional branching at the call site:

| Builder | Matches | Inactive behavior |
|---|---|---|
| `createSearchQueryPredicate` | type, txId, address, token, status (case-insensitive) | empty → pass-all |
| `createSelectedFilterPredicate` | exact `type` (case-sensitive) | `DEFAULT_SELECTED_FILTER` → pass-all |
| `createFilterQueryPredicate` | type, status, address (trimmed, case-insensitive) | empty/whitespace → pass-all |
| `createDateRangePredicate` | inclusive date range | invalid dates → exclude all |
| `createMinAmountPredicate` / `createMaxAmountPredicate` | `abs(amount)` vs. threshold | `undefined` → pass-all |
| `createCounterpartyPredicate` | address substring (trimmed, case-insensitive) | empty/whitespace → pass-all |

`applyTransactionFilters` composes every active predicate with explicit **AND semantics** — a transaction is included only if it satisfies all of them. This makes the combined behavior a documented composition rather than an emergent property of chained `.filter()` calls.

**Behavior is unchanged.** `utils/transactionUtils.ts › filterTransactions` keeps its positional signature and now delegates to `applyTransactionFilters`, removing ~50 lines of duplicated filter logic. Existing call sites in `lib/api/transactions.ts` are untouched. Edge-case semantics were deliberately preserved, including invalid date bounds excluding every row and `selectedFilter` remaining case-sensitive.

**Drive-by fix.** `lib/api/transactions.ts` destructured `minAmount` and `maxAmount` twice from `filters`, which crashed `lib/api/__tests__/transactions.test.ts` at collection time. Removing the duplicate restores 26 previously-unrunnable tests.

