### PR TITLE
 Add font preload hints and font-display FIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ This project is App-Router-only. All routes, layouts, and pages live under app/;
 Transactions URL state
 components/transactions/transactions-content.tsx mirrors the visible transactions list state into the URL query string via next/navigation, so a refreshed, bookmarked, or shared /transactions link reproduces the same slice of data.
 
-Query key	State	Example
-q	Search text	?q=USDC
-filter	Transaction type (sent, received; default all is omitted)	?filter=sent
-from / to	Inclusive ISO date range (YYYY-MM-DD)	?from=2024-02-01&to=2024-02-29
-sort	Primary and optional secondary sort as field.direction	?sort=amount.asc,date.desc
-page	1-based page number; page 1 is omitted	?page=3
+Query key State Example
+q Search text ?q=USDC
+filter Transaction type (sent, received; default all is omitted) ?filter=sent
+from / to Inclusive ISO date range (YYYY-MM-DD) ?from=2024-02-01&to=2024-02-29
+sort Primary and optional secondary sort as field.direction ?sort=amount.asc,date.desc
+page 1-based page number; page 1 is omitted ?page=3
 The component reads those parameters once on first load, validates untrusted values, and falls back to the default 30-day range, All Transactions, date.desc, and page 1 when a shared URL is malformed. User-driven updates call router.replace(..., { scroll: false }), not push, so debounced search typing and pagination do not create a new browser-history entry per keystroke or click.
 
 Accessibility and responsive notes:
@@ -56,16 +56,16 @@ npm run dev
 Open http://localhost:3000 to see the app. The page auto-updates as you edit files under app/.
 
 Available Scripts
-Script	Command	Purpose
-Dev server	npm run dev	Starts Next.js with Turbopack
-Build	npm run build	Production build
-Start	npm run start	Serves the production build
-Lint	npm run lint	ESLint via next lint
-Type-check	npm run type-check	tsc --noEmit
-Unit tests	npm run test	Vitest with coverage
-Unit tests (watch)	npm run test:watch	Vitest in watch mode
-E2E tests	npm run test:e2e	Playwright (npx playwright test)
-Format	npm run prettier	Prettier write
+Script Command Purpose
+Dev server npm run dev Starts Next.js with Turbopack
+Build npm run build Production build
+Start npm run start Serves the production build
+Lint npm run lint ESLint via next lint
+Type-check npm run type-check tsc --noEmit
+Unit tests npm run test Vitest with coverage
+Unit tests (watch) npm run test:watch Vitest in watch mode
+E2E tests npm run test:e2e Playwright (npx playwright test)
+Format npm run prettier Prettier write
 Wallet and network state
 The connected wallet and the active network live in a single React context, WalletProvider, declared in context/wallet-context.tsx. The provider is wrapped around the entire app in the App Router (app/layout.tsx), so every surface that needs to know which account or network is active reads from the same source of truth.
 
@@ -76,15 +76,15 @@ React
 import { useWallet, formatAddress } from "@/context/wallet-context";
 
 export function AccountBadge() {
-  const { address, isConnected, connect, disconnect, network } = useWallet();
-  if (!isConnected) {
-    return <button onClick={() => connect()}>Connect Wallet</button>;
-  }
-  return (
-    <span>
-      {formatAddress(address)} on {network.name}
-    </span>
-  );
+const { address, isConnected, connect, disconnect, network } = useWallet();
+if (!isConnected) {
+return <button onClick={() => connect()}>Connect Wallet</button>;
+}
+return (
+<span>
+{formatAddress(address)} on {network.name}
+</span>
+);
 }
 The context exposes:
 
@@ -131,14 +131,14 @@ app/layout.test.tsx — Integration test verifying the banner is rendered inside
 Sitemap & Robots
 The App Router generates both files automatically using the Next.js file-convention handlers:
 
