### PR TITLE
 Persist filter, sort, and page state to the URL FIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,78 @@
-# StelloPay Frontend
-
+StelloPay Frontend
 StelloPay is a payroll and crypto payments platform built on the Stellar blockchain. This repository contains the web frontend: the marketing/landing site, authentication flows, and an authenticated dashboard for managing transactions, account summaries, and settings.
 
-## Tech Stack
+Tech Stack
+Framework: Next.js 15 (App Router, Turbopack dev server)
+UI: React 19
+Language: TypeScript
+Styling: Tailwind CSS 4 with Radix UI primitives and shadcn-style components
+Forms & validation: react-hook-form + Zod
+Date handling: date-fns (see utils/date-utils.ts)
+Unit testing: Vitest + Testing Library
+E2E testing: Playwright
+Please see our Contributing Guide for details on project structure, the data-layer pattern, testing, and conventions.
 
-- **Framework**: [Next.js 15](https://nextjs.org) (App Router, Turbopack dev server)
-- **UI**: [React 19](https://react.dev)
-- **Language**: [TypeScript](https://www.typescriptlang.org)
-- **Styling**: [Tailwind CSS 4](https://tailwindcss.com) with [Radix UI](https://www.radix-ui.com) primitives and `shadcn`-style components
-- **Forms & validation**: [react-hook-form](https://react-hook-form.com) + [Zod](https://zod.dev)
-- **Date handling**: [date-fns](https://date-fns.org) (see [`utils/date-utils.ts`](utils/date-utils.ts))
-- **Unit testing**: [Vitest](https://vitest.dev) + [Testing Library](https://testing-library.com)
-- **E2E testing**: [Playwright](https://playwright.dev)
+Routing
+This project is App-Router-only. All routes, layouts, and pages live under app/; the legacy pages/ directory was removed (#290). Do not add a pages/ directory.
 
-Please see our [Contributing Guide](CONTRIBUTING.md) for details on project structure, the data-layer pattern, testing, and conventions.
+Transactions URL state
+components/transactions/transactions-content.tsx mirrors the visible transactions list state into the URL query string via next/navigation, so a refreshed, bookmarked, or shared /transactions link reproduces the same slice of data.
 
-## Routing
+Query key	State	Example
+q	Search text	?q=USDC
+filter	Transaction type (sent, received; default all is omitted)	?filter=sent
+from / to	Inclusive ISO date range (YYYY-MM-DD)	?from=2024-02-01&to=2024-02-29
+sort	Primary and optional secondary sort as field.direction	?sort=amount.asc,date.desc
+page	1-based page number; page 1 is omitted	?page=3
+The component reads those parameters once on first load, validates untrusted values, and falls back to the default 30-day range, All Transactions, date.desc, and page 1 when a shared URL is malformed. User-driven updates call router.replace(..., { scroll: false }), not push, so debounced search typing and pagination do not create a new browser-history entry per keystroke or click.
 
-This project is **App-Router-only**. All routes, layouts, and pages live under `app/`; the legacy `pages/` directory was removed (#290). Do not add a `pages/` directory.
+Accessibility and responsive notes:
 
-## Getting Started
+The search input exposes the explicit accessible name Search transactions and stays keyboard operable, including the clear-search button.
+Pagination keeps its keyboard handling and aria-current="page" semantics while the URL updates.
+The existing dark theme tokens and responsive breakpoints remain unchanged (sm 640, md 768, lg 1024, xl 1280); URL synchronization is state-only and does not add breakpoint-specific markup.
+Unrelated query parameters are preserved so future tabs/deep-link context can coexist with transactions filters.
+Focused regression coverage lives in components/transactions/transactions-content.test.tsx and can be run with:
 
-### Prerequisites
+Bash
 
-- Node.js 20 LTS
-- npm — this is the only supported package manager for this repo. `package-lock.json` is the single source of truth for dependency versions; do not generate or commit a `yarn.lock` or `pnpm-lock.yaml` (see [CONTRIBUTING.md](CONTRIBUTING.md)). A `preinstall` check (`scripts/check-package-manager.js`) fails the install if one is present.
+npx vitest run components/transactions/transactions-content.test.tsx --coverage.enabled=false
+Getting Started
+Prerequisites
+Node.js 20 LTS
+npm — this is the only supported package manager for this repo. package-lock.json is the single source of truth for dependency versions; do not generate or commit a yarn.lock or pnpm-lock.yaml (see CONTRIBUTING.md). A preinstall check (scripts/check-package-manager.js) fails the install if one is present.
+Setup
+Bash
 
-### Setup
-
-```bash
 git clone <repository-url>
 cd stellopay-frontend
 npm install
-```
+No environment variables are required to run the app locally — the dashboard is currently backed by mock data in public/data/mock-data.ts and lib/demo-data.ts.
 
-No environment variables are required to run the app locally — the dashboard is currently backed by mock data in [`public/data/mock-data.ts`](public/data/mock-data.ts) and [`lib/demo-data.ts`](lib/demo-data.ts).
+Run the dev server
+Bash
 
-### Run the dev server
-
-```bash
 npm run dev
-```
+Open http://localhost:3000 to see the app. The page auto-updates as you edit files under app/.
 
-Open [http://localhost:3000](http://localhost:3000) to see the app. The page auto-updates as you edit files under `app/`.
+Available Scripts
+Script	Command	Purpose
+Dev server	npm run dev	Starts Next.js with Turbopack
+Build	npm run build	Production build
+Start	npm run start	Serves the production build
+Lint	npm run lint	ESLint via next lint
+Type-check	npm run type-check	tsc --noEmit
+Unit tests	npm run test	Vitest with coverage
+Unit tests (watch)	npm run test:watch	Vitest in watch mode
+E2E tests	npm run test:e2e	Playwright (npx playwright test)
+Format	npm run prettier	Prettier write
+Wallet and network state
+The connected wallet and the active network live in a single React context, WalletProvider, declared in context/wallet-context.tsx. The provider is wrapped around the entire app in the App Router (app/layout.tsx), so every surface that needs to know which account or network is active reads from the same source of truth.
 
-## Available Scripts
+Read the context with the useWallet hook. Calling it outside of a WalletProvider throws an explicit error, which makes provider wiring issues fail loudly during development instead of silently rendering placeholder data.
 
-| Script             | Command              | Purpose                            |
-| ------------------ | -------------------- | ---------------------------------- |
-| Dev server         | `npm run dev`        | Starts Next.js with Turbopack      |
-| Build              | `npm run build`      | Production build                   |
-| Start              | `npm run start`      | Serves the production build        |
-| Lint               | `npm run lint`       | ESLint via `next lint`             |
-| Type-check         | `npm run type-check` | `tsc --noEmit`                     |
-| Unit tests         | `npm run test`       | Vitest with coverage               |
-| Unit tests (watch) | `npm run test:watch` | Vitest in watch mode               |
-| E2E tests          | `npm run test:e2e`   | Playwright (`npx playwright test`) |
-| Format             | `npm run prettier`   | Prettier write                     |
+React
 
-## Wallet and network state
-
-The connected wallet and the active network live in a single React context, `WalletProvider`, declared in `context/wallet-context.tsx`. The provider is wrapped around the entire app in the App Router (`app/layout.tsx`), so every surface that needs to know which account or network is active reads from the same source of truth.
-
-Read the context with the `useWallet` hook. Calling it outside of a `WalletProvider` throws an explicit error, which makes provider wiring issues fail loudly during development instead of silently rendering placeholder data.
-
-```tsx
 import { useWallet, formatAddress } from "@/context/wallet-context";
 
 export function AccountBadge() {
@@ -78,87 +86,66 @@ export function AccountBadge() {
     </span>
   );
 }
-```
-
 The context exposes:
 
-- `address` — the public Stellar G-address of the connected wallet, or `null` when disconnected. Only public material is ever stored or logged. The provider refuses any value that looks like a Stellar secret key (`S` followed by 55 base32 characters).
-- `isConnected` — derived from `address !== null`. Use this for branching rather than null-checking the address yourself.
-- `network` — a `{ id, name }` pair from `SUPPORTED_NETWORKS`. Defaults to Stellar.
-- `connect(address?)` — populates the address. Without an argument it uses a synthetic Stellar-style address for the demo flow. A real wallet integration replaces the body of this function without changing the public surface.
-- `disconnect()` — clears the address. The network selection survives a disconnect.
-- `setNetwork(network)` — switches the active network and persists the id in `localStorage` under `stellopay.wallet.network`. Hydration on the client follows the same SSR-safe pattern as `ThemeProvider` and `SidebarProvider`, so the server render and the first client render agree and React does not flag a hydration mismatch. The address itself is never persisted, so a page reload always returns to a disconnected state.
+address — the public Stellar G-address of the connected wallet, or null when disconnected. Only public material is ever stored or logged. The provider refuses any value that looks like a Stellar secret key (S followed by 55 base32 characters).
+isConnected — derived from address !== null. Use this for branching rather than null-checking the address yourself.
+network — a { id, name } pair from SUPPORTED_NETWORKS. Defaults to Stellar.
+connect(address?) — populates the address. Without an argument it uses a synthetic Stellar-style address for the demo flow. A real wallet integration replaces the body of this function without changing the public surface.
+disconnect() — clears the address. The network selection survives a disconnect.
+setNetwork(network) — switches the active network and persists the id in localStorage under stellopay.wallet.network. Hydration on the client follows the same SSR-safe pattern as ThemeProvider and SidebarProvider, so the server render and the first client render agree and React does not flag a hydration mismatch. The address itself is never persisted, so a page reload always returns to a disconnected state.
+Surfaces that read the context
+components/common/network-switcher.tsx reads the active network and the supported network list from the context. It keeps the existing confirmation dialog, and the selectedNetwork and onNetworkChange props still work for callers that want to treat the switcher as a controlled component.
+components/dashboard/account-overview.tsx shows a Connect Wallet CTA when disconnected and the truncated context address when connected.
+components/dashboard/dashboard-navbar.tsx mirrors the address pill and the network badge from the same context, so the navbar and the dashboard body never disagree.
+Tests
+context/wallet-context.test.tsx — Vitest unit coverage for the reducer surface, the localStorage hydration, the secret-key guard, and the useWallet outside-provider error.
+tests/wallet.spec.ts — Playwright end-to-end coverage for the connect, disconnect, switch network, cancel switch, and reload-persistence flows on /dashboard.
+Run the unit suite with npm test and the end-to-end suite with npx playwright test tests/wallet.spec.ts.
 
-### Surfaces that read the context
-
-- `components/common/network-switcher.tsx` reads the active network and the supported network list from the context. It keeps the existing confirmation dialog, and the `selectedNetwork` and `onNetworkChange` props still work for callers that want to treat the switcher as a controlled component.
-- `components/dashboard/account-overview.tsx` shows a `Connect Wallet` CTA when disconnected and the truncated context address when connected.
-- `components/dashboard/dashboard-navbar.tsx` mirrors the address pill and the network badge from the same context, so the navbar and the dashboard body never disagree.
-
-### Tests
-
-- `context/wallet-context.test.tsx` — Vitest unit coverage for the reducer surface, the localStorage hydration, the secret-key guard, and the `useWallet` outside-provider error.
-- `tests/wallet.spec.ts` — Playwright end-to-end coverage for the connect, disconnect, switch network, cancel switch, and reload-persistence flows on `/dashboard`.
-
-Run the unit suite with `npm test` and the end-to-end suite with `npx playwright test tests/wallet.spec.ts`.
-
-## Error handling
-
+Error handling
 The App Router uses two cooperating client boundaries.
 
-`app/error.tsx` is the route-segment boundary. Any uncaught render or runtime error inside a route segment is caught here. It renders inside the root layout, so it has access to theme tokens and shared UI: a generic "Something went wrong" surface built from `bg-background`, `text-foreground`, and `text-destructive`, plus a "Try again" action wired to the `reset()` callback Next.js passes in, and a "Go to dashboard" escape hatch. The surface uses `role="alert"` and `aria-live="assertive"` so assistive tech announces it. In production, the raw `error.message` and `error.stack` are never rendered; the underlying message is only revealed when `process.env.NODE_ENV !== "production"` to keep debugging cheap locally. The `error.digest` Next.js attaches in production is logged through `console.error` so it can be correlated with server logs, but it is intentionally not surfaced in the UI.
+app/error.tsx is the route-segment boundary. Any uncaught render or runtime error inside a route segment is caught here. It renders inside the root layout, so it has access to theme tokens and shared UI: a generic "Something went wrong" surface built from bg-background, text-foreground, and text-destructive, plus a "Try again" action wired to the reset() callback Next.js passes in, and a "Go to dashboard" escape hatch. The surface uses role="alert" and aria-live="assertive" so assistive tech announces it. In production, the raw error.message and error.stack are never rendered; the underlying message is only revealed when process.env.NODE_ENV !== "production" to keep debugging cheap locally. The error.digest Next.js attaches in production is logged through console.error so it can be correlated with server logs, but it is intentionally not surfaced in the UI.
 
-`app/global-error.tsx` is the wider safety net for when the root layout itself or one of its providers throws. It ships its own `<html>/<body>` shell with inline styles because the layout that loads `globals.css` is exactly what failed.
+app/global-error.tsx is the wider safety net for when the root layout itself or one of its providers throws. It ships its own <html>/<body> shell with inline styles because the layout that loads globals.css is exactly what failed.
 
-Coverage for `app/error.tsx` is gated by the same 95% thresholds as the rest of the suite via `vitest.config.ts`. See `app/error.test.tsx` for the unit coverage.
+Coverage for app/error.tsx is gated by the same 95% thresholds as the rest of the suite via vitest.config.ts. See app/error.test.tsx for the unit coverage.
 
-## Offline Banner
+Offline Banner
+The app surfaces network-connectivity changes through a persistent banner rendered inside the root layout (app/layout.tsx). The component lives at components/common/offline-banner.tsx.
 
-The app surfaces network-connectivity changes through a persistent banner rendered inside the root layout (`app/layout.tsx`). The component lives at [`components/common/offline-banner.tsx`](components/common/offline-banner.tsx).
+Behaviour
+Initial detection: Reads navigator.onLine on mount.
+Live updates: Subscribes to online / offline window events and updates the UI immediately.
+Offline banner: When the browser goes offline, a fixed warning banner with a dismiss button appears at the top of the viewport. The dismiss button hides the banner, but it reappears on the next offline event.
+Reconnection: When connectivity is restored, the banner transitions to a brief success state ("Your internet connection was restored") that auto-dismisses after 3 seconds. The reconnected banner is only shown after a genuine offline → online transition — not on the initial page load.
+Accessibility
+role="alert" and aria-live="assertive" ensure screen readers announce every connectivity change.
+The dismiss button carries a descriptive aria-label.
+Decorative icons are marked aria-hidden="true".
+Colour contrast meets WCAG 2.1 AA in both light and dark themes.
+Tests
+components/common/offline-banner.test.tsx — Vitest unit suite covering online/offline transitions, dismiss behaviour, reconnection state, auto-dismiss timeout, event-listener cleanup, and the negative case where an online event fires on an already-online browser.
+app/layout.test.tsx — Integration test verifying the banner is rendered inside the root layout shell.
+Sitemap & Robots
+The App Router generates both files automatically using the Next.js file-convention handlers:
 
-### Behaviour
+File	Served at	Purpose
+app/sitemap.ts	/sitemap.xml	Enumerates public marketing and help routes for crawler discovery
+app/robots.ts	/robots.txt	Disallows authenticated app routes from being indexed
+Public routes (sitemap)
+URL	changeFrequency	priority
+https://stellopay.com	weekly	1.0
+https://stellopay.com/help/support	monthly	0.8
+https://stellopay.com/help/support/accountManagement	monthly	0.6
+Auth flows (/auth/login, /auth/sign-up, /verify-email) are excluded from the sitemap. They already carry robots: { index: false } in their route metadata and have no organic search value.
 
-- **Initial detection**: Reads `navigator.onLine` on mount.
-- **Live updates**: Subscribes to `online` / `offline` window events and updates the UI immediately.
-- **Offline banner**: When the browser goes offline, a fixed warning banner with a dismiss button appears at the top of the viewport. The dismiss button hides the banner, but it reappears on the next `offline` event.
-- **Reconnection**: When connectivity is restored, the banner transitions to a brief success state ("Your internet connection was restored") that auto-dismisses after 3 seconds. The reconnected banner is only shown after a genuine offline → online transition — not on the initial page load.
+Disallowed routes (robots.txt)
+The following path prefixes are disallowed for all crawlers (*) and Googlebot:
 
-### Accessibility
+text
 
-- `role="alert"` and `aria-live="assertive"` ensure screen readers announce every connectivity change.
-- The dismiss button carries a descriptive `aria-label`.
-- Decorative icons are marked `aria-hidden="true"`.
-- Colour contrast meets WCAG 2.1 AA in both light and dark themes.
-
-### Tests
-
-- [`components/common/offline-banner.test.tsx`](components/common/offline-banner.test.tsx) — Vitest unit suite covering online/offline transitions, dismiss behaviour, reconnection state, auto-dismiss timeout, event-listener cleanup, and the negative case where an `online` event fires on an already-online browser.
-- [`app/layout.test.tsx`](app/layout.test.tsx) — Integration test verifying the banner is rendered inside the root layout shell.
-
-## Sitemap & Robots
-
-The App Router generates both files automatically using the [Next.js file-convention handlers](https://nextjs.org/docs/app/api-reference/file-conventions/metadata):
-
-| File | Served at | Purpose |
-|------|-----------|---------|
-| `app/sitemap.ts` | `/sitemap.xml` | Enumerates public marketing and help routes for crawler discovery |
-| `app/robots.ts` | `/robots.txt` | Disallows authenticated app routes from being indexed |
-
-### Public routes (sitemap)
-
-| URL | changeFrequency | priority |
-|-----|----------------|----------|
-| `https://stellopay.com` | weekly | 1.0 |
-| `https://stellopay.com/help/support` | monthly | 0.8 |
-| `https://stellopay.com/help/support/accountManagement` | monthly | 0.6 |
-
-Auth flows (`/auth/login`, `/auth/sign-up`, `/verify-email`) are **excluded** from the sitemap. They already carry `robots: { index: false }` in their route metadata and have no organic search value.
-
-### Disallowed routes (robots.txt)
-
-The following path prefixes are disallowed for all crawlers (`*`) and Googlebot:
-
-```
 /dashboard
 /transactions
 /account-summary
@@ -166,102 +153,83 @@ The following path prefixes are disallowed for all crawlers (`*`) and Googlebot:
 /settings
 /auth
 /verify-email
-```
+These rules are a belt-and-suspenders defence: the routes also set robots: { index: false, follow: false } in their Next.js metadata, so search engines receive two independent signals not to index them.
 
-These rules are a belt-and-suspenders defence: the routes also set `robots: { index: false, follow: false }` in their Next.js metadata, so search engines receive two independent signals not to index them.
-
-### Exported constants
-
+Exported constants
 Both files export named constants so tests can assert canonical values without duplicating strings:
 
-```ts
+TypeScript
+
 import sitemap, { BASE_URL, PUBLIC_ROUTES } from "@/app/sitemap";
 import robots, { DISALLOWED_PATHS } from "@/app/robots";
 
 BASE_URL         // "https://stellopay.com"
 PUBLIC_ROUTES    // MetadataRoute.Sitemap — array of public route entries
 DISALLOWED_PATHS // string[] — private route prefixes
-```
+Verifying locally
+After starting the dev server (npm run dev) or after a production build (npm run build && npm run start), inspect the generated files directly:
 
-### Verifying locally
+Bash
 
-After starting the dev server (`npm run dev`) or after a production build (`npm run build && npm run start`), inspect the generated files directly:
-
-```bash
 # Sitemap
 curl http://localhost:3000/sitemap.xml
 
 # Robots
 curl http://localhost:3000/robots.txt
-```
+Tests
+Sitemap and robots behaviour is covered in app/metadata.test.ts:
 
-### Tests
+Bash
 
-Sitemap and robots behaviour is covered in `app/metadata.test.ts`:
-
-```bash
 npm test app/metadata.test.ts
-```
-
 The suite asserts:
-- `BASE_URL` matches the canonical domain
-- Every sitemap entry URL is absolute and starts with `BASE_URL`
-- Every entry has a valid `lastModified` date, `changeFrequency`, and `priority`
-- Authenticated and auth-flow routes are absent from the sitemap
-- Every disallowed path is present in the robots rules for both `*` and `Googlebot`
-- The sitemap pointer in `robots.txt` is `https://stellopay.com/sitemap.xml`
 
-## Metadata & Viewport
+BASE_URL matches the canonical domain
+Every sitemap entry URL is absolute and starts with BASE_URL
+Every entry has a valid lastModified date, changeFrequency, and priority
+Authenticated and auth-flow routes are absent from the sitemap
+Every disallowed path is present in the robots rules for both * and Googlebot
+The sitemap pointer in robots.txt is https://stellopay.com/sitemap.xml
+Metadata & Viewport
+Following Next.js 15 conventions, global metadata (titles, descriptions, OpenGraph) and viewport configurations are exported as separate objects in app/layout.tsx.
 
-Following Next.js 15 conventions, global metadata (titles, descriptions, OpenGraph) and viewport configurations are exported as separate objects in `app/layout.tsx`.
+metadata: Contains SEO tags, OpenGraph data, and Twitter cards.
+viewport: Contains responsive design parameters (e.g., width, initialScale) and theme colors for dark/light modes.
+Dynamic Open Graph Image
+app/opengraph-image.tsx implements the Next.js file-convention OG image route. It is served automatically at /opengraph-image and generates a 1200 × 630 px PNG at request time using next/og (ImageResponse / Satori).
 
-- **`metadata`**: Contains SEO tags, OpenGraph data, and Twitter cards.
-- **`viewport`**: Contains responsive design parameters (e.g., `width`, `initialScale`) and theme colors for dark/light modes.
-
-## Dynamic Open Graph Image
-
-`app/opengraph-image.tsx` implements the [Next.js file-convention OG image route](https://nextjs.org/docs/app/api-reference/file-conventions/opengraph-image). It is served automatically at `/opengraph-image` and generates a **1200 × 630 px PNG** at request time using `next/og` (`ImageResponse` / Satori).
-
-### What's rendered
-
-| Element | Detail |
-|---|---|
-| Background | White (`#FFFFFF`) — matches the light-mode hero surface |
-| Badge | Dark pill with the StelloPay brand name and "Blockchain Payroll" label |
-| Headline | Three-line hero h1 — "The Future of / **Payroll on** / Blockchain" |
-| Gradient | "Payroll on" uses the brand gradient: `#2563EB → #7C3AED → #059669` |
-| Tagline | Hero paragraph copy — "Built for modern businesses…" |
-| Font | Clash Display Variable loaded from `public/font/clash-display-variable.ttf` |
-| Decorative blobs | Three radial-gradient orbs mirroring the hero decorative orbs |
-| Accent bar | Bottom-right brand gradient stripe |
-
-### Accessibility
-
+What's rendered
+Element	Detail
+Background	White (#FFFFFF) — matches the light-mode hero surface
+Badge	Dark pill with the StelloPay brand name and "Blockchain Payroll" label
+Headline	Three-line hero h1 — "The Future of / Payroll on / Blockchain"
+Gradient	"Payroll on" uses the brand gradient: #2563EB → #7C3AED → #059669
+Tagline	Hero paragraph copy — "Built for modern businesses…"
+Font	Clash Display Variable loaded from public/font/clash-display-variable.ttf
+Decorative blobs	Three radial-gradient orbs mirroring the hero decorative orbs
+Accent bar	Bottom-right brand gradient stripe
+Accessibility
 The OG image is a static bitmap consumed by crawlers and social previews. WCAG 2.1 AA contrast requirements are met for all rendered text:
 
-| Text element | Foreground | Background | Contrast ratio |
-|---|---|---|---|
-| Headline (dark) | `#09090B` | `#FFFFFF` | ≈ 20.7 : 1 ✓ |
-| Tagline (muted) | `#52525B` | `#FFFFFF` | ≈ 7.0 : 1 ✓ |
-| Badge label | `#FFFFFF` | `#09090B` | ≈ 20.7 : 1 ✓ |
+Text element	Foreground	Background	Contrast ratio
+Headline (dark)	#09090B	#FFFFFF	≈ 20.7 : 1 ✓
+Tagline (muted)	#52525B	#FFFFFF	≈ 7.0 : 1 ✓
+Badge label	#FFFFFF	#09090B	≈ 20.7 : 1 ✓
+The gradient headline ("Payroll on") is decorative text whose semantic equivalent is conveyed by the alt attribute set in openGraph.images[].alt inside app/layout.tsx:
 
-The gradient headline ("Payroll on") is decorative text whose semantic equivalent is conveyed by the `alt` attribute set in `openGraph.images[].alt` inside `app/layout.tsx`:
+"StelloPay — The Future of Payroll on Blockchain. Brand gradient headline on white background."
 
-> "StelloPay — The Future of Payroll on Blockchain. Brand gradient headline on white background."
+File locations
+text
 
-### File locations
-
-```
 app/
 ├─ opengraph-image.tsx       # Route handler — generates the PNG
 └─ opengraph-image.test.ts   # Vitest unit tests
-```
-
-### Exported constants
-
+Exported constants
 The module exports several constants so tests and other files can reference canonical values without duplicating strings:
 
-```ts
+TypeScript
+
 import OGImage, { size, contentType, BRAND_GRADIENT, COLORS, COPY } from "@/app/opengraph-image";
 
 size           // { width: 1200, height: 630 }
@@ -269,34 +237,27 @@ contentType    // "image/png"
 BRAND_GRADIENT // { from: "#2563EB", via: "#7C3AED", to: "#059669" }
 COLORS         // { background, foreground, muted, accent }
 COPY           // { headlinePrefix, headlineGradient, headlineSuffix, tagline, brand, badgeSub }
-```
+Font loading
+The handler reads public/font/clash-display-variable.ttf at request time and passes the ArrayBuffer to ImageResponse via the fonts option. If the file cannot be read (e.g., in a stripped production image), the handler falls back gracefully to the default sans-serif typeface — the image is still generated without throwing.
 
-### Font loading
-
-The handler reads `public/font/clash-display-variable.ttf` at request time and passes the `ArrayBuffer` to `ImageResponse` via the `fonts` option. If the file cannot be read (e.g., in a stripped production image), the handler falls back gracefully to the default sans-serif typeface — the image is still generated without throwing.
-
-### Validating the live image
-
+Validating the live image
 After deploying, inspect the OG image with:
 
-- **Facebook debugger**: https://developers.facebook.com/tools/debug/
-- **Twitter Card validator**: https://cards-dev.twitter.com/validator
-- **OG preview**: https://www.opengraph.xyz/
-
+Facebook debugger: https://developers.facebook.com/tools/debug/
+Twitter Card validator: https://cards-dev.twitter.com/validator
+OG preview: https://www.opengraph.xyz/
 To inspect the raw PNG locally with a running dev server:
 
-```bash
+Bash
+
 npm run dev
 # open http://localhost:3000/opengraph-image
-```
+Keeping copy in sync
+The headline and tagline in app/opengraph-image.tsx are defined in the COPY constant and should be kept in sync with components/landing/hero.tsx. The unit tests assert the exact strings so a mismatch will fail CI.
 
-### Keeping copy in sync
+Project Structure
+text
 
-The headline and tagline in `app/opengraph-image.tsx` are defined in the `COPY` constant and should be kept in sync with `components/landing/hero.tsx`. The unit tests assert the exact strings so a mismatch will fail CI.
-
-## Project Structure
-
-```
 stellopay-frontend
 ├─ app/                  # Next.js App Router routes, layouts, and segment metadata
 │  ├─ account-summary/
@@ -327,44 +288,38 @@ stellopay-frontend
 ├─ tests/                # Playwright E2E specs
 ├─ e2e/                  # Additional Playwright specs
 └─ pages/                # Legacy Pages Router landing page assets
-```
+Settings section structure
+app/settings/preferences is a tabbed shell with five sections — Account
+(profile, identity, and locale defaults), Notifications (transaction alerts
+and delivery-channel toggles), Security (password, 2-FA, and session
+management), Wallets (connected Stellar wallets and transfer safeguards),
+and Statements (downloadable tax summaries and periodic statements) — each
+driven by a ?section=<value> deep-link parameter.
 
-### Settings section structure
-
-`app/settings/preferences` is a tabbed shell with five sections — **Account**
-(profile, identity, and locale defaults), **Notifications** (transaction alerts
-and delivery-channel toggles), **Security** (password, 2-FA, and session
-management), **Wallets** (connected Stellar wallets and transfer safeguards),
-and **Statements** (downloadable tax summaries and periodic statements) — each
-driven by a `?section=<value>` deep-link parameter.
-
-See [design/settings-ia.md](design/settings-ia.md) for the full information
+See design/settings-ia.md for the full information
 architecture: per-tab breakdown, routing behaviour, unsaved-changes guard,
 accessibility requirements, and step-by-step instructions for adding a new
 settings section.
 
-> **Adding a new settings section?** Follow the checklist in
-> `design/settings-ia.md` → *Adding a new settings section*, then update the
-> tab table at the top of that file and add a corresponding subsection. Keep
-> the spec, the code (`buildSections()` in `settings-page-shell.tsx`), and the
-> tests in sync — the spec is the single source of truth for the settings IA.
+Adding a new settings section? Follow the checklist in
+design/settings-ia.md → Adding a new settings section, then update the
+tab table at the top of that file and add a corresponding subsection. Keep
+the spec, the code (buildSections() in settings-page-shell.tsx), and the
+tests in sync — the spec is the single source of truth for the settings IA.
 
-## Design Resources
-
-- **Main Figma Design Workspace**: See [design/figma-design.txt](design/figma-design.txt) for all page-specific layouts (Dashboard, Settings, Help/Support, etc.)
-- **Landing Page Redesign Figma Link**: [Figma Link](https://www.figma.com/design/J4X2XvMo8knspQEEQbHoDN/Stellopay-Landing-page?node-id=0-1&t=edynl8rBO0dXUrXp-1)
-
-## Theme System & Dark Mode
-
+Design Resources
+Main Figma Design Workspace: See design/figma-design.txt for all page-specific layouts (Dashboard, Settings, Help/Support, etc.)
+Landing Page Redesign Figma Link: Figma Link
+Theme System & Dark Mode
 The application uses a context-based theme system with Tailwind CSS and local storage persistence.
 
-### Architecture & Usage
-
-The context provider is configured in `context/theme-context.tsx` and wraps the root layout in `app/layout.tsx`.
+Architecture & Usage
+The context provider is configured in context/theme-context.tsx and wraps the root layout in app/layout.tsx.
 
 You can access and toggle the theme programmatically in components using the custom hook:
 
-```tsx
+React
+
 import { useTheme } from "@/context/theme-context";
 
 export default function MyComponent() {
@@ -376,170 +331,131 @@ export default function MyComponent() {
   // Toggle between light and dark themes
   return <button onClick={toggleTheme}>Toggle Theme</button>;
 }
-```
+Theme Toggle UI: Located in the top-right corner within components/landing/navbar.tsx.
+System Preference: Falls back to the system's preferred color scheme if no preference is stored in localStorage.
+Tailwind Integration: Utilizes Tailwind's native dark: modifier (e.g. bg-white dark:bg-zinc-900) for styling.
+Testing
+npm run test runs the Vitest unit suite with coverage for utils (auth, transactions, pagination, dates), auth schemas, and select components. Coverage thresholds are enforced at 95% (lines/branches/functions/statements) for the files listed in vitest.config.ts.
+npm run test:watch runs Vitest in watch mode while developing unit tests.
+npm run test:e2e runs the full Playwright suite under tests/**/*.spec.ts and e2e/**/*.spec.ts across chromium, firefox, and webkit against a local dev server.
+Unit tests for utils/*.ts are colocated as utils/<name>.test.ts (e.g. utils/date-utils.test.ts); Playwright specs live under tests/*.spec.ts.
+Covered Flows
+Authentication: Validation rules (email format, strong passwords matching), form state, and UI feedback for Login (tests/auth-login.spec.ts), Sign-up (tests/auth-signup.spec.ts), and Email Verification (tests/verify-email.spec.ts).
+Wallet: Connect, disconnect, and network switching (tests/wallet.spec.ts).
+Dashboard: Account overview, settings, and paginated transactions (tests/dashboard.spec.ts, tests/settings.spec.ts, tests/pagination.spec.ts).
+Date utilities
+All date parsing, formatting, and range-checking lives in a single module, utils/date-utils.ts, built on date-fns for deterministic, locale-independent output. Invalid input fails safely: parseTransactionDate returns null and formatDate returns "" rather than throwing.
 
-- **Theme Toggle UI**: Located in the top-right corner within `components/landing/navbar.tsx`.
-- **System Preference**: Falls back to the system's preferred color scheme if no preference is stored in `localStorage`.
-- **Tailwind Integration**: Utilizes Tailwind's native `dark:` modifier (e.g. `bg-white dark:bg-zinc-900`) for styling.
+Accessibility testing
+Automated accessibility scanning runs as part of the Playwright suite using @axe-core/playwright, so a11y regressions (missing labels, low-contrast text, incorrect roles) fail CI the same way a broken assertion would — not just at design-review time.
 
-## Testing
+Shared helper: tests/axe-helper.ts exports expectNoSeriousA11yViolations(page, options?), which scans the current page against WCAG 2.x A/AA + best-practice rules and fails the test if any serious or critical violation is found.
 
-- `npm run test` runs the Vitest unit suite with coverage for utils (auth, transactions, pagination, dates), auth schemas, and select components. Coverage thresholds are enforced at 95% (lines/branches/functions/statements) for the files listed in `vitest.config.ts`.
-- `npm run test:watch` runs Vitest in watch mode while developing unit tests.
-- `npm run test:e2e` runs the full Playwright suite under `tests/**/*.spec.ts` and `e2e/**/*.spec.ts` across **chromium**, **firefox**, and **webkit** against a local dev server.
-- Unit tests for `utils/*.ts` are colocated as `utils/<name>.test.ts` (e.g. [`utils/date-utils.test.ts`](utils/date-utils.test.ts)); Playwright specs live under `tests/*.spec.ts`.
+Where it runs: tests/auth-forms.spec.ts (/auth/login, /auth/sign-up), tests/dashboard.spec.ts (/dashboard), and tests/pagination.spec.ts (/transactions).
 
-### Covered Flows
+Severity thresholds: minor/moderate violations are logged via console.warn (visible in the Playwright report) but do not fail the build — they're worth fixing but shouldn't block shipping. serious/critical violations fail the test.
 
-- **Authentication**: Validation rules (email format, strong passwords matching), form state, and UI feedback for Login (`tests/auth-login.spec.ts`), Sign-up (`tests/auth-signup.spec.ts`), and Email Verification (`tests/verify-email.spec.ts`).
-- **Wallet**: Connect, disconnect, and network switching (`tests/wallet.spec.ts`).
-- **Dashboard**: Account overview, settings, and paginated transactions (`tests/dashboard.spec.ts`, `tests/settings.spec.ts`, `tests/pagination.spec.ts`).
+Triaged allowlist: a known issue that can't be fixed immediately should be allowlisted explicitly, not silenced wholesale — pass it via the allowlist option with a reason (ideally linking a tracking issue):
 
-### Date utilities
+TypeScript
 
-All date parsing, formatting, and range-checking lives in a single module, [`utils/date-utils.ts`](utils/date-utils.ts), built on `date-fns` for deterministic, locale-independent output. Invalid input fails safely: `parseTransactionDate` returns `null` and `formatDate` returns `""` rather than throwing.
+await expectNoSeriousA11yViolations(page, {
+  allowlist: [
+    {
+      id: "color-contrast",
+      reason: "Tracked in #999 — pending design token update",
+    },
+  ],
+});
+Allowlisted violations still print to the console on every run so they stay visible instead of disappearing.
 
-### Accessibility testing
+Running scans locally:
 
-Automated accessibility scanning runs as part of the Playwright suite using [`@axe-core/playwright`](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright), so a11y regressions (missing labels, low-contrast text, incorrect roles) fail CI the same way a broken assertion would — not just at design-review time.
+Bash
 
-- **Shared helper**: [`tests/axe-helper.ts`](tests/axe-helper.ts) exports `expectNoSeriousA11yViolations(page, options?)`, which scans the current page against WCAG 2.x A/AA + best-practice rules and fails the test if any **serious** or **critical** violation is found.
-- **Where it runs**: [`tests/auth-forms.spec.ts`](tests/auth-forms.spec.ts) (`/auth/login`, `/auth/sign-up`), [`tests/dashboard.spec.ts`](tests/dashboard.spec.ts) (`/dashboard`), and [`tests/pagination.spec.ts`](tests/pagination.spec.ts) (`/transactions`).
-- **Severity thresholds**: `minor`/`moderate` violations are logged via `console.warn` (visible in the Playwright report) but do not fail the build — they're worth fixing but shouldn't block shipping. `serious`/`critical` violations fail the test.
-- **Triaged allowlist**: a known issue that can't be fixed immediately should be allowlisted explicitly, not silenced wholesale — pass it via the `allowlist` option with a `reason` (ideally linking a tracking issue):
-
-  ```ts
-  await expectNoSeriousA11yViolations(page, {
-    allowlist: [
-      {
-        id: "color-contrast",
-        reason: "Tracked in #999 — pending design token update",
-      },
-    ],
-  });
-  ```
-
-  Allowlisted violations still print to the console on every run so they stay visible instead of disappearing.
-
-**Running scans locally:**
-
-```bash
 npx playwright test                                # full suite, includes a11y scans
 npx playwright test tests/dashboard.spec.ts         # a single spec
 npx playwright show-report                          # inspect the last HTML report
-```
+Interpreting a failure: the test output includes the axe rule id, impact level, the number of affected DOM nodes (with selectors), and a helpUrl linking to the deque rule documentation explaining the fix. Reproduce locally with npx playwright test --headed <file> to inspect the flagged elements in the browser.
 
-**Interpreting a failure**: the test output includes the axe rule id, impact level, the number of affected DOM nodes (with selectors), and a `helpUrl` linking to the deque rule documentation explaining the fix. Reproduce locally with `npx playwright test --headed <file>` to inspect the flagged elements in the browser.
+Iconography
+To keep the application's bundle light and ensure visual consistency, the project consolidates all UI icons onto Lucide React (lucide-react) as the single primary icon set.
 
-## Iconography
+Guidelines
+Primary Set: Use lucide-react for all UI icons.
+Custom / Brand Icons: For brand logos or unique custom shapes (e.g., StellOpayLogo, StellarIcon), use raw SVG components located in public/svg/svg.tsx or local custom components.
+Restricted Libraries: Do NOT import from react-icons, @hugeicons/react, or @hugeicons/core-free-icons.
+Guardrails
+ESLint Rule: The no-restricted-imports rule in .eslintrc.json blocks imports from restricted packages.
+CI Guard Test: utils/import-guard.test.ts scans all source files in app/ and components/ to verify no prohibited icon libraries are referenced.
+CI Pipeline
+Every pull request and push to main runs two jobs via .github/workflows/ci.yml:
 
-To keep the application's bundle light and ensure visual consistency, the project consolidates all UI icons onto **Lucide React** (`lucide-react`) as the single primary icon set.
+Job	Step	Command	Purpose
+lint-typecheck-build	Install dependencies	npm ci	Reproducible install from lockfile
+Unit Tests	npm run test	Vitest utility/schema tests for auth, transaction, pagination, and date utils, plus auth schemas
+Lint	npm run lint	ESLint via next lint
+Type-check	npm run type-check	tsc --noEmit — catches type errors
+Build	npm run build	Full Next.js production build
+playwright	Install Playwright browsers	npx playwright install --with-deps chromium	Provision the Chromium runtime used by the suite
+E2E + accessibility	npx playwright test	Full Playwright suite, including the axe-core a11y scans described in Accessibility testing — a serious/critical violation fails this job
+On failure, the playwright job uploads the HTML report as a build artifact (playwright-report, retained 7 days) so violations and traces can be inspected without re-running locally.
 
-### Guidelines
+Running a single browser locally
+Pass --project=<name> to target one browser:
 
-- **Primary Set**: Use `lucide-react` for all UI icons.
-- **Custom / Brand Icons**: For brand logos or unique custom shapes (e.g., `StellOpayLogo`, `StellarIcon`), use raw SVG components located in [`public/svg/svg.tsx`](public/svg/svg.tsx) or local custom components.
-- **Restricted Libraries**: Do NOT import from `react-icons`, `@hugeicons/react`, or `@hugeicons/core-free-icons`.
+Bash
 
-### Guardrails
-
-- **ESLint Rule**: The `no-restricted-imports` rule in [`.eslintrc.json`](.eslintrc.json) blocks imports from restricted packages.
-- **CI Guard Test**: [`utils/import-guard.test.ts`](utils/import-guard.test.ts) scans all source files in `app/` and `components/` to verify no prohibited icon libraries are referenced.
-
-## CI Pipeline
-
-Every pull request and push to `main` runs two jobs via `.github/workflows/ci.yml`:
-
-| Job                    | Step                        | Command                                       | Purpose                                                                                                                                                             |
-| ---------------------- | --------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `lint-typecheck-build` | Install dependencies        | `npm ci`                                      | Reproducible install from lockfile                                                                                                                                  |
-|                        | Unit Tests                  | `npm run test`                                | Vitest utility/schema tests for auth, transaction, pagination, and date utils, plus auth schemas                                                                    |
-|                        | Lint                        | `npm run lint`                                | ESLint via `next lint`                                                                                                                                              |
-|                        | Type-check                  | `npm run type-check`                          | `tsc --noEmit` — catches type errors                                                                                                                                |
-|                        | Build                       | `npm run build`                               | Full Next.js production build                                                                                                                                       |
-| `playwright`           | Install Playwright browsers | `npx playwright install --with-deps chromium` | Provision the Chromium runtime used by the suite                                                                                                                    |
-|                        | E2E + accessibility         | `npx playwright test`                         | Full Playwright suite, including the axe-core a11y scans described in [Accessibility testing](#accessibility-testing) — a serious/critical violation fails this job |
-
-On failure, the `playwright` job uploads the HTML report as a build artifact (`playwright-report`, retained 7 days) so violations and traces can be inspected without re-running locally.
-
-### Running a single browser locally
-
-Pass `--project=<name>` to target one browser:
-
-```bash
 npx playwright test --project=chromium
 npx playwright test --project=firefox
 npx playwright test --project=webkit
-```
-
 You can also scope to a single spec file at the same time:
 
-```bash
+Bash
+
 npx playwright test tests/wallet.spec.ts --project=firefox
-```
+Retries
+Tests run with 0 retries locally. In CI (CI=true) each test is retried up to 2 times to absorb transient flakes.
 
-### Retries
-
-Tests run with **0 retries** locally. In CI (`CI=true`) each test is retried up to **2 times** to absorb transient flakes.
-
-## Performance Optimization & Code-Splitting
-
+Performance Optimization & Code-Splitting
 Target performance optimizations were applied across the landing page and dashboard to improve First Paint, LCP (Largest Contentful Paint), and TBT (Total Blocking Time).
 
-### Key Changes
-
-1. **Below-the-Fold Dynamic Imports**: Code-split `HowItWorks`, `EnterpriseSolutionSection`, and `FAQSection` on the landing page ([`components/landing/landing-page.tsx`](components/landing/landing-page.tsx)) using `next/dynamic` to keep the initial HTML payload lightweight.
-2. **Chart & Insights Code-Splitting**: Dynamically loaded the recharts-heavy component ([`AnalyticsViews`](components/analytics/client-analytics-view.tsx)) and KPI metrics ([`AnalyticsInsights`](components/dashboard/dashboard-page.tsx)) with structural skeleton fallbacks equipped with accessibility attributes (`aria-busy="true"` and `aria-live="polite"`).
-3. **Optimized Layout Animations**: Replaced `framer-motion` JS-driven layout width transitions on the sidebar container ([`components/common/side-bar.tsx`](components/common/side-bar.tsx)) with pure CSS grid animations to prevent layout thrashing and lower Total Blocking Time (TBT).
-4. **Hero Image Optimization**: Upgraded native `img` tags for the network logo assets inside the above-the-fold Hero component ([`components/landing/hero.tsx`](components/landing/hero.tsx)) to Next.js `Image` components with explicit dimensions.
-
-### Bundle Size Impact (`next build` Route JS)
-
-| Route                     | Metric        | Before  | After   | Change                |
-| ------------------------- | ------------- | ------- | ------- | --------------------- |
-| `/landing` (Pages Router) | Route Size    | 64.1 kB | 26.1 kB | **-38.0 kB (-59.3%)** |
-| `/landing` (Pages Router) | First Load JS | 165 kB  | 127 kB  | **-38.0 kB (-23.0%)** |
-
-### Bundle Budget
-
+Key Changes
+Below-the-Fold Dynamic Imports: Code-split HowItWorks, EnterpriseSolutionSection, and FAQSection on the landing page (components/landing/landing-page.tsx) using next/dynamic to keep the initial HTML payload lightweight.
+Chart & Insights Code-Splitting: Dynamically loaded the recharts-heavy component (AnalyticsViews) and KPI metrics (AnalyticsInsights) with structural skeleton fallbacks equipped with accessibility attributes (aria-busy="true" and aria-live="polite").
+Optimized Layout Animations: Replaced framer-motion JS-driven layout width transitions on the sidebar container (components/common/side-bar.tsx) with pure CSS grid animations to prevent layout thrashing and lower Total Blocking Time (TBT).
+Hero Image Optimization: Upgraded native img tags for the network logo assets inside the above-the-fold Hero component (components/landing/hero.tsx) to Next.js Image components with explicit dimensions.
+Bundle Size Impact (next build Route JS)
+Route	Metric	Before	After	Change
+/landing (Pages Router)	Route Size	64.1 kB	26.1 kB	-38.0 kB (-59.3%)
+/landing (Pages Router)	First Load JS	165 kB	127 kB	-38.0 kB (-23.0%)
+Bundle Budget
 We maintain a CI-enforced bundle budget for key routes to ensure fast first-load performance.
 
-| Route         | Budget | Current First Load JS |
-| ------------- | ------ | --------------------- |
-| `/` (Landing) | 225 kB | 213 kB                |
-| `/dashboard`  | 180 kB | 165 kB                |
-
+Route	Budget	Current First Load JS
+/ (Landing)	225 kB	213 kB
+/dashboard	180 kB	165 kB
 To run the bundle analyzer locally:
 
-```bash
+Bash
+
 npm run analyze
-```
+Candidate Wins for Optimization
+Icon deduplication: We currently have multiple icon libraries (lucide-react, hugeicons, react-icons). Consolidating all icons to lucide-react will significantly reduce the shared bundle size.
+Dynamic imports for Recharts: Use next/dynamic for chart components in AnalyticsViews and AnalyticsInsights to move heavy visualization logic out of the critical path.
+Centralized Demo Data & Illustrative Stats
+To prevent hardcoded realistic PII (Personal Identifiable Information) and fabricated marketing trust metrics from being shipped inline in production components, this project uses a centralized demo-data configuration located at lib/demo-data.ts.
 
-#### Candidate Wins for Optimization
-
-- **Icon deduplication**: We currently have multiple icon libraries (`lucide-react`, `hugeicons`, `react-icons`). Consolidating all icons to `lucide-react` will significantly reduce the shared bundle size.
-- **Dynamic imports for Recharts**: Use `next/dynamic` for chart components in `AnalyticsViews` and `AnalyticsInsights` to move heavy visualization logic out of the critical path.
-
-## Centralized Demo Data & Illustrative Stats
-
-To prevent hardcoded realistic PII (Personal Identifiable Information) and fabricated marketing trust metrics from being shipped inline in production components, this project uses a centralized demo-data configuration located at `lib/demo-data.ts`.
-
-- **Security Compliance**: All mockup emails, phone numbers, and wallet addresses are set to standard, obvious placeholder domains/values (e.g. `example.com`, `+1 555 0100`, and redacted addresses like `GB-REDACTED-DEMO-STELLAR-ADDRESS-XXXX`). This reduces compliance exposure and prevents test/seed data from being mistaken for active production credentials.
-- **Illustrative Marketing Stats**: Landing page statistics are managed via the same config file and clearly decorated with visual badges indicating they are illustrative placeholders.
-- **Backend Integration**: These structures are designed to be easily replaced by backend API hooks once user authentication, profile retrieval, and wallet connectivity endpoints are finalized.
-
-## Metadata and Open Graph Architecture
-
+Security Compliance: All mockup emails, phone numbers, and wallet addresses are set to standard, obvious placeholder domains/values (e.g. example.com, +1 555 0100, and redacted addresses like GB-REDACTED-DEMO-STELLAR-ADDRESS-XXXX). This reduces compliance exposure and prevents test/seed data from being mistaken for active production credentials.
+Illustrative Marketing Stats: Landing page statistics are managed via the same config file and clearly decorated with visual badges indicating they are illustrative placeholders.
+Backend Integration: These structures are designed to be easily replaced by backend API hooks once user authentication, profile retrieval, and wallet connectivity endpoints are finalized.
+Metadata and Open Graph Architecture
 Route-level metadata is defined across application routes in the Next.js App Router to ensure optimal SEO, canonical URLs, and distinct social preview cards (Open Graph / Twitter).
 
-### Metadata Configurations
-
-- **Root Layout (`app/layout.tsx`)**: Defines root default title templates, fallback description, global site name, and default dynamic `/opengraph-image` preview card.
-- **Dashboard (`app/dashboard/layout.tsx`)**: Configures route title, description, canonical URL (`https://stellopay.com/dashboard`), custom Open Graph image (`/dashboard-preview.jpg`), and private route `robots: { index: false, follow: false }` directives.
-- **Transactions (`app/transactions/layout.tsx`)**: Configures route title, description, canonical URL (`https://stellopay.com/transactions`), Open Graph image (`/opengraph-image`), and `robots: { index: false, follow: false }` directives.
-- **Settings & Preferences (`app/settings/preferences/layout.tsx`)**: Configures route title, description, canonical URL (`https://stellopay.com/settings/preferences`), Open Graph image (`/opengraph-image`), and `robots: { index: false, follow: false }` directives.
-
-### Testing and Validation
-
-All metadata exports are covered by unit tests in `app/metadata.test.ts` to verify uniqueness of titles/descriptions, correct canonical URLs, Open Graph parameters, and fallback logic.
-
+Metadata Configurations
+Root Layout (app/layout.tsx): Defines root default title templates, fallback description, global site name, and default dynamic /opengraph-image preview card.
+Dashboard (app/dashboard/layout.tsx): Configures route title, description, canonical URL (https://stellopay.com/dashboard), custom Open Graph image (/dashboard-preview.jpg), and private route robots: { index: false, follow: false } directives.
+Transactions (app/transactions/layout.tsx): Configures route title, description, canonical URL (https://stellopay.com/transactions), Open Graph image (/opengraph-image), and robots: { index: false, follow: false } directives.
+Settings & Preferences (app/settings/preferences/layout.tsx): Configures route title, description, canonical URL (https://stellopay.com/settings/preferences), Open Graph image (/opengraph-image), and robots: { index: false, follow: false } directives.
+Testing and Validation
+All metadata exports are covered by unit tests in app/metadata.test.ts to verify uniqueness of titles/descriptions, correct canonical URLs, Open Graph parameters, and fallback logic.

--- a/components/common/search-bar.tsx
+++ b/components/common/search-bar.tsx
@@ -3,8 +3,20 @@ import { useEffect, useRef, useState } from "react";
 import { X } from "lucide-react";
 import useSidebar from "@/context/sidebar-context";
 import { SearchIcon } from "@/public/svg/svg";
+import { cn } from "@/utils/commonUtils";
 
 export interface SearchBarProps {
+  /**
+   * Controlled value to display in the input. When omitted, SearchBar manages
+   * its own local value for backward compatibility with existing consumers.
+   */
+  value?: string;
+  /** Input placeholder when the search field is expanded. */
+  placeholder?: string;
+  /** Accessible name for the input. */
+  ariaLabel?: string;
+  /** Extra classes applied to the input element. */
+  className?: string;
   /**
    * Called with the current query as the user types. Debounced by
    * `debounceMs`, except when the query is cleared via the clear button,
@@ -15,9 +27,16 @@ export interface SearchBarProps {
   debounceMs?: number;
 }
 
-export const SearchBar = ({ onSearch, debounceMs = 300 }: SearchBarProps = {}) => {
+export const SearchBar = ({
+  value,
+  placeholder = "Search",
+  ariaLabel = "Search",
+  className,
+  onSearch,
+  debounceMs = 300,
+}: SearchBarProps = {}) => {
   const { isSidebarOpen, isMobile } = useSidebar();
-  const [value, setValue] = useState("");
+  const [draftValue, setDraftValue] = useState(value ?? "");
 
   // Show expanded search on mobile or when desktop sidebar is expanded
   const isExpanded = isMobile || (isSidebarOpen && !isMobile);
@@ -30,48 +49,61 @@ export const SearchBar = ({ onSearch, debounceMs = 300 }: SearchBarProps = {}) =
 
   // Tracks the last query actually delivered to onSearch, so an immediate
   // clear doesn't get re-delivered a second time once the debounce timer
-  // for the pre-clear keystroke fires.
-  const lastSentRef = useRef<string | undefined>(undefined);
+  // for the pre-clear keystroke fires. Initialize from the incoming value so a
+  // controlled URL-initialized search does not fire onSearch on mount.
+  const lastSentRef = useRef<string | undefined>(value ?? "");
+
+  // Synchronize controlled value changes (for example, URL hydration or Clear
+  // all from the transactions toolbar) into the visible draft without treating
+  // the sync itself as a new user search.
+  useEffect(() => {
+    if (value === undefined) return;
+    setDraftValue(value);
+    lastSentRef.current = value;
+  }, [value]);
 
   // Debounce the search callback so it doesn't fire on every keystroke.
   useEffect(() => {
     if (!onSearchRef.current) return;
 
     const timer = setTimeout(() => {
-      if (lastSentRef.current === value) return;
-      lastSentRef.current = value;
-      onSearchRef.current?.(value);
+      if (lastSentRef.current === draftValue) return;
+      lastSentRef.current = draftValue;
+      onSearchRef.current?.(draftValue);
     }, debounceMs);
 
     return () => clearTimeout(timer);
-  }, [value, debounceMs]);
+  }, [draftValue, debounceMs]);
 
   const handleClear = () => {
-    setValue("");
+    setDraftValue("");
     lastSentRef.current = "";
     onSearchRef.current?.("");
   };
 
-  const showClearButton = isExpanded && value !== "";
+  const showClearButton = isExpanded && draftValue !== "";
 
   return (
     <div className="relative w-full">
       <input
         type="text"
-        placeholder={isExpanded ? "Search" : ""}
-        aria-label="Search"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        className={`border border-zinc-200 dark:border-[#2D333E] bg-zinc-50 dark:bg-[#0D0D0D] text-sm font-normal text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-500 dark:placeholder:text-[#98A2B3] py-2 focus:border outline-none focus:border-zinc-300 dark:focus:border-[#464d5c] w-full transition-colors ${
+        placeholder={isExpanded ? placeholder : ""}
+        aria-label={ariaLabel}
+        value={draftValue}
+        onChange={(e) => setDraftValue(e.target.value)}
+        className={cn(
+          "border border-zinc-200 dark:border-[#2D333E] bg-zinc-50 dark:bg-[#0D0D0D] text-sm font-normal text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-500 dark:placeholder:text-[#98A2B3] py-2 focus:border outline-none focus:border-zinc-300 dark:focus:border-[#464d5c] w-full transition-colors",
           isExpanded
             ? `pl-10 rounded-sm ${showClearButton ? "pr-9" : "pr-3"}`
-            : "!px-2 pl-6 rounded-lg"
-        }`}
+            : "!px-2 pl-6 rounded-lg",
+          className,
+        )}
       />
       <div
         className={`absolute ${
           isExpanded ? "left-3" : "left-1/2 -translate-x-1/2"
         } top-1/2 -translate-y-1/2 text-zinc-500 dark:text-zinc-400`}
+        aria-hidden="true"
       >
         <SearchIcon />
       </div>

--- a/components/transactions/transactions-content.test.tsx
+++ b/components/transactions/transactions-content.test.tsx
@@ -1,19 +1,42 @@
 import React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import {
   TRANSACTIONS_PAGE_SIZE,
   getDefaultDateRange,
 } from "./transactions-config";
 import { TransactionsTable } from "./transactions-table";
+import type { TransactionFilters } from "@/types/transaction";
+
+const navigationMock = vi.hoisted(() => ({
+  router: {
+    replace: vi.fn(),
+  },
+  pathname: "/transactions",
+  searchParams: new URLSearchParams(),
+}));
 
 // next/image is not available in jsdom — swap it for a plain <img>.
 vi.mock("next/image", () => ({
   default: ({ src, alt }: { src: string; alt: string }) => (
     <img src={src} alt={alt} />
   ),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => navigationMock.pathname,
+  useRouter: () => navigationMock.router,
+  useSearchParams: () => navigationMock.searchParams,
+}));
+
+vi.mock("@/context/sidebar-context", () => ({
+  __esModule: true,
+  default: () => ({ isSidebarOpen: true, isMobile: false }),
+}));
+
+vi.mock("@/hooks/useTransactions", () => ({
+  useTransactions: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -71,6 +94,118 @@ describe("getDefaultDateRange", () => {
 });
 
 // ---------------------------------------------------------------------------
+// TransactionsContent URL-state helpers
+// ---------------------------------------------------------------------------
+
+import {
+  buildTransactionsQueryString,
+  createDefaultTransactionFilters,
+  parseSortConfigs,
+  parseTransactionsUrlState,
+  serializeSortConfigs,
+} from "./transactions-content";
+
+function makeDeterministicDefaults(): TransactionFilters {
+  return {
+    ...createDefaultTransactionFilters(),
+    fromDate: "2024-01-01",
+    toDate: "2024-01-31",
+    sortConfigs: [{ field: "date", direction: "desc" }],
+  };
+}
+
+describe("TransactionsContent URL query-string helpers", () => {
+  it("parses filter, sort, and page state from URL parameters", () => {
+    const defaults = makeDeterministicDefaults();
+    const params = new URLSearchParams(
+      "q=stellar&filter=sent&from=2024-02-01&to=2024-02-29&sort=amount.asc,status.desc&page=3",
+    );
+
+    const result = parseTransactionsUrlState(params, defaults);
+
+    expect(result.page).toBe(3);
+    expect(result.filters).toMatchObject({
+      searchQuery: "stellar",
+      selectedFilter: "Payment Sent",
+      fromDate: "2024-02-01",
+      toDate: "2024-02-29",
+    });
+    expect(result.filters.sortConfigs).toEqual([
+      { field: "amount", direction: "asc" },
+      { field: "status", direction: "desc" },
+    ]);
+  });
+
+  it("falls back to safe defaults for invalid URL values", () => {
+    const defaults = makeDeterministicDefaults();
+    const params = new URLSearchParams(
+      "filter=unknown&from=2024-99-99&to=not-a-date&sort=hacked.up&page=-2",
+    );
+
+    const result = parseTransactionsUrlState(params, defaults);
+
+    expect(result.page).toBe(1);
+    expect(result.filters.selectedFilter).toBe("All Transactions");
+    expect(result.filters.fromDate).toBe(defaults.fromDate);
+    expect(result.filters.toDate).toBe(defaults.toDate);
+    expect(result.filters.sortConfigs).toEqual(defaults.sortConfigs);
+  });
+
+  it("serializes non-default state while preserving unrelated query parameters", () => {
+    const defaults = makeDeterministicDefaults();
+    const filters: TransactionFilters = {
+      ...defaults,
+      searchQuery: "USDC payroll",
+      selectedFilter: "Payment Received",
+      fromDate: "2024-02-01",
+      toDate: "2024-02-29",
+      sortConfigs: [
+        { field: "amount", direction: "asc" },
+        { field: "date", direction: "desc" },
+      ],
+    };
+
+    const queryString = buildTransactionsQueryString(
+      new URLSearchParams("tab=ledger&page=7&q=old"),
+      { filters, page: 3 },
+      defaults,
+    );
+    const nextParams = new URLSearchParams(queryString);
+
+    expect(nextParams.get("tab")).toBe("ledger");
+    expect(nextParams.get("q")).toBe("USDC payroll");
+    expect(nextParams.get("filter")).toBe("received");
+    expect(nextParams.get("from")).toBe("2024-02-01");
+    expect(nextParams.get("to")).toBe("2024-02-29");
+    expect(nextParams.get("sort")).toBe("amount.asc,date.desc");
+    expect(nextParams.get("page")).toBe("3");
+  });
+
+  it("omits controlled URL parameters when state equals the defaults", () => {
+    const defaults = makeDeterministicDefaults();
+    const queryString = buildTransactionsQueryString(
+      new URLSearchParams("tab=ledger&q=old&page=5"),
+      { filters: defaults, page: 1 },
+      defaults,
+    );
+
+    expect(queryString).toBe("tab=ledger");
+  });
+
+  it("normalizes sort configs to the supported fields and directions", () => {
+    expect(
+      parseSortConfigs("date:asc,amount.desc,amount.asc,bad.desc"),
+    ).toEqual([
+      { field: "date", direction: "asc" },
+      { field: "amount", direction: "desc" },
+    ]);
+    expect(serializeSortConfigs([{ field: "status", direction: "desc" }])).toBe(
+      "status.desc",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // skeleton count parity: TRANSACTIONS_PAGE_SIZE ↔ TransactionsTable rows
 // ---------------------------------------------------------------------------
 
@@ -121,20 +256,37 @@ describe("TransactionsTable skeleton count parity", () => {
 });
 
 // ---------------------------------------------------------------------------
-// TransactionsContent: error vs empty state
+// TransactionsContent: error, empty, and URL state
 // ---------------------------------------------------------------------------
 
 import { useTransactions } from "@/hooks/useTransactions";
 import TransactionsContent from "./transactions-content";
 
-// Mock the hook
-vi.mock("@/hooks/useTransactions", () => ({
-  useTransactions: vi.fn(),
-}));
+function mockTransactionsSuccess(total = 0) {
+  vi.mocked(useTransactions).mockReturnValue({
+    data: {
+      data: [],
+      total,
+      page: 1,
+      pageSize: TRANSACTIONS_PAGE_SIZE,
+      totalPages: Math.max(1, Math.ceil(total / TRANSACTIONS_PAGE_SIZE)),
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+}
 
 describe("TransactionsContent states", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    navigationMock.router.replace.mockClear();
+    navigationMock.pathname = "/transactions";
+    navigationMock.searchParams = new URLSearchParams();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("renders ErrorState with retry when fetch fails", () => {
@@ -147,32 +299,92 @@ describe("TransactionsContent states", () => {
     });
 
     render(<TransactionsContent />);
-    
+
     // Should see error state
     expect(screen.getByRole("alert")).toBeInTheDocument();
     expect(screen.getByText("Network timeout")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
-    
+    expect(
+      screen.getByRole("button", { name: "Try Again" }),
+    ).toBeInTheDocument();
+
     // Retry action is wired
     screen.getByRole("button", { name: "Try Again" }).click();
     expect(mockRefetch).toHaveBeenCalled();
   });
 
   it("renders empty state table when fetch succeeds but returns empty array", () => {
-    vi.mocked(useTransactions).mockReturnValue({
-      data: { data: [], total: 0 },
-      isLoading: false,
-      error: null,
-      refetch: vi.fn(),
-    });
+    mockTransactionsSuccess();
 
     render(<TransactionsContent />);
-    
+
     // No error state
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     // Table empty state
     expect(
-      screen.getAllByText("No transactions found. Try adjusting your filters.")[0]
+      screen.getAllByText(
+        "No transactions found. Try adjusting your filters.",
+      )[0],
     ).toBeInTheDocument();
+  });
+
+  it("initializes filter, sort, and pagination state from the URL", () => {
+    navigationMock.searchParams = new URLSearchParams(
+      "q=stellar&filter=sent&from=2024-02-01&to=2024-02-29&sort=amount.asc,status.desc&page=3",
+    );
+    mockTransactionsSuccess(42);
+
+    render(<TransactionsContent />);
+
+    const firstHookOptions = vi.mocked(useTransactions).mock.calls[0][0];
+
+    expect(firstHookOptions.page).toBe(3);
+    expect(firstHookOptions.pageSize).toBe(TRANSACTIONS_PAGE_SIZE);
+    expect(firstHookOptions.filters).toMatchObject({
+      searchQuery: "stellar",
+      selectedFilter: "Payment Sent",
+      fromDate: "2024-02-01",
+      toDate: "2024-02-29",
+    });
+    expect(firstHookOptions.filters?.sortConfigs).toEqual([
+      { field: "amount", direction: "asc" },
+      { field: "status", direction: "desc" },
+    ]);
+    expect(screen.getByLabelText("Search transactions")).toHaveValue("stellar");
+  });
+
+  it("replaces the current history entry when search state changes", async () => {
+    navigationMock.searchParams = new URLSearchParams("page=4");
+    mockTransactionsSuccess(42);
+
+    render(<TransactionsContent />);
+    navigationMock.router.replace.mockClear();
+
+    fireEvent.change(screen.getByLabelText("Search transactions"), {
+      target: { value: "USDC" },
+    });
+
+    await waitFor(() => {
+      expect(navigationMock.router.replace).toHaveBeenCalledWith(
+        "/transactions?q=USDC",
+        { scroll: false },
+      );
+    });
+  });
+
+  it("replaces the current history entry when pagination changes", async () => {
+    navigationMock.searchParams = new URLSearchParams("q=USDC");
+    mockTransactionsSuccess(42);
+
+    render(<TransactionsContent />);
+    navigationMock.router.replace.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Page 2" }));
+
+    await waitFor(() => {
+      expect(navigationMock.router.replace).toHaveBeenCalledWith(
+        "/transactions?q=USDC&page=2",
+        { scroll: false },
+      );
+    });
   });
 });

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useState, useMemo, useCallback, useRef } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { FileText } from "lucide-react";
 import type {
   SortField,
   SortConfig,
+  SortDirection,
   TransactionFilters,
   Transaction,
   TransactionProps,
@@ -15,11 +18,237 @@ import TransactionsFilters from "./transactions-filters";
 import { TransactionsTable } from "./transactions-table";
 import TransactionsPagination from "./transactions-pagination";
 import { BulkActionBar } from "./bulk-action-bar";
+import { TransactionsStatement } from "./transactions-statement";
 import { ErrorState } from "@/components/ui/error-state";
 import {
   TRANSACTIONS_PAGE_SIZE,
   getDefaultDateRange,
 } from "./transactions-config";
+
+const DEFAULT_SELECTED_FILTER = "All Transactions";
+const DEFAULT_SORT_CONFIGS: readonly SortConfig[] = [
+  { field: "date", direction: "desc" },
+];
+
+const FILTER_QUERY_VALUE_TO_LABEL: Readonly<Record<string, string>> = {
+  all: DEFAULT_SELECTED_FILTER,
+  sent: "Payment Sent",
+  received: "Payment Received",
+};
+
+const FILTER_LABEL_TO_QUERY_VALUE: Readonly<Record<string, string>> = {
+  [DEFAULT_SELECTED_FILTER]: "all",
+  "Payment Sent": "sent",
+  "Payment Received": "received",
+};
+
+const SORT_FIELDS = [
+  "date",
+  "amount",
+  "type",
+  "status",
+] as const satisfies readonly SortField[];
+const SORT_DIRECTIONS = [
+  "asc",
+  "desc",
+] as const satisfies readonly SortDirection[];
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export const TRANSACTIONS_QUERY_KEYS = {
+  search: "q",
+  filter: "filter",
+  fromDate: "from",
+  toDate: "to",
+  sort: "sort",
+  page: "page",
+} as const;
+
+type SearchParamsLike = Pick<URLSearchParams, "get" | "toString">;
+
+export interface TransactionsUrlState {
+  filters: TransactionFilters;
+  page: number;
+}
+
+function cloneSortConfigs(configs: readonly SortConfig[]): SortConfig[] {
+  return configs.map(({ field, direction }) => ({ field, direction }));
+}
+
+export function createDefaultTransactionFilters(): TransactionFilters {
+  return {
+    searchQuery: "",
+    filterQuery: "",
+    ...getDefaultDateRange(),
+    selectedFilter: DEFAULT_SELECTED_FILTER,
+    sortConfigs: cloneSortConfigs(DEFAULT_SORT_CONFIGS),
+  };
+}
+
+function isValidIsoDate(value: string | null): value is string {
+  if (!value || !ISO_DATE_PATTERN.test(value)) return false;
+
+  const parsedDate = new Date(`${value}T00:00:00.000Z`);
+  return (
+    !Number.isNaN(parsedDate.getTime()) &&
+    parsedDate.toISOString().slice(0, 10) === value
+  );
+}
+
+function isSortField(value: string): value is SortField {
+  return (SORT_FIELDS as readonly string[]).includes(value);
+}
+
+function isSortDirection(value: string): value is SortDirection {
+  return (SORT_DIRECTIONS as readonly string[]).includes(value);
+}
+
+function parsePage(value: string | null): number {
+  if (!value) return 1;
+  const numericValue = Number(value);
+  return Number.isInteger(numericValue) && numericValue > 0 ? numericValue : 1;
+}
+
+function parseSelectedFilter(value: string | null): string {
+  if (!value) return DEFAULT_SELECTED_FILTER;
+
+  const normalizedValue = value.trim().toLowerCase();
+  if (normalizedValue in FILTER_QUERY_VALUE_TO_LABEL) {
+    return FILTER_QUERY_VALUE_TO_LABEL[normalizedValue];
+  }
+
+  const matchingLabel = Object.values(FILTER_QUERY_VALUE_TO_LABEL).find(
+    (label) => label.toLowerCase() === normalizedValue,
+  );
+
+  return matchingLabel ?? DEFAULT_SELECTED_FILTER;
+}
+
+function serializeSelectedFilter(label: string): string {
+  return FILTER_LABEL_TO_QUERY_VALUE[label] ?? "all";
+}
+
+export function parseSortConfigs(value: string | null): SortConfig[] {
+  if (!value) return cloneSortConfigs(DEFAULT_SORT_CONFIGS);
+
+  const seenFields = new Set<SortField>();
+  const sortConfigs: SortConfig[] = [];
+
+  for (const rawToken of value.split(",")) {
+    if (sortConfigs.length >= 2) break;
+
+    const token = rawToken.trim();
+    if (!token) continue;
+
+    // Support both `date.desc` and `date:desc` for hand-written links while
+    // always writing the compact dot format back into the address bar.
+    const [field, direction] = token.split(/[.:]/);
+    if (!field || !direction) continue;
+    if (!isSortField(field) || !isSortDirection(direction)) continue;
+    if (seenFields.has(field)) continue;
+
+    seenFields.add(field);
+    sortConfigs.push({ field, direction });
+  }
+
+  return sortConfigs.length > 0
+    ? sortConfigs
+    : cloneSortConfigs(DEFAULT_SORT_CONFIGS);
+}
+
+export function serializeSortConfigs(configs: readonly SortConfig[]): string {
+  const seenFields = new Set<SortField>();
+  const safeConfigs = configs.filter(({ field, direction }) => {
+    if (!isSortField(field) || !isSortDirection(direction)) return false;
+    if (seenFields.has(field)) return false;
+    seenFields.add(field);
+    return true;
+  });
+
+  const configsToSerialize =
+    safeConfigs.length > 0
+      ? safeConfigs
+      : cloneSortConfigs(DEFAULT_SORT_CONFIGS);
+
+  return configsToSerialize
+    .slice(0, 2)
+    .map(({ field, direction }) => `${field}.${direction}`)
+    .join(",");
+}
+
+export function parseTransactionsUrlState(
+  searchParams: SearchParamsLike,
+  defaults: TransactionFilters = createDefaultTransactionFilters(),
+): TransactionsUrlState {
+  const fromDateParam = searchParams.get(TRANSACTIONS_QUERY_KEYS.fromDate);
+  const toDateParam = searchParams.get(TRANSACTIONS_QUERY_KEYS.toDate);
+
+  let fromDate = isValidIsoDate(fromDateParam)
+    ? fromDateParam
+    : defaults.fromDate;
+  let toDate = isValidIsoDate(toDateParam) ? toDateParam : defaults.toDate;
+
+  if (new Date(fromDate) > new Date(toDate)) {
+    fromDate = defaults.fromDate;
+    toDate = defaults.toDate;
+  }
+
+  return {
+    filters: {
+      ...defaults,
+      searchQuery: searchParams.get(TRANSACTIONS_QUERY_KEYS.search) ?? "",
+      selectedFilter: parseSelectedFilter(
+        searchParams.get(TRANSACTIONS_QUERY_KEYS.filter),
+      ),
+      fromDate,
+      toDate,
+      sortConfigs: parseSortConfigs(
+        searchParams.get(TRANSACTIONS_QUERY_KEYS.sort),
+      ),
+    },
+    page: parsePage(searchParams.get(TRANSACTIONS_QUERY_KEYS.page)),
+  };
+}
+
+export function buildTransactionsQueryString(
+  currentSearchParams: SearchParamsLike,
+  state: TransactionsUrlState,
+  defaults: TransactionFilters = createDefaultTransactionFilters(),
+): string {
+  const nextParams = new URLSearchParams(currentSearchParams.toString());
+
+  Object.values(TRANSACTIONS_QUERY_KEYS).forEach((key) => {
+    nextParams.delete(key);
+  });
+
+  const searchQuery = state.filters.searchQuery;
+  if (searchQuery.trim().length > 0) {
+    nextParams.set(TRANSACTIONS_QUERY_KEYS.search, searchQuery);
+  }
+
+  const selectedFilter = serializeSelectedFilter(state.filters.selectedFilter);
+  if (selectedFilter !== "all") {
+    nextParams.set(TRANSACTIONS_QUERY_KEYS.filter, selectedFilter);
+  }
+
+  if (state.filters.fromDate !== defaults.fromDate) {
+    nextParams.set(TRANSACTIONS_QUERY_KEYS.fromDate, state.filters.fromDate);
+  }
+
+  if (state.filters.toDate !== defaults.toDate) {
+    nextParams.set(TRANSACTIONS_QUERY_KEYS.toDate, state.filters.toDate);
+  }
+
+  const serializedSort = serializeSortConfigs(state.filters.sortConfigs);
+  if (serializedSort !== serializeSortConfigs(defaults.sortConfigs)) {
+    nextParams.set(TRANSACTIONS_QUERY_KEYS.sort, serializedSort);
+  }
+
+  if (state.page > 1) {
+    nextParams.set(TRANSACTIONS_QUERY_KEYS.page, String(state.page));
+  }
+
+  return nextParams.toString();
+}
 
 /** Map token symbol → icon path */
 const getTokenIcon = (token: string): string => {
@@ -52,14 +281,32 @@ const toTransactionProps = (t: Transaction): TransactionProps => ({
 });
 
 export default function TransactionsContent() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const defaultFiltersRef = useRef<TransactionFilters | null>(null);
+  if (defaultFiltersRef.current === null) {
+    defaultFiltersRef.current = createDefaultTransactionFilters();
+  }
+
+  const initialUrlStateRef = useRef<TransactionsUrlState | null>(null);
+  if (initialUrlStateRef.current === null) {
+    initialUrlStateRef.current = parseTransactionsUrlState(
+      searchParams,
+      defaultFiltersRef.current,
+    );
+  }
+
+  const defaultFilters = defaultFiltersRef.current;
+  const initialUrlState = initialUrlStateRef.current;
+  const currentQueryString = searchParams.toString();
+
   const [filters, setFilters] = useState<TransactionFilters>(() => ({
-    searchQuery: "",
-    filterQuery: "",
-    ...getDefaultDateRange(),
-    selectedFilter: "All Transactions",
-    sortConfigs: [{ field: "date", direction: "desc" }],
+    ...initialUrlState.filters,
+    sortConfigs: cloneSortConfigs(initialUrlState.filters.sortConfigs),
   }));
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(initialUrlState.page);
   const [statementRange, setStatementRange] = useState<{
     fromDate: string;
     toDate: string;
@@ -85,20 +332,39 @@ export default function TransactionsContent() {
     });
   }, []);
 
-  const handleSelectAll = useCallback(
-    (checked: boolean, pageIds: string[]) => {
-      setSelectedIds((prev) => {
-        const next = new Set(prev);
-        if (checked) {
-          pageIds.forEach((id) => next.add(id));
-        } else {
-          pageIds.forEach((id) => next.delete(id));
-        }
-        return next;
-      });
-    },
-    [],
-  );
+  const handleSelectAll = useCallback((checked: boolean, pageIds: string[]) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        pageIds.forEach((id) => next.add(id));
+      } else {
+        pageIds.forEach((id) => next.delete(id));
+      }
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    const nextQueryString = buildTransactionsQueryString(
+      new URLSearchParams(currentQueryString),
+      { filters, page: currentPage },
+      defaultFilters,
+    );
+
+    if (nextQueryString === currentQueryString) return;
+
+    router.replace(
+      nextQueryString ? `${pathname}?${nextQueryString}` : pathname,
+      { scroll: false },
+    );
+  }, [
+    currentPage,
+    currentQueryString,
+    defaultFilters,
+    filters,
+    pathname,
+    router,
+  ]);
 
   // ── Data ─────────────────────────────────────────────────────────────────────
   const { data, isLoading, error, refetch } = useTransactions({
@@ -177,8 +443,7 @@ export default function TransactionsContent() {
               { field: primary.field, direction: primary.direction },
               {
                 field,
-                direction:
-                  secondary.direction === "asc" ? "desc" : "asc",
+                direction: secondary.direction === "asc" ? "desc" : "asc",
               },
             ];
             return { ...prev, sortConfigs: newConfigs };
@@ -211,9 +476,7 @@ export default function TransactionsContent() {
   const handleBulkExport = useCallback(() => {
     // Stub: collect the selected transactions and trigger a CSV download.
     // Replace with a real implementation once the export endpoint is available.
-    const selected = paginatedTransactions.filter((t) =>
-      selectedIds.has(t.id),
-    );
+    const selected = paginatedTransactions.filter((t) => selectedIds.has(t.id));
     const csv = [
       ["ID", "Type", "Address", "Date", "Token", "Amount", "Status"].join(","),
       ...selected.map((t) =>
@@ -277,7 +540,10 @@ export default function TransactionsContent() {
           <button
             type="button"
             onClick={() =>
-              setStatementRange({ fromDate: filters.fromDate, toDate: filters.toDate })
+              setStatementRange({
+                fromDate: filters.fromDate,
+                toDate: filters.toDate,
+              })
             }
             disabled={statementLedger.isLoading || !!statementLedger.error}
             className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:cursor-not-allowed disabled:opacity-60"
@@ -287,7 +553,8 @@ export default function TransactionsContent() {
             Generate statement
           </button>
           <span id="statement-help" className="sr-only">
-            Creates a printable reconciliation statement for the selected date range.
+            Creates a printable reconciliation statement for the selected date
+            range.
           </span>
           {statementLedger.error && (
             <p role="status" className="ml-3 self-center text-sm text-red-300">

--- a/components/transactions/transactions-filters.tsx
+++ b/components/transactions/transactions-filters.tsx
@@ -109,15 +109,12 @@ export default function TransactionsFilters({
         {/* Search Input */}
         <div className="relative">
           <span className="absolute left-3 top-1/2 transform -translate-y-1/2">
-            <Search
-              size={16}
-              color="#9CA3AF"
-              strokeWidth={1.5}
-            />
+            <Search size={16} color="#9CA3AF" strokeWidth={1.5} />
           </span>
           {/* Debounced Search Input */}
           <SearchBar
             placeholder="Search"
+            ariaLabel="Search transactions"
             value={searchQuery}
             onSearch={onSearchChange}
             debounceMs={debounceMs}
@@ -153,19 +150,19 @@ export default function TransactionsFilters({
           </Button>
         )}
 
-          {/* Clear All Filters */}
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              onSearchChange('');
-              onFilterChange('All Transactions');
-            }}
-            aria-label="Clear all filters"
-            className="text-gray-400 hover:text-white"
-          >
-            Clear all
-          </Button>
+        {/* Clear All Filters */}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            onSearchChange("");
+            onFilterChange("All Transactions");
+          }}
+          aria-label="Clear all filters"
+          className="text-gray-400 hover:text-white"
+        >
+          Clear all
+        </Button>
 
         {/* Filter Dropdown */}
         <DropdownMenu>

--- a/components/transactions/transactions-table.test.tsx
+++ b/components/transactions/transactions-table.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { TransactionsTable } from "./transactions-table";
 import { BulkActionBar } from "./bulk-action-bar";
@@ -67,7 +67,9 @@ describe("TransactionsTable", () => {
 
     it("shows the empty state when transactions array is empty", () => {
       render(<TransactionsTable transactions={[]} />);
-      expect(screen.getAllByText("No Transactions Found").length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText("No Transactions Found").length,
+      ).toBeGreaterThan(0);
     });
 
     it("shows the loading skeleton rows when isLoading=true", () => {
@@ -81,258 +83,252 @@ describe("TransactionsTable", () => {
 
     it("does NOT render checkboxes when selection props are omitted", () => {
       render(<TransactionsTable transactions={mockTransactions} />);
-      expect(
-        screen.queryByRole("checkbox"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
     });
   });
 });
 
-  // ──────────────────────────────────────────────────────────────────────────
-  // Checkbox column and selection
-  // ──────────────────────────────────────────────────────────────────────────
+// ──────────────────────────────────────────────────────────────────────────
+// Checkbox column and selection
+// ──────────────────────────────────────────────────────────────────────────
 
-  describe("checkbox column (selection props provided)", () => {
-    it("renders a header checkbox and one checkbox per row", () => {
-      render(
-        <TransactionsTable
-          transactions={mockTransactions}
-          selectedIds={new Set()}
-          onSelectRow={vi.fn()}
-          onSelectAll={vi.fn()}
-        />,
-      );
-      // 1 header + 3 rows = at least 4 checkboxes (doubled for mobile/desktop)
-      const checkboxes = screen.getAllByRole("checkbox");
-      // Desktop: 4 (1 header + 3 rows); Mobile: 3 (no header checkbox on mobile)
-      // Total ≥ 4
-      expect(checkboxes.length).toBeGreaterThanOrEqual(4);
-    });
-
-    it("header checkbox has accessible label for select-all", () => {
-      render(
-        <TransactionsTable
-          transactions={mockTransactions}
-          selectedIds={new Set()}
-          onSelectRow={vi.fn()}
-          onSelectAll={vi.fn()}
-        />,
-      );
-      expect(
-        screen.getByRole("checkbox", {
-          name: /select all transactions on this page/i,
-        }),
-      ).toBeInTheDocument();
-    });
-
-    it("row checkboxes have accessible labels with transaction id", () => {
-      render(
-        <TransactionsTable
-          transactions={mockTransactions}
-          selectedIds={new Set()}
-          onSelectRow={vi.fn()}
-          onSelectAll={vi.fn()}
-        />,
-      );
-      // Each transaction id has at least one labelled checkbox
-      expect(
-        screen.getAllByRole("checkbox", { name: /select transaction 1/i })
-          .length,
-      ).toBeGreaterThanOrEqual(1);
-    });
-
-    it("calls onSelectRow with the correct id and checked state", () => {
-      const onSelectRow = vi.fn();
-      render(
-        <TransactionsTable
-          transactions={mockTransactions}
-          selectedIds={new Set()}
-          onSelectRow={onSelectRow}
-          onSelectAll={vi.fn()}
-        />,
-      );
-      const rowCheckboxes = screen.getAllByRole("checkbox", {
-        name: /select transaction 1/i,
-      });
-      fireEvent.click(rowCheckboxes[0]);
-      expect(onSelectRow).toHaveBeenCalledWith("1", true);
-    });
-
-    it("calls onSelectAll with true when header checkbox is clicked (none selected)", () => {
-      const onSelectAll = vi.fn();
-      render(
-        <TransactionsTable
-          transactions={mockTransactions}
-          selectedIds={new Set()}
-          onSelectRow={vi.fn()}
-          onSelectAll={onSelectAll}
-        />,
-      );
-      const headerCheckbox = screen.getByRole("checkbox", {
-        name: /select all transactions on this page/i,
-      });
-      fireEvent.click(headerCheckbox);
-      expect(onSelectAll).toHaveBeenCalledWith(true);
-    });
-
-    it("calls onSelectAll with false when header checkbox is clicked (all selected)", () => {
-      const allIds = new Set(["1", "2", "3"]);
-      const onSelectAll = vi.fn();
-      render(
-        <TransactionsTable
-          transactions={mockTransactions}
-          selectedIds={allIds}
-          onSelectRow={vi.fn()}
-          onSelectAll={onSelectAll}
-        />,
-      );
-      const headerCheckbox = screen.getByRole("checkbox", {
-        name: /deselect all transactions on this page/i,
-      });
-      fireEvent.click(headerCheckbox);
-      expect(onSelectAll).toHaveBeenCalledWith(false);
-    });
-
-    it("header checkbox is checked when all rows are selected", () => {
-      const allIds = new Set(["1", "2", "3"]);
-      render(
-        <TransactionsTable
-          transactions={mockTransactions}
-          selectedIds={allIds}
-          onSelectRow={vi.fn()}
-          onSelectAll={vi.fn()}
-        />,
-      );
-      const headerCheckbox = screen.getByRole("checkbox", {
-        name: /deselect all transactions on this page/i,
-      });
-      expect(headerCheckbox).toHaveAttribute("data-state", "checked");
-    });
-
-    it("header checkbox is indeterminate when some rows are selected", () => {
-      const partialIds = new Set(["1"]);
-      render(
-        <TransactionsTable
-          transactions={mockTransactions}
-          selectedIds={partialIds}
-          onSelectRow={vi.fn()}
-          onSelectAll={vi.fn()}
-        />,
-      );
-      const headerCheckbox = screen.getByRole("checkbox", {
-        name: /select all transactions on this page/i,
-      });
-      expect(headerCheckbox).toHaveAttribute("data-state", "indeterminate");
-    });
-
-    it("header checkbox is unchecked when no rows are selected", () => {
-      render(
-        <TransactionsTable
-          transactions={mockTransactions}
-          selectedIds={new Set()}
-          onSelectRow={vi.fn()}
-          onSelectAll={vi.fn()}
-        />,
-      );
-      const headerCheckbox = screen.getByRole("checkbox", {
-        name: /select all transactions on this page/i,
-      });
-      expect(headerCheckbox).toHaveAttribute("data-state", "unchecked");
-    });
-
-    it("selected row has aria-selected=true", () => {
-      const { container } = render(
-        <TransactionsTable
-          transactions={mockTransactions}
-          selectedIds={new Set(["2"])}
-          onSelectRow={vi.fn()}
-          onSelectAll={vi.fn()}
-        />,
-      );
-      // Grab the desktop table rows (not the mobile cards which don't set aria-selected)
-      const tableRows = container.querySelectorAll("tr[aria-selected='true']");
-      expect(tableRows.length).toBeGreaterThanOrEqual(1);
-    });
+describe("checkbox column (selection props provided)", () => {
+  it("renders a header checkbox and one checkbox per row", () => {
+    render(
+      <TransactionsTable
+        transactions={mockTransactions}
+        selectedIds={new Set()}
+        onSelectRow={vi.fn()}
+        onSelectAll={vi.fn()}
+      />,
+    );
+    // 1 header + 3 rows = at least 4 checkboxes (doubled for mobile/desktop)
+    const checkboxes = screen.getAllByRole("checkbox");
+    // Desktop: 4 (1 header + 3 rows); Mobile: 3 (no header checkbox on mobile)
+    // Total ≥ 4
+    expect(checkboxes.length).toBeGreaterThanOrEqual(4);
   });
 
-  // ──────────────────────────────────────────────────────────────────────────
-  // Tooltips for long text (regression)
-  // ──────────────────────────────────────────────────────────────────────────
-
-  describe("tooltips for long text values", () => {
-    it("applies title and tabIndex to long addresses", () => {
-      render(<TransactionsTable transactions={mockTransactions} />);
-      const addressElements = screen.getAllByTitle(
-        "0x1234567890abcdef1234567890abcdef1234567890abcdef",
-      );
-      expect(addressElements.length).toBeGreaterThan(0);
-      expect(addressElements[0]).toHaveAttribute("tabIndex", "0");
-      expect(addressElements[0]).toHaveClass("truncate");
-    });
-
-    it("applies title and tabIndex to long amounts", () => {
-      render(<TransactionsTable transactions={mockTransactions} />);
-      const amountElements = screen.getAllByTitle(
-        "+1000000000000000000000000000.00",
-      );
-      expect(amountElements.length).toBeGreaterThan(0);
-      expect(amountElements[0]).toHaveAttribute("tabIndex", "0");
-      expect(amountElements[0]).toHaveClass("truncate");
-    });
+  it("header checkbox has accessible label for select-all", () => {
+    render(
+      <TransactionsTable
+        transactions={mockTransactions}
+        selectedIds={new Set()}
+        onSelectRow={vi.fn()}
+        onSelectAll={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("checkbox", {
+        name: /select all transactions on this page/i,
+      }),
+    ).toBeInTheDocument();
   });
 
-  // ──────────────────────────────────────────────────────────────────────────
-  // Edge cases
-  // ──────────────────────────────────────────────────────────────────────────
+  it("row checkboxes have accessible labels with transaction id", () => {
+    render(
+      <TransactionsTable
+        transactions={mockTransactions}
+        selectedIds={new Set()}
+        onSelectRow={vi.fn()}
+        onSelectAll={vi.fn()}
+      />,
+    );
+    // Each transaction id has at least one labelled checkbox
+    expect(
+      screen.getAllByRole("checkbox", { name: /select transaction 1/i }).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
 
-  describe("edge cases", () => {
-    it("renders empty state with correct colSpan when selection is enabled", () => {
-      const { container } = render(
+  it("calls onSelectRow with the correct id and checked state", () => {
+    const onSelectRow = vi.fn();
+    render(
+      <TransactionsTable
+        transactions={mockTransactions}
+        selectedIds={new Set()}
+        onSelectRow={onSelectRow}
+        onSelectAll={vi.fn()}
+      />,
+    );
+    const rowCheckboxes = screen.getAllByRole("checkbox", {
+      name: /select transaction 1/i,
+    });
+    fireEvent.click(rowCheckboxes[0]);
+    expect(onSelectRow).toHaveBeenCalledWith("1", true);
+  });
+
+  it("calls onSelectAll with true when header checkbox is clicked (none selected)", () => {
+    const onSelectAll = vi.fn();
+    render(
+      <TransactionsTable
+        transactions={mockTransactions}
+        selectedIds={new Set()}
+        onSelectRow={vi.fn()}
+        onSelectAll={onSelectAll}
+      />,
+    );
+    const headerCheckbox = screen.getByRole("checkbox", {
+      name: /select all transactions on this page/i,
+    });
+    fireEvent.click(headerCheckbox);
+    expect(onSelectAll).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onSelectAll with false when header checkbox is clicked (all selected)", () => {
+    const allIds = new Set(["1", "2", "3"]);
+    const onSelectAll = vi.fn();
+    render(
+      <TransactionsTable
+        transactions={mockTransactions}
+        selectedIds={allIds}
+        onSelectRow={vi.fn()}
+        onSelectAll={onSelectAll}
+      />,
+    );
+    const headerCheckbox = screen.getByRole("checkbox", {
+      name: /deselect all transactions on this page/i,
+    });
+    fireEvent.click(headerCheckbox);
+    expect(onSelectAll).toHaveBeenCalledWith(false);
+  });
+
+  it("header checkbox is checked when all rows are selected", () => {
+    const allIds = new Set(["1", "2", "3"]);
+    render(
+      <TransactionsTable
+        transactions={mockTransactions}
+        selectedIds={allIds}
+        onSelectRow={vi.fn()}
+        onSelectAll={vi.fn()}
+      />,
+    );
+    const headerCheckbox = screen.getByRole("checkbox", {
+      name: /deselect all transactions on this page/i,
+    });
+    expect(headerCheckbox).toHaveAttribute("data-state", "checked");
+  });
+
+  it("header checkbox is indeterminate when some rows are selected", () => {
+    const partialIds = new Set(["1"]);
+    render(
+      <TransactionsTable
+        transactions={mockTransactions}
+        selectedIds={partialIds}
+        onSelectRow={vi.fn()}
+        onSelectAll={vi.fn()}
+      />,
+    );
+    const headerCheckbox = screen.getByRole("checkbox", {
+      name: /select all transactions on this page/i,
+    });
+    expect(headerCheckbox).toHaveAttribute("data-state", "indeterminate");
+  });
+
+  it("header checkbox is unchecked when no rows are selected", () => {
+    render(
+      <TransactionsTable
+        transactions={mockTransactions}
+        selectedIds={new Set()}
+        onSelectRow={vi.fn()}
+        onSelectAll={vi.fn()}
+      />,
+    );
+    const headerCheckbox = screen.getByRole("checkbox", {
+      name: /select all transactions on this page/i,
+    });
+    expect(headerCheckbox).toHaveAttribute("data-state", "unchecked");
+  });
+
+  it("selected row has aria-selected=true", () => {
+    const { container } = render(
+      <TransactionsTable
+        transactions={mockTransactions}
+        selectedIds={new Set(["2"])}
+        onSelectRow={vi.fn()}
+        onSelectAll={vi.fn()}
+      />,
+    );
+    // Grab the desktop table rows (not the mobile cards which don't set aria-selected)
+    const tableRows = container.querySelectorAll("tr[aria-selected='true']");
+    expect(tableRows.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tooltips for long text (regression)
+// ──────────────────────────────────────────────────────────────────────────
+
+describe("tooltips for long text values", () => {
+  it("applies title and tabIndex to long addresses", () => {
+    render(<TransactionsTable transactions={mockTransactions} />);
+    const addressElements = screen.getAllByTitle(
+      "0x1234567890abcdef1234567890abcdef1234567890abcdef",
+    );
+    expect(addressElements.length).toBeGreaterThan(0);
+    expect(addressElements[0]).toHaveAttribute("tabIndex", "0");
+    expect(addressElements[0]).toHaveClass("truncate");
+  });
+
+  it("applies title and tabIndex to long amounts", () => {
+    render(<TransactionsTable transactions={mockTransactions} />);
+    const amountElements = screen.getAllByTitle(
+      "+1000000000000000000000000000.00",
+    );
+    expect(amountElements.length).toBeGreaterThan(0);
+    expect(amountElements[0]).toHaveAttribute("tabIndex", "0");
+    expect(amountElements[0]).toHaveClass("truncate");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Edge cases
+// ──────────────────────────────────────────────────────────────────────────
+
+describe("edge cases", () => {
+  it("renders empty state with correct colSpan when selection is enabled", () => {
+    const { container } = render(
+      <TransactionsTable
+        transactions={[]}
+        selectedIds={new Set()}
+        onSelectRow={vi.fn()}
+        onSelectAll={vi.fn()}
+      />,
+    );
+    // colSpan should be 7 (6 data columns + 1 checkbox column)
+    const td = container.querySelector("td[colspan='7']");
+    expect(td).toBeInTheDocument();
+  });
+
+  it("renders empty state with colSpan 6 when selection is disabled", () => {
+    const { container } = render(<TransactionsTable transactions={[]} />);
+    const td = container.querySelector("td[colspan='6']");
+    expect(td).toBeInTheDocument();
+  });
+
+  it("handles an empty selectedIds set gracefully", () => {
+    expect(() =>
+      render(
         <TransactionsTable
-          transactions={[]}
+          transactions={mockTransactions}
           selectedIds={new Set()}
           onSelectRow={vi.fn()}
           onSelectAll={vi.fn()}
         />,
-      );
-      // colSpan should be 7 (6 data columns + 1 checkbox column)
-      const td = container.querySelector("td[colspan='7']");
-      expect(td).toBeInTheDocument();
-    });
+      ),
+    ).not.toThrow();
+  });
 
-    it("renders empty state with colSpan 6 when selection is disabled", () => {
-      const { container } = render(
-        <TransactionsTable transactions={[]} />,
-      );
-      const td = container.querySelector("td[colspan='6']");
-      expect(td).toBeInTheDocument();
-    });
-
-    it("handles an empty selectedIds set gracefully", () => {
-      expect(() =>
-        render(
-          <TransactionsTable
-            transactions={mockTransactions}
-            selectedIds={new Set()}
-            onSelectRow={vi.fn()}
-            onSelectAll={vi.fn()}
-          />,
-        ),
-      ).not.toThrow();
-    });
-
-    it("does not throw when selectedIds contains ids not in the current page", () => {
-      expect(() =>
-        render(
-          <TransactionsTable
-            transactions={mockTransactions}
-            selectedIds={new Set(["999"])}
-            onSelectRow={vi.fn()}
-            onSelectAll={vi.fn()}
-          />,
-        ),
-      ).not.toThrow();
-    });
+  it("does not throw when selectedIds contains ids not in the current page", () => {
+    expect(() =>
+      render(
+        <TransactionsTable
+          transactions={mockTransactions}
+          selectedIds={new Set(["999"])}
+          onSelectRow={vi.fn()}
+          onSelectAll={vi.fn()}
+        />,
+      ),
+    ).not.toThrow();
   });
 });
 
@@ -404,9 +400,15 @@ describe("BulkActionBar", () => {
       />,
     );
     const bar = screen.getByTestId("bulk-action-bar");
-    expect(within(bar).getByRole("button", { name: /export/i })).toBeInTheDocument();
-    expect(within(bar).getByRole("button", { name: /tag/i })).toBeInTheDocument();
-    expect(within(bar).getByRole("button", { name: /archive/i })).toBeInTheDocument();
+    expect(
+      within(bar).getByRole("button", { name: /export/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(bar).getByRole("button", { name: /tag/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(bar).getByRole("button", { name: /archive/i }),
+    ).toBeInTheDocument();
     expect(
       within(bar).getByRole("button", { name: /clear selection/i }),
     ).toBeInTheDocument();
@@ -503,110 +505,138 @@ describe("BulkActionBar", () => {
   describe("Quick-view Dialog", () => {
     it("renders view detail buttons for each transaction", () => {
       render(<TransactionsTable transactions={mockTransactions} />);
-      
+
       // Desktop view - find the eye icon button
-      const viewDetailButtons = screen.getAllByLabelText(/View details for transaction/i);
+      const viewDetailButtons = screen.getAllByLabelText(
+        /View details for transaction/i,
+      );
       expect(viewDetailButtons.length).toBeGreaterThan(0);
     });
 
     it("opens quick-view dialog when clicking view detail button", () => {
       render(<TransactionsTable transactions={mockTransactions} />);
-      
-      const viewDetailButton = screen.getAllByLabelText(/View details for transaction/i)[0];
+
+      const viewDetailButton = screen.getAllByLabelText(
+        /View details for transaction/i,
+      )[0];
       fireEvent.click(viewDetailButton);
-      
+
       // Dialog should be visible
       expect(screen.getByText("Transaction Details")).toBeInTheDocument();
-      expect(screen.getByText("Test memo for deposit transaction")).toBeInTheDocument();
+      expect(
+        screen.getByText("Test memo for deposit transaction"),
+      ).toBeInTheDocument();
     });
 
     it("opens quick-view dialog on Enter key press", () => {
       render(<TransactionsTable transactions={mockTransactions} />);
-      
-      const viewDetailButton = screen.getAllByLabelText(/View details for transaction/i)[0];
+
+      const viewDetailButton = screen.getAllByLabelText(
+        /View details for transaction/i,
+      )[0];
       fireEvent.keyDown(viewDetailButton, { key: "Enter" });
-      
+
       expect(screen.getByText("Transaction Details")).toBeInTheDocument();
     });
 
     it("opens quick-view dialog on Space key press", () => {
       render(<TransactionsTable transactions={mockTransactions} />);
-      
-      const viewDetailButton = screen.getAllByLabelText(/View details for transaction/i)[0];
+
+      const viewDetailButton = screen.getAllByLabelText(
+        /View details for transaction/i,
+      )[0];
       fireEvent.keyDown(viewDetailButton, { key: " " });
-      
+
       expect(screen.getByText("Transaction Details")).toBeInTheDocument();
     });
 
     it("displays all transaction details in the dialog", () => {
       render(<TransactionsTable transactions={mockTransactions} />);
-      
-      const viewDetailButton = screen.getAllByLabelText(/View details for transaction/i)[0];
+
+      const viewDetailButton = screen.getAllByLabelText(
+        /View details for transaction/i,
+      )[0];
       fireEvent.click(viewDetailButton);
-      
+
       // Check all fields are displayed
       expect(screen.getByText("Transaction Details")).toBeInTheDocument();
       // Use getAllByText since "Deposit" appears in both table and dialog
       expect(screen.getAllByText("Deposit").length).toBeGreaterThan(0);
       expect(screen.getAllByText("#1").length).toBeGreaterThan(0);
-      expect(screen.getByText("Test memo for deposit transaction")).toBeInTheDocument();
+      expect(
+        screen.getByText("Test memo for deposit transaction"),
+      ).toBeInTheDocument();
       expect(screen.getByText("0.001 ETH")).toBeInTheDocument();
-      expect(screen.getByText("0xhash1234567890abcdef1234567890abcdef1234567890abcdef1234567890")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "0xhash1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        ),
+      ).toBeInTheDocument();
       expect(screen.getByText("View Full Details")).toBeInTheDocument();
     });
 
     it("includes link to full transaction details page", () => {
       render(<TransactionsTable transactions={mockTransactions} />);
-      
-      const viewDetailButton = screen.getAllByLabelText(/View details for transaction/i)[0];
+
+      const viewDetailButton = screen.getAllByLabelText(
+        /View details for transaction/i,
+      )[0];
       fireEvent.click(viewDetailButton);
-      
-      const fullDetailsLink = screen.getByRole("link", { name: /View full details/i });
+
+      const fullDetailsLink = screen.getByRole("link", {
+        name: /View full details/i,
+      });
       expect(fullDetailsLink).toHaveAttribute("href", "/transactions/1");
     });
 
     it("closes dialog when pressing Escape", () => {
       render(<TransactionsTable transactions={mockTransactions} />);
-      
-      const viewDetailButton = screen.getAllByLabelText(/View details for transaction/i)[0];
+
+      const viewDetailButton = screen.getAllByLabelText(
+        /View details for transaction/i,
+      )[0];
       fireEvent.click(viewDetailButton);
-      
+
       expect(screen.getByText("Transaction Details")).toBeInTheDocument();
-      
+
       // Press Escape to close
       fireEvent.keyDown(document, { key: "Escape" });
-      
+
       // Dialog should be closed
       expect(screen.queryByText("Transaction Details")).not.toBeInTheDocument();
     });
 
     it("handles transactions without optional fields", () => {
-      const minimalTransaction = [{
-        id: "2",
-        type: "Withdrawal",
-        txId: "TX124",
-        address: "0x987654321",
-        date: "2023-10-28",
-        time: "2:00 PM",
-        token: "USDC",
-        amount: "-50.00",
-        status: "Pending" as const,
-        tokenIcon: "/icons/usdc.svg",
-        statusColor: "warning" as const,
-      }];
-      
+      const minimalTransaction = [
+        {
+          id: "2",
+          type: "Withdrawal",
+          txId: "TX124",
+          address: "0x987654321",
+          date: "2023-10-28",
+          time: "2:00 PM",
+          token: "USDC",
+          amount: "-50.00",
+          status: "Pending" as const,
+          tokenIcon: "/icons/usdc.svg",
+          statusColor: "warning" as const,
+        },
+      ];
+
       render(<TransactionsTable transactions={minimalTransaction} />);
-      
+
       // Use getAllByLabelText since both desktop and mobile views render the button
-      const viewDetailButtons = screen.getAllByLabelText(/View details for transaction 2/i);
+      const viewDetailButtons = screen.getAllByLabelText(
+        /View details for transaction 2/i,
+      );
       fireEvent.click(viewDetailButtons[0]);
-      
+
       // Dialog should still open and show basic info
       expect(screen.getByText("Transaction Details")).toBeInTheDocument();
       // Use getAllByText since "Withdrawal" appears in both table and dialog
       expect(screen.getAllByText("Withdrawal").length).toBeGreaterThan(0);
       expect(screen.getAllByText("#2").length).toBeGreaterThan(0);
-      
+
       // Optional fields should not be in the document
       expect(screen.queryByText("Memo")).not.toBeInTheDocument();
       expect(screen.queryByText("Counterparty")).not.toBeInTheDocument();
@@ -618,20 +648,26 @@ describe("BulkActionBar", () => {
   describe("Mobile Cards", () => {
     it("renders mobile transaction cards", () => {
       render(<TransactionsTable transactions={mockTransactions} />);
-      
+
       // Mobile cards should be in the document (hidden on desktop)
-      const mobileCards = screen.getAllByRole("button", { name: /View details for transaction/i });
+      const mobileCards = screen.getAllByRole("button", {
+        name: /View details for transaction/i,
+      });
       // At least one mobile card should exist
       expect(mobileCards.length).toBeGreaterThan(0);
     });
 
     it("opens dialog when clicking mobile transaction card", () => {
       render(<TransactionsTable transactions={mockTransactions} />);
-      
+
       // Find mobile card button
-      const mobileCards = screen.getAllByRole("button", { name: /View details for transaction 1/i });
-      const mobileCard = mobileCards.find(card => card.className.includes("w-full text-left"));
-      
+      const mobileCards = screen.getAllByRole("button", {
+        name: /View details for transaction 1/i,
+      });
+      const mobileCard = mobileCards.find((card) =>
+        card.className.includes("w-full text-left"),
+      );
+
       if (mobileCard) {
         fireEvent.click(mobileCard);
         expect(screen.getByText("Transaction Details")).toBeInTheDocument();
@@ -642,31 +678,45 @@ describe("BulkActionBar", () => {
   describe("Accessibility", () => {
     it("has accessible labels for view detail buttons", () => {
       render(<TransactionsTable transactions={mockTransactions} />);
-      
-      const viewDetailButtons = screen.getAllByLabelText(/View details for transaction/i);
+
+      const viewDetailButtons = screen.getAllByLabelText(
+        /View details for transaction/i,
+      );
       viewDetailButtons.forEach((button, index) => {
-        expect(button).toHaveAttribute("aria-label", `View details for transaction ${mockTransactions[0].id}`);
+        const transaction = mockTransactions[index % mockTransactions.length];
+        expect(button).toHaveAttribute(
+          "aria-label",
+          `View details for transaction ${transaction.id}`,
+        );
       });
     });
 
     it("has proper status badge aria-labels in dialog", () => {
       render(<TransactionsTable transactions={mockTransactions} />);
-      
-      const viewDetailButton = screen.getAllByLabelText(/View details for transaction/i)[0];
+
+      const viewDetailButton = screen.getAllByLabelText(
+        /View details for transaction/i,
+      )[0];
       fireEvent.click(viewDetailButton);
-      
+
       // Status badges should have aria-label (multiple may exist - one in table, one in dialog)
-      const statusBadges = screen.getAllByLabelText(`Status: ${mockTransactions[0].status}`);
+      const statusBadges = screen.getAllByLabelText(
+        `Status: ${mockTransactions[0].status}`,
+      );
       expect(statusBadges.length).toBeGreaterThan(0);
     });
 
     it("has accessible link to full transaction details", () => {
       render(<TransactionsTable transactions={mockTransactions} />);
-      
-      const viewDetailButton = screen.getAllByLabelText(/View details for transaction/i)[0];
+
+      const viewDetailButton = screen.getAllByLabelText(
+        /View details for transaction/i,
+      )[0];
       fireEvent.click(viewDetailButton);
-      
-      const fullDetailsLink = screen.getByRole("link", { name: /View full details for transaction/i });
+
+      const fullDetailsLink = screen.getByRole("link", {
+        name: /View full details for transaction/i,
+      });
       expect(fullDetailsLink).toBeInTheDocument();
     });
   });

--- a/components/transactions/transactions-table.tsx
+++ b/components/transactions/transactions-table.tsx
@@ -12,6 +12,8 @@ import {
 import { TransactionsTableProps, TransactionProps } from "@/types/transaction";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TransactionTableSkeleton } from "@/components/ui/table-skeleton";
 import { getStatusColor } from "@/utils/transactionUtils";
 import { truncateStellarAddress } from "@/utils/stellarAddress";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -106,7 +108,9 @@ function TransactionQuickViewDialog({
               <p className="text-sm font-semibold">#{transaction.id}</p>
             </div>
             <div>
-              <p className="text-sm font-medium text-muted-foreground">Status</p>
+              <p className="text-sm font-medium text-muted-foreground">
+                Status
+              </p>
               <p className="text-sm font-semibold">{transaction.status}</p>
             </div>
           </div>
@@ -114,7 +118,9 @@ function TransactionQuickViewDialog({
           {/* Address & Counterparty */}
           <div className="space-y-2">
             <div>
-              <p className="text-sm font-medium text-muted-foreground">Address</p>
+              <p className="text-sm font-medium text-muted-foreground">
+                Address
+              </p>
               <p
                 className="text-sm font-mono break-all cursor-help focus:outline-none focus:ring-2 focus:ring-[#D7E0EF] rounded px-1 -ml-1"
                 title={transaction.address}
@@ -125,7 +131,9 @@ function TransactionQuickViewDialog({
             </div>
             {transaction.counterparty && (
               <div>
-                <p className="text-sm font-medium text-muted-foreground">Counterparty</p>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Counterparty
+                </p>
                 <p
                   className="text-sm font-mono break-all cursor-help focus:outline-none focus:ring-2 focus:ring-[#D7E0EF] rounded px-1 -ml-1"
                   title={transaction.counterparty}
@@ -141,13 +149,19 @@ function TransactionQuickViewDialog({
           <div className="grid grid-cols-2 gap-4">
             <div>
               <p className="text-sm font-medium text-muted-foreground">Date</p>
-              <time dateTime={transaction.date} className="text-sm font-semibold">
+              <time
+                dateTime={transaction.date}
+                className="text-sm font-semibold"
+              >
                 {transaction.date}
               </time>
             </div>
             <div>
               <p className="text-sm font-medium text-muted-foreground">Time</p>
-              <time dateTime={transaction.time} className="text-sm font-semibold">
+              <time
+                dateTime={transaction.time}
+                className="text-sm font-semibold"
+              >
                 {transaction.time}
               </time>
             </div>
@@ -164,11 +178,15 @@ function TransactionQuickViewDialog({
                   width={16}
                   height={16}
                 />
-                <span className="text-sm font-semibold">{transaction.token}</span>
+                <span className="text-sm font-semibold">
+                  {transaction.token}
+                </span>
               </div>
             </div>
             <div>
-              <p className="text-sm font-medium text-muted-foreground">Amount</p>
+              <p className="text-sm font-medium text-muted-foreground">
+                Amount
+              </p>
               <p
                 className={`text-sm font-semibold ${
                   transaction.amount.startsWith("+")
@@ -202,7 +220,9 @@ function TransactionQuickViewDialog({
           {/* Transaction Hash */}
           {transaction.hash && (
             <div>
-              <p className="text-sm font-medium text-muted-foreground">Transaction Hash</p>
+              <p className="text-sm font-medium text-muted-foreground">
+                Transaction Hash
+              </p>
               <p
                 className="text-sm font-mono break-all cursor-help focus:outline-none focus:ring-2 focus:ring-[#D7E0EF] rounded px-1 -ml-1"
                 title={transaction.hash}
@@ -238,22 +258,28 @@ export function TransactionsTable({
   onSelectRow,
   onSelectAll,
 }: TransactionsTablePropsExtended) {
-  const [selectedTransaction, setSelectedTransaction] = useState<TransactionsTablePropsExtended["transactions"][number] | null>(null);
-
   const isEmpty = !isLoading && transactions.length === 0;
-  
+
   // State for quick-view dialog
-  const [selectedTransaction, setSelectedTransaction] = React.useState<TransactionProps | null>(null);
+  const [selectedTransaction, setSelectedTransaction] =
+    React.useState<TransactionProps | null>(null);
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
   const triggerRef = React.useRef<HTMLButtonElement | null>(null);
+  const tableWrapperRef = React.useRef<HTMLDivElement | null>(null);
 
-  const handleRowClick = (transaction: TransactionProps, event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleRowClick = (
+    transaction: TransactionProps,
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
     triggerRef.current = event.currentTarget;
     setSelectedTransaction(transaction);
     setIsDialogOpen(true);
   };
 
-  const handleRowKeyDown = (transaction: TransactionProps, event: React.KeyboardEvent<HTMLButtonElement>) => {
+  const handleRowKeyDown = (
+    transaction: TransactionProps,
+    event: React.KeyboardEvent<HTMLButtonElement>,
+  ) => {
     // Open dialog on Enter or Space
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
@@ -299,7 +325,9 @@ export function TransactionsTable({
       >
         <Table>
           {/* caption is visually hidden but announced by screen readers */}
-          <caption className="sr-only">Transaction history. Click a row to view transaction details.</caption>
+          <caption className="sr-only">
+            Transaction history. Click a row to view transaction details.
+          </caption>
           <TableHeader>
             <TableRow className="bg-[#191919]">
               {isSelectable && (
@@ -410,7 +438,22 @@ export function TransactionsTable({
                 <TableRow
                   key={transaction.id ?? index}
                   className="border border-[#2D2D2D]"
+                  aria-selected={
+                    isSelectable ? selectedIds.has(transaction.id) : undefined
+                  }
                 >
+                  {isSelectable && (
+                    <TableCell className="border border-[#2D2D2D] py-4 px-4 w-12">
+                      <Checkbox
+                        aria-label={`Select transaction ${transaction.id}`}
+                        checked={selectedIds.has(transaction.id)}
+                        onCheckedChange={(checked) =>
+                          onSelectRow?.(transaction.id, checked === true)
+                        }
+                        className="border-[#555] data-[state=checked]:border-white"
+                      />
+                    </TableCell>
+                  )}
                   <TableCell className="font-medium border border-[#2D2D2D] py-4 px-6">
                     <span className="text-[#D7E0EF]">{transaction.type}</span>
                     <p>#{transaction.id}</p>
@@ -421,7 +464,7 @@ export function TransactionsTable({
                       title={transaction.address}
                       tabIndex={0}
                     >
-                      {transaction.address}
+                      {truncateStellarAddress(transaction.address)}
                     </span>
                   </TableCell>
                   <TableCell className="border border-[#2D2D2D] py-4 px-6">
@@ -483,16 +526,6 @@ export function TransactionsTable({
                 </TableRow>
               ))
             )}
-
-            <DownloadReceiptButton
-            transaction={{
-              id: transaction.id,
-              hash: transaction.hash,
-              amount: transaction.amount,
-              counterparty: transaction.counterparty,
-              timestamp: transaction.timestamp,
-            }}
-          />
           </TableBody>
         </Table>
       </div>
@@ -525,14 +558,14 @@ export function TransactionsTable({
                   <p className="font-medium">
                     {transaction.type} #{transaction.id}
                   </p>
-                  <p 
+                  <p
                     className="text-sm text-muted-foreground block truncate max-w-[180px] cursor-help focus:outline-none focus:ring-2 focus:ring-[#D7E0EF] rounded px-1 -ml-1"
                     title={transaction.address}
                     tabIndex={0}
                     onClick={(e) => e.stopPropagation()}
                   >
-                    {transaction.status}
-                  </Badge>
+                    {truncateStellarAddress(transaction.address)}
+                  </p>
                 </div>
                 <Badge
                   variant={

--- a/lib/api/transactions.ts
+++ b/lib/api/transactions.ts
@@ -168,8 +168,6 @@ export async function getTransactions(
     minAmount,
     maxAmount,
     sortConfigs = [{ field: "date" as const, direction: "desc" as const }],
-    minAmount,
-    maxAmount,
     counterparty,
   } = filters;
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,4 @@
-import type { NextConfig } from "next";import type { NextConfig } from "next";
+import type { NextConfig } from "next";
 import bundleAnalyzer from "@next/bundle-analyzer";
 
 const nextConfig: NextConfig = {
@@ -8,22 +8,6 @@ const nextConfig: NextConfig = {
     // The repo currently pins TypeScript 7. Next.js requires this flag to
     // delegate type checking to the TypeScript CLI until its compiler API is
     // supported by the framework build worker.
-    useTypeScriptCli: true,
-  },
-};
-
-const withBundleAnalyzer = bundleAnalyzer({
-  enabled: process.env.ANALYZE === "true",
-});
-
-export default withBundleAnalyzer(nextConfig);
-
-import bundleAnalyzer from "@next/bundle-analyzer";
-
-const nextConfig: NextConfig = {
-  // ESLint now runs during `next build` so lint errors surface in CI.
-  // Remove ignoreDuringBuilds so the build gate is meaningful.
-  experimental: {
     useTypeScriptCli: true,
   },
 };

--- a/types/transaction.ts
+++ b/types/transaction.ts
@@ -39,10 +39,6 @@ export interface TransactionFilters {
   /** Ordered list of sort criteria. The first entry is the primary sort,
    *  the second (if present) is the secondary (tiebreaker) sort, etc. */
   sortConfigs: SortConfig[];
-  /** Minimum transaction amount filter (absolute value). */
-  minAmount?: number;
-  /** Maximum transaction amount filter (absolute value). */
-  maxAmount?: number;
   /** Counterparty address filter (partial match). */
   counterparty?: string;
 }


### PR DESCRIPTION
Description
Syncs the transactions list state in components/transactions/transactions-content.tsx with the URL query string so users can refresh, bookmark, or share a specific filtered/sorted/paginated transaction view.

Changes include:

Initializes transaction filters, sort order, date range, and current page from URL query params on first load.
Writes transaction state back to the URL using next/navigation.
Uses router.replace(..., { scroll: false }) instead of push to avoid adding a new history entry per search update.
Preserves unrelated query params when updating transactions state.
Adds validation/fallback behavior for malformed URL values.
Makes the shared URL search value visible in the transactions search input.
Adds an explicit accessible label for the transactions search input.
Documents the transactions URL-state contract in README.md.
Adds/updates regression tests for URL parsing, serialization, first-load state hydration, and replace-based URL updates.
Repairs transactions table/test issues that blocked the focused transaction tests from running.
Related Issue
Addresses the issue where components/transactions/transactions-content.tsx kept filter, sort, and pagination state only in memory, causing refreshes and shared links to reset the transactions view to defaults.

Checklist
 I have tested the changes locally.

 I have added/updated documentation as needed.

 I have reviewed the code and ensured it follows the project guidelines.

 I have added necessary tests.

Screenshots/Recordings
Not attached.

The change is state/URL behavior focused. Verified through local unit tests covering URL initialization and URL replacement behavior.

Additional Notes
Focused tests passed locally:

text

npx vitest run components/common/search-bar.test.tsx components/transactions/transactions-content.test.tsx --coverage.enabled=false
Result:

text

2 test files passed
31 tests passed
Transactions table tests also passed locally:

text

npx vitest run components/transactions/transactions-table.test.tsx --coverage.enabled=false
Result:

text

1 test file passed
44 tests passed
git diff --check passed.

npm run build was attempted, but the build is currently blocked by unrelated pre-existing errors outside this change, including parse/type issues in:

app/verify-email/page.tsx
lib/api/auth.ts
app/settings/preferences/components/account-section.tsx
components/auth/login/login-form.tsx
npm test was also attempted, but the full suite is currently blocked by unrelated existing failures outside this transaction URL-state work.


Closes #740 