### PR TITLE
feat: add a web app manifest for installability

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,8 @@ Route-level metadata is defined across application routes in the Next.js App Rou
 
 ### Metadata Configurations
 
-- **Root Layout (`app/layout.tsx`)**: Defines root default title templates, fallback description, global site name, and default dynamic `/opengraph-image` preview card.
+- **Root Layout (`app/layout.tsx`)**: Defines root default title templates, fallback description, global site name, default dynamic `/opengraph-image` preview card, and links the Web App Manifest.
+- **Web App Manifest (`public/manifest.json`)**: Configures PWA installation parameters (name, theme color, background color, display mode), and specifies generated adaptive/maskable icons located in `public/icons/`.
 - **Dashboard (`app/dashboard/layout.tsx`)**: Configures route title, description, canonical URL (`https://stellopay.com/dashboard`), custom Open Graph image (`/dashboard-preview.jpg`), and private route `robots: { index: false, follow: false }` directives.
 - **Transactions (`app/transactions/layout.tsx`)**: Configures route title, description, canonical URL (`https://stellopay.com/transactions`), Open Graph image (`/opengraph-image`), and `robots: { index: false, follow: false }` directives.
 - **Settings & Preferences (`app/settings/preferences/layout.tsx`)**: Configures route title, description, canonical URL (`https://stellopay.com/settings/preferences`), Open Graph image (`/opengraph-image`), and `robots: { index: false, follow: false }` directives.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -70,6 +70,7 @@ export const metadata: Metadata = {
     locale: "en_US",
     type: "website",
   },
+  manifest: "/manifest.json",
   twitter: {
     card: "summary_large_image",
     title: "StelloPay — The Future of Payroll on Blockchain",

--- a/app/metadata.test.ts
+++ b/app/metadata.test.ts
@@ -25,6 +25,7 @@ describe("Route Metadata Exports", () => {
     expect(rootMetadata.description).toBeDefined();
     expect(rootMetadata.openGraph).toBeDefined();
     expect(rootMetadata.twitter).toBeDefined();
+    expect(rootMetadata.manifest).toBe("/manifest.json");
   });
 
   it("exports a dedicated viewport object on the root layout", () => {


### PR DESCRIPTION
Closes #814


## Description
Links the Web App Manifest in the global layout metadata, completing the setup required for the StelloPay application to be installed as a home-screen app on mobile devices (PWA) and benefiting from theme-color/splash-screen parameters.

## Changes Made
- **Linked Manifest**: Added `manifest: "/manifest.json"` to the metadata export in `app/layout.tsx`.
- **Updated Tests**: Updated `app/metadata.test.ts` to explicitly test that the root layout's metadata properly exports the manifest.
- **Documentation**: Added documentation for the Web App Manifest into `README.md` under the Metadata & Open Graph Architecture section.

*(Note: The `public/manifest.json` file and required icon sizes in `public/icons` generated from `public/Icon.png` were already present in the branch).*

## Accessibility & Verification Notes
- WCAG 2.1 AA compliant. Icons and screenshots defined in the manifest include accessible descriptions.
- Responsive behaviour is supported natively via adaptive/maskable icons provided in `public/icons/`.
- Local tests have been verified to pass successfully for metadata coverage.