-File	Served at	Purpose
-app/sitemap.ts	/sitemap.xml	Enumerates public marketing and help routes for crawler discovery
-app/robots.ts	/robots.txt	Disallows authenticated app routes from being indexed
+File Served at Purpose
+app/sitemap.ts /sitemap.xml Enumerates public marketing and help routes for crawler discovery
+app/robots.ts /robots.txt Disallows authenticated app routes from being indexed
 Public routes (sitemap)
-URL	changeFrequency	priority
-https://stellopay.com	weekly	1.0
-https://stellopay.com/help/support	monthly	0.8
-https://stellopay.com/help/support/accountManagement	monthly	0.6
+URL changeFrequency priority
+https://stellopay.com weekly 1.0
+https://stellopay.com/help/support monthly 0.8
+https://stellopay.com/help/support/accountManagement monthly 0.6
 Auth flows (/auth/login, /auth/sign-up, /verify-email) are excluded from the sitemap. They already carry robots: { index: false } in their route metadata and have no organic search value.
 
 Disallowed routes (robots.txt)
@@ -163,18 +163,18 @@ TypeScript
 import sitemap, { BASE_URL, PUBLIC_ROUTES } from "@/app/sitemap";
 import robots, { DISALLOWED_PATHS } from "@/app/robots";
 
-BASE_URL         // "https://stellopay.com"
-PUBLIC_ROUTES    // MetadataRoute.Sitemap — array of public route entries
+BASE_URL // "https://stellopay.com"
+PUBLIC_ROUTES // MetadataRoute.Sitemap — array of public route entries
 DISALLOWED_PATHS // string[] — private route prefixes
 Verifying locally
 After starting the dev server (npm run dev) or after a production build (npm run build && npm run start), inspect the generated files directly:
 
 Bash
 
-# Sitemap
+Sitemap
 curl http://localhost:3000/sitemap.xml
 
-# Robots
+Robots
 curl http://localhost:3000/robots.txt
 Tests
 Sitemap and robots behaviour is covered in app/metadata.test.ts:
@@ -199,22 +199,22 @@ Dynamic Open Graph Image
 app/opengraph-image.tsx implements the Next.js file-convention OG image route. It is served automatically at /opengraph-image and generates a 1200 × 630 px PNG at request time using next/og (ImageResponse / Satori).
 
 What's rendered
-Element	Detail
-Background	White (#FFFFFF) — matches the light-mode hero surface
-Badge	Dark pill with the StelloPay brand name and "Blockchain Payroll" label
-Headline	Three-line hero h1 — "The Future of / Payroll on / Blockchain"
-Gradient	"Payroll on" uses the brand gradient: #2563EB → #7C3AED → #059669
-Tagline	Hero paragraph copy — "Built for modern businesses…"
-Font	Clash Display Variable loaded from public/font/clash-display-variable.ttf
-Decorative blobs	Three radial-gradient orbs mirroring the hero decorative orbs
-Accent bar	Bottom-right brand gradient stripe
+Element Detail
+Background White (#FFFFFF) — matches the light-mode hero surface
+Badge Dark pill with the StelloPay brand name and "Blockchain Payroll" label
+Headline Three-line hero h1 — "The Future of / Payroll on / Blockchain"
+Gradient "Payroll on" uses the brand gradient: #2563EB → #7C3AED → #059669
+Tagline Hero paragraph copy — "Built for modern businesses…"
+Font Clash Display Variable loaded from public/font/clash-display-variable.ttf
+Decorative blobs Three radial-gradient orbs mirroring the hero decorative orbs
+Accent bar Bottom-right brand gradient stripe
 Accessibility
 The OG image is a static bitmap consumed by crawlers and social previews. WCAG 2.1 AA contrast requirements are met for all rendered text:
 
-Text element	Foreground	Background	Contrast ratio
-Headline (dark)	#09090B	#FFFFFF	≈ 20.7 : 1 ✓
-Tagline (muted)	#52525B	#FFFFFF	≈ 7.0 : 1 ✓
-Badge label	#FFFFFF	#09090B	≈ 20.7 : 1 ✓
+Text element Foreground Background Contrast ratio
+Headline (dark) #09090B #FFFFFF ≈ 20.7 : 1 ✓
+Tagline (muted) #52525B #FFFFFF ≈ 7.0 : 1 ✓
+Badge label #FFFFFF #09090B ≈ 20.7 : 1 ✓
 The gradient headline ("Payroll on") is decorative text whose semantic equivalent is conveyed by the alt attribute set in openGraph.images[].alt inside app/layout.tsx:
 
 "StelloPay — The Future of Payroll on Blockchain. Brand gradient headline on white background."
@@ -223,8 +223,8 @@ File locations
 text
 
 app/
-├─ opengraph-image.tsx       # Route handler — generates the PNG
-└─ opengraph-image.test.ts   # Vitest unit tests
+├─ opengraph-image.tsx # Route handler — generates the PNG
+└─ opengraph-image.test.ts # Vitest unit tests
 Exported constants
 The module exports several constants so tests and other files can reference canonical values without duplicating strings:
 
@@ -232,11 +232,11 @@ TypeScript
 
 import OGImage, { size, contentType, BRAND_GRADIENT, COLORS, COPY } from "@/app/opengraph-image";
 
-size           // { width: 1200, height: 630 }
-contentType    // "image/png"
+size // { width: 1200, height: 630 }
+contentType // "image/png"
 BRAND_GRADIENT // { from: "#2563EB", via: "#7C3AED", to: "#059669" }
-COLORS         // { background, foreground, muted, accent }
-COPY           // { headlinePrefix, headlineGradient, headlineSuffix, tagline, brand, badgeSub }
+COLORS // { background, foreground, muted, accent }
+COPY // { headlinePrefix, headlineGradient, headlineSuffix, tagline, brand, badgeSub }
 Font loading
 The handler reads public/font/clash-display-variable.ttf at request time and passes the ArrayBuffer to ImageResponse via the fonts option. If the file cannot be read (e.g., in a stripped production image), the handler falls back gracefully to the default sans-serif typeface — the image is still generated without throwing.
 
@@ -251,7 +251,8 @@ To inspect the raw PNG locally with a running dev server:
 Bash
 
 npm run dev
-# open http://localhost:3000/opengraph-image
+
+open http://localhost:3000/opengraph-image
 Keeping copy in sync
 The headline and tagline in app/opengraph-image.tsx are defined in the COPY constant and should be kept in sync with components/landing/hero.tsx. The unit tests assert the exact strings so a mismatch will fail CI.
 
@@ -259,35 +260,35 @@ Project Structure
 text
 
 stellopay-frontend
-├─ app/                  # Next.js App Router routes, layouts, and segment metadata
-│  ├─ account-summary/
-│  ├─ analytics-view/
-│  ├─ auth/              # login, sign-up
-│  ├─ dashboard/
-│  ├─ help/support/
-│  ├─ settings/          # preferences (tabbed shell — see design/settings-ia.md)
-│  ├─ transactions/
-│  ├─ layout.tsx
-│  └─ page.tsx           # landing page
-├─ components/           # Reusable UI, grouped by feature
-│  ├─ analytics/
-│  ├─ auth/
-│  ├─ common/            # navbar, sidebar, shared inputs
-│  ├─ dashboard/
-│  ├─ landing/
-│  ├─ transactions/
-│  └─ ui/                # shadcn/Radix-based primitives (button, dialog, table, ...)
-├─ context/              # React context providers (sidebar, theme)
-├─ hooks/                # Custom hooks (e.g. useTransactions, usePaymentHistory)
-├─ lib/                  # API client, demo data, shared non-UI logic
-│  └─ api/
-├─ public/               # Static assets
-│  └─ data/              # Mock data used by the UI in the absence of a real backend
-├─ types/                # Shared TypeScript types
-├─ utils/                # Pure utility functions (formatting, pagination, auth, dates, ...)
-├─ tests/                # Playwright E2E specs
-├─ e2e/                  # Additional Playwright specs
-└─ pages/                # Legacy Pages Router landing page assets
+├─ app/ # Next.js App Router routes, layouts, and segment metadata
+│ ├─ account-summary/
+│ ├─ analytics-view/
+│ ├─ auth/ # login, sign-up
+│ ├─ dashboard/
+│ ├─ help/support/
+│ ├─ settings/ # preferences (tabbed shell — see design/settings-ia.md)
+│ ├─ transactions/
+│ ├─ layout.tsx
+│ └─ page.tsx # landing page
+├─ components/ # Reusable UI, grouped by feature
+│ ├─ analytics/
+│ ├─ auth/
+│ ├─ common/ # navbar, sidebar, shared inputs
+│ ├─ dashboard/
+│ ├─ landing/
+│ ├─ transactions/
+│ └─ ui/ # shadcn/Radix-based primitives (button, dialog, table, ...)
+├─ context/ # React context providers (sidebar, theme)
+├─ hooks/ # Custom hooks (e.g. useTransactions, usePaymentHistory)
+├─ lib/ # API client, demo data, shared non-UI logic
+│ └─ api/
+├─ public/ # Static assets
+│ └─ data/ # Mock data used by the UI in the absence of a real backend
+├─ types/ # Shared TypeScript types
+├─ utils/ # Pure utility functions (formatting, pagination, auth, dates, ...)
+├─ tests/ # Playwright E2E specs
+├─ e2e/ # Additional Playwright specs
+└─ pages/ # Legacy Pages Router landing page assets
 Settings section structure
 app/settings/preferences is a tabbed shell with five sections — Account
 (profile, identity, and locale defaults), Notifications (transaction alerts
@@ -323,13 +324,13 @@ React
 import { useTheme } from "@/context/theme-context";
 
 export default function MyComponent() {
-  const { theme, toggleTheme, setTheme } = useTheme();
+const { theme, toggleTheme, setTheme } = useTheme();
 
-  // Access current theme ("light" or "dark")
-  console.log(theme);
+// Access current theme ("light" or "dark")
+console.log(theme);
 
-  // Toggle between light and dark themes
-  return <button onClick={toggleTheme}>Toggle Theme</button>;
+// Toggle between light and dark themes
+return <button onClick={toggleTheme}>Toggle Theme</button>;
 }
 Theme Toggle UI: Located in the top-right corner within components/landing/navbar.tsx.
 System Preference: Falls back to the system's preferred color scheme if no preference is stored in localStorage.
@@ -337,8 +338,8 @@ Tailwind Integration: Utilizes Tailwind's native dark: modifier (e.g. bg-white d
 Testing
 npm run test runs the Vitest unit suite with coverage for utils (auth, transactions, pagination, dates), auth schemas, and select components. Coverage thresholds are enforced at 95% (lines/branches/functions/statements) for the files listed in vitest.config.ts.
 npm run test:watch runs Vitest in watch mode while developing unit tests.
-npm run test:e2e runs the full Playwright suite under tests/**/*.spec.ts and e2e/**/*.spec.ts across chromium, firefox, and webkit against a local dev server.
-Unit tests for utils/*.ts are colocated as utils/<name>.test.ts (e.g. utils/date-utils.test.ts); Playwright specs live under tests/*.spec.ts.
+npm run test:e2e runs the full Playwright suite under tests//*.spec.ts and e2e//.spec.ts across chromium, firefox, and webkit against a local dev server.
+Unit tests for utils/.ts are colocated as utils/<name>.test.ts (e.g. utils/date-utils.test.ts); Playwright specs live under tests/*.spec.ts.
 Covered Flows
 Authentication: Validation rules (email format, strong passwords matching), form state, and UI feedback for Login (tests/auth-login.spec.ts), Sign-up (tests/auth-signup.spec.ts), and Email Verification (tests/verify-email.spec.ts).
 Wallet: Connect, disconnect, and network switching (tests/wallet.spec.ts).
@@ -360,12 +361,12 @@ Triaged allowlist: a known issue that can't be fixed immediately should be allow
 TypeScript
 
 await expectNoSeriousA11yViolations(page, {
-  allowlist: [
-    {
-      id: "color-contrast",
-      reason: "Tracked in #999 — pending design token update",
-    },
-  ],
+allowlist: [
+{
+id: "color-contrast",
+reason: "Tracked in #999 — pending design token update",
+},
+],
 });
 Allowlisted violations still print to the console on every run so they stay visible instead of disappearing.
 
@@ -373,9 +374,9 @@ Running scans locally:
 
 Bash
 
-npx playwright test                                # full suite, includes a11y scans
-npx playwright test tests/dashboard.spec.ts         # a single spec
-npx playwright show-report                          # inspect the last HTML report
+npx playwright test # full suite, includes a11y scans
+npx playwright test tests/dashboard.spec.ts # a single spec
+npx playwright show-report # inspect the last HTML report
 Interpreting a failure: the test output includes the axe rule id, impact level, the number of affected DOM nodes (with selectors), and a helpUrl linking to the deque rule documentation explaining the fix. Reproduce locally with npx playwright test --headed <file> to inspect the flagged elements in the browser.
 
 Iconography
@@ -391,14 +392,14 @@ CI Guard Test: utils/import-guard.test.ts scans all source files in app/ and com
 CI Pipeline
 Every pull request and push to main runs two jobs via .github/workflows/ci.yml:
 
-Job	Step	Command	Purpose
-lint-typecheck-build	Install dependencies	npm ci	Reproducible install from lockfile
-Unit Tests	npm run test	Vitest utility/schema tests for auth, transaction, pagination, and date utils, plus auth schemas
-Lint	npm run lint	ESLint via next lint
-Type-check	npm run type-check	tsc --noEmit — catches type errors
-Build	npm run build	Full Next.js production build
-playwright	Install Playwright browsers	npx playwright install --with-deps chromium	Provision the Chromium runtime used by the suite
-E2E + accessibility	npx playwright test	Full Playwright suite, including the axe-core a11y scans described in Accessibility testing — a serious/critical violation fails this job
+Job Step Command Purpose
+lint-typecheck-build Install dependencies npm ci Reproducible install from lockfile
+Unit Tests npm run test Vitest utility/schema tests for auth, transaction, pagination, and date utils, plus auth schemas
+Lint npm run lint ESLint via next lint
+Type-check npm run type-check tsc --noEmit — catches type errors
+Build npm run build Full Next.js production build
+playwright Install Playwright browsers npx playwright install --with-deps chromium Provision the Chromium runtime used by the suite
+E2E + accessibility npx playwright test Full Playwright suite, including the axe-core a11y scans described in Accessibility testing — a serious/critical violation fails this job
 On failure, the playwright job uploads the HTML report as a build artifact (playwright-report, retained 7 days) so violations and traces can be inspected without re-running locally.
 
 Running a single browser locally
@@ -426,15 +427,15 @@ Chart & Insights Code-Splitting: Dynamically loaded the recharts-heavy component
 Optimized Layout Animations: Replaced framer-motion JS-driven layout width transitions on the sidebar container (components/common/side-bar.tsx) with pure CSS grid animations to prevent layout thrashing and lower Total Blocking Time (TBT).
 Hero Image Optimization: Upgraded native img tags for the network logo assets inside the above-the-fold Hero component (components/landing/hero.tsx) to Next.js Image components with explicit dimensions.
 Bundle Size Impact (next build Route JS)
-Route	Metric	Before	After	Change
-/landing (Pages Router)	Route Size	64.1 kB	26.1 kB	-38.0 kB (-59.3%)
-/landing (Pages Router)	First Load JS	165 kB	127 kB	-38.0 kB (-23.0%)
+Route Metric Before After Change
+/landing (Pages Router) Route Size 64.1 kB 26.1 kB -38.0 kB (-59.3%)
+/landing (Pages Router) First Load JS 165 kB 127 kB -38.0 kB (-23.0%)
 Bundle Budget
 We maintain a CI-enforced bundle budget for key routes to ensure fast first-load performance.
 
-Route	Budget	Current First Load JS
-/ (Landing)	225 kB	213 kB
-/dashboard	180 kB	165 kB
+Route Budget Current First Load JS
+/ (Landing) 225 kB 213 kB
+/dashboard 180 kB 165 kB
 To run the bundle analyzer locally:
 
 Bash
@@ -459,3 +460,36 @@ Transactions (app/transactions/layout.tsx): Configures route title, description,
 Settings & Preferences (app/settings/preferences/layout.tsx): Configures route title, description, canonical URL (https://stellopay.com/settings/preferences), Open Graph image (/opengraph-image), and robots: { index: false, follow: false } directives.
 Testing and Validation
 All metadata exports are covered by unit tests in app/metadata.test.ts to verify uniqueness of titles/descriptions, correct canonical URLs, Open Graph parameters, and fallback logic.
+
+Font loading and first paint
+The landing-page hero uses local Clash Display and General Sans variable
+fonts. Their loading configuration is defined in app/layout.tsx:
+
+preload: true asks next/font/local to emit a <link rel="preload" as="font"> for each above-the-fold font. Next.js supplies the emitted,
+fingerprinted URL and the correct type/crossorigin attributes, avoiding
+stale or duplicate hand-written links.
+Both local font faces set display: "swap". Text therefore remains visible
+in its system-font fallback while a slow font download completes; this avoids
+FOIT. The General Sans CSS variable is --font-general-sans, matching the
+existing typography tokens in app/globals.css.
+This change alters font delivery only: it does not add focusable UI or modify
+colours, ARIA semantics, responsive breakpoints (sm, md, lg, xl), or
+dark-mode tokens. The existing skip link, keyboard navigation, and WCAG 2.1 AA
+contrast remain intact.
+
+Verification
+Run the focused contract test and production build:
+
+Bash
+
+npx vitest run app/metadata.test.ts --coverage.enabled=false
+npm run type-check
+npm run build
+For a deployment-specific LCP comparison, use a fresh Chrome profile and the
+same landing-page URL for both revisions. In DevTools Performance, select a
+mobile device, disable cache, set Slow 4G with 4× CPU slowdown, record a
+reload, and note the LCP marker. Repeat at least three times per revision and
+compare the medians. The preload requests should begin in the document head
+before hero text is discovered; exact LCP values depend on the host, cache, and
+network, so they should be captured in CI or the target deployment rather than
+claimed from a local build.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,20 +12,29 @@ import { Toaster } from "@/components/ui/toaster";
 const inter = Inter({
   variable: "--font-inter",
   subsets: ["latin"],
+  // Keep the fallback visible for the remaining custom typeface as well.
+  display: "swap",
 });
 
+/**
+ * These first-viewport local fonts explicitly use Next.js preloading and a
+ * swap display policy. Next.js emits fingerprinted preload links, so there is
+ * no fragile hand-written URL that could become stale after a build.
+ */
 const clashDisplay = localFont({
   src: "../public/font/clash-display-variable.ttf",
   variable: "--font-clash",
   weight: "500",
   display: "swap",
+  preload: true,
 });
 
 const generalSans = localFont({
   src: "../public/font/general-sans-variable.ttf",
-  variable: "--font-general",
+  variable: "--font-general-sans",
   weight: "400",
   display: "swap",
+  preload: true,
 });
 
 /**

--- a/app/metadata.test.ts
+++ b/app/metadata.test.ts
@@ -1,14 +1,21 @@
 import { describe, expect, it, vi } from "vitest";
 
+const { mockLocalFont } = vi.hoisted(() => ({
+  mockLocalFont: vi.fn(() => ({ variable: "font-local" })),
+}));
+
 vi.mock("next/font/google", () => ({
   Inter: () => ({ variable: "font-inter" }),
 }));
 
 vi.mock("next/font/local", () => ({
-  default: () => ({ variable: "font-local" }),
+  default: mockLocalFont,
 }));
 
-import { metadata as rootMetadata, viewport as rootViewport } from "@/app/layout";
+import {
+  metadata as rootMetadata,
+  viewport as rootViewport,
+} from "@/app/layout";
 import sitemap, { BASE_URL, PUBLIC_ROUTES } from "@/app/sitemap";
 import robots, { DISALLOWED_PATHS } from "@/app/robots";
 import { metadata as dashboardMetadata } from "@/app/dashboard/layout";
@@ -31,6 +38,28 @@ describe("Route Metadata Exports", () => {
     expect(rootViewport).toBeDefined();
     expect(rootViewport.themeColor).toBeDefined();
     expect(rootViewport.width).toBe("device-width");
+  });
+
+  it("preloads above-the-fold local fonts and uses swap to avoid FOIT", () => {
+    const localFonts = mockLocalFont.mock.calls.map(([options]) => options);
+
+    expect(localFonts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          src: "../public/font/clash-display-variable.ttf",
+          variable: "--font-clash",
+          display: "swap",
+          preload: true,
+        }),
+        expect.objectContaining({
+          src: "../public/font/general-sans-variable.ttf",
+          // Matches the body typography token in app/globals.css.
+          variable: "--font-general-sans",
+          display: "swap",
+          preload: true,
+        }),
+      ]),
+    );
   });
 
   it("each route exports unique page titles and descriptions", () => {
@@ -119,21 +148,33 @@ describe("Route Metadata Exports", () => {
 
   it("exports canonical URLs for dashboard, transactions, and settings routes", () => {
     expect(dashboardMetadata.alternates?.canonical).toBe(
-      "https://stellopay.com/dashboard"
+      "https://stellopay.com/dashboard",
     );
     expect(transactionsMetadata.alternates?.canonical).toBe(
-      "https://stellopay.com/transactions"
+      "https://stellopay.com/transactions",
     );
     expect(settingsMetadata.alternates?.canonical).toBe(
-      "https://stellopay.com/settings/preferences"
+      "https://stellopay.com/settings/preferences",
     );
   });
 
   it("exports Open Graph and Twitter metadata variants with dedicated images", () => {
     const routes = [
-      { meta: dashboardMetadata, expectedUrl: "https://stellopay.com/dashboard", expectedImage: "/dashboard-preview.jpg" },
-      { meta: transactionsMetadata, expectedUrl: "https://stellopay.com/transactions", expectedImage: "/opengraph-image" },
-      { meta: settingsMetadata, expectedUrl: "https://stellopay.com/settings/preferences", expectedImage: "/opengraph-image" },
+      {
+        meta: dashboardMetadata,
+        expectedUrl: "https://stellopay.com/dashboard",
+        expectedImage: "/dashboard-preview.jpg",
+      },
+      {
+        meta: transactionsMetadata,
+        expectedUrl: "https://stellopay.com/transactions",
+        expectedImage: "/opengraph-image",
+      },
+      {
+        meta: settingsMetadata,
+        expectedUrl: "https://stellopay.com/settings/preferences",
+        expectedImage: "/opengraph-image",
+      },
     ];
 
     routes.forEach(({ meta, expectedUrl, expectedImage }) => {
@@ -142,7 +183,10 @@ describe("Route Metadata Exports", () => {
       expect(meta.openGraph?.siteName).toBe("StelloPay");
       expect(meta.openGraph?.images).toBeDefined();
 
-      const ogImages = meta.openGraph?.images as Array<{ url: string | URL; alt?: string }>;
+      const ogImages = meta.openGraph?.images as Array<{
+        url: string | URL;
+        alt?: string;
+      }>;
       expect(ogImages.length).toBeGreaterThan(0);
       expect(String(ogImages[0].url)).toBe(expectedImage);
 
@@ -401,7 +445,9 @@ describe("Robots — app/robots.ts", () => {
   it("result includes a sitemap URL", () => {
     const result = robots();
     expect(result.sitemap).toBeDefined();
-    expect(typeof result.sitemap === "string" || Array.isArray(result.sitemap)).toBe(true);
+    expect(
+      typeof result.sitemap === "string" || Array.isArray(result.sitemap),
+    ).toBe(true);
   });
 
   it("sitemap URL points to /sitemap.xml on the canonical domain", () => {
@@ -428,7 +474,11 @@ describe("Robots — app/robots.ts", () => {
   });
 
   it("DISALLOWED_PATHS does not contain public marketing routes", () => {
-    const publicRoutes = ["/", "/help/support", "/help/support/accountManagement"];
+    const publicRoutes = [
+      "/",
+      "/help/support",
+      "/help/support/accountManagement",
+    ];
     publicRoutes.forEach((route) => {
       expect(DISALLOWED_PATHS).not.toContain(route);
     });


### PR DESCRIPTION
Description
Improves first-paint font loading for the landing page by explicitly preloading the above-the-fold local Clash Display and General Sans font assets through Next.js next/font/local.

Changes included:

Added preload: true for Clash Display and General Sans in app/layout.tsx.
Confirmed display: "swap" for Clash Display, General Sans, and Inter to prevent invisible text while fonts load.
Corrected the General Sans font variable from --font-general to --font-general-sans so it matches the existing typography token usage in app/globals.css.
Added metadata-level regression coverage that verifies preload and swap-display configuration for both local fonts.
Documented the font-loading strategy, accessibility/responsive impact, and throttled LCP measurement procedure in the README.
Next.js generates the appropriate fingerprinted <link rel="preload" as="font"> tags during production builds. This avoids fragile manually authored preload URLs and ensures preload URLs always match emitted assets.

Related Issue
Addresses the reported font-loading performance issue:

app/layout.tsx loaded Clash Display and General Sans without explicit preload configuration, creating a risk of delayed first paint or FOIT on slow connections, especially in the text-heavy landing hero.

Checklist
 I have tested the changes locally.

Passed: npx vitest run app/layout.test.tsx app/metadata.test.ts --coverage.enabled=false
Result: 42 tests passed.
 I have added/updated documentation as needed.

Added README guidance for preload behavior, font-display: swap, accessibility impact, and Slow 4G LCP verification.
 I have reviewed the code and ensured it follows the project guidelines.

Uses the existing Next.js App Router and next/font/local approach.
Preserves existing design tokens, responsive breakpoints, keyboard navigation, skip link, dark mode, and WCAG 2.1 AA behavior.
 I have added necessary tests.

Added regression assertions in app/metadata.test.ts for the font preload, display strategy, asset paths, and General Sans variable name.
Screenshots/Recordings
No screenshots are included because this is a font-delivery and first-paint performance change with no intended visual design change.

The README includes a repeatable procedure for capturing before/after LCP measurements in Chrome DevTools using Slow 4G, disabled cache, and 4× CPU throttling.

Additional Notes
npm run type-check and npm run build were attempted but are blocked by pre-existing syntax errors in unrelated files:

app/settings/preferences/components/account-section.tsx
app/verify-email/page.tsx
components/common/notification-panel.tsx
The final build output no longer reports a font-loader error from app/layout.tsx; the remaining failures are unrelated to this PR.

Files modified:

app/layout.tsx
app/metadata.test.ts
README.md

Closes #778 