### PR TITLE
feat(settings): add digest frequency selector per notification channel

### DIFF
--- a/app/settings/preferences/components/notifications-section.test.tsx
+++ b/app/settings/preferences/components/notifications-section.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { useForm, FormProvider } from "react-hook-form";
 import NotificationsSection, {
   DEFAULT_NOTIFICATION_SETTINGS,
+  DIGEST_FREQUENCY_LABELS,
 } from "./notifications-section";
 
 const TestWrapper = ({ children }: { children: React.ReactNode }) => {
@@ -49,6 +50,33 @@ describe("NotificationsSection", () => {
 
     const emailToggle = screen.getByRole("switch", { name: /Email/i });
     expect(emailToggle).not.toBeChecked();
+  });
+
+  it("merges new digest frequency defaults when loading older stored payloads", () => {
+    // Simulate an older stored payload missing digest frequency fields
+    const oldPayload = {
+      transactionAlerts: true,
+      securityAlerts: true,
+      productUpdates: true,
+      marketing: false,
+      emailChannel: true,
+      pushChannel: true,
+      smsChannel: false,
+    };
+    localStorage.setItem(
+      "notification_preferences",
+      JSON.stringify(oldPayload),
+    );
+
+    render(
+      <TestWrapper>
+        <NotificationsSection />
+      </TestWrapper>,
+    );
+
+    // The email digest selector should default to "immediate"
+    const immediateRadio = screen.getByTestId("digest-email-immediate");
+    expect(immediateRadio).toBeChecked();
   });
 
   it("handles successful save via mock API", async () => {
@@ -171,5 +199,220 @@ describe("NotificationsSection", () => {
       localStorage.getItem("notification_preferences") || "{}",
     );
     expect(stored.marketing).toBe(true);
+  });
+});
+
+// ─── Digest Frequency Tests ─────────────────────────────────────────────────
+
+describe("NotificationsSection – digest frequency", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders digest frequency selectors for each enabled channel", () => {
+    render(
+      <TestWrapper>
+        <NotificationsSection />
+      </TestWrapper>,
+    );
+
+    // Email and push channels are enabled by default
+    expect(
+      screen.getByTestId("digest-email-immediate"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("digest-push-immediate"),
+    ).toBeInTheDocument();
+
+    // SMS channel is disabled by default, so its selector is hidden
+    expect(
+      screen.queryByTestId("digest-sms-immediate"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows SMS digest selector when SMS channel is enabled", async () => {
+    render(
+      <TestWrapper>
+        <NotificationsSection />
+      </TestWrapper>,
+    );
+
+    // Enable SMS channel
+    const smsToggle = screen.getByRole("switch", { name: /SMS fallback/i });
+    await userEvent.click(smsToggle);
+
+    expect(
+      screen.getByTestId("digest-sms-immediate"),
+    ).toBeInTheDocument();
+  });
+
+  it("persists digest frequency changes to localStorage on save", async () => {
+    render(
+      <TestWrapper>
+        <NotificationsSection />
+      </TestWrapper>,
+    );
+
+    // Select "Daily digest" for email
+    const dailyRadio = screen.getByTestId("digest-email-daily");
+    await userEvent.click(dailyRadio);
+
+    const saveButton = screen.getByRole("button", {
+      name: /Save notification settings/i,
+    });
+    await userEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Notification preferences updated. Critical alerts remain prioritized.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    const stored = JSON.parse(
+      localStorage.getItem("notification_preferences") || "{}",
+    );
+    expect(stored.emailDigestFrequency).toBe("daily");
+    expect(stored.pushDigestFrequency).toBe("immediate");
+  });
+
+  it("sends digest frequency in API payload", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "http://localhost:3000";
+
+    const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(() => {
+      return new Promise((resolve) => {
+        setTimeout(
+          () => resolve({ ok: true, json: async () => ({}) } as Response),
+          100,
+        );
+      });
+    });
+
+    render(
+      <TestWrapper>
+        <NotificationsSection />
+      </TestWrapper>,
+    );
+
+    // Select "Weekly digest" for email
+    const weeklyRadio = screen.getByTestId("digest-email-weekly");
+    await userEvent.click(weeklyRadio);
+
+    const saveButton = screen.getByRole("button", {
+      name: /Save notification settings/i,
+    });
+    await userEvent.click(saveButton);
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText(
+            "Notification preferences updated. Critical alerts remain prioritized.",
+          ),
+        ).toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]?.[1] as RequestInit)?.body as string,
+    );
+    expect(body.emailDigestFrequency).toBe("weekly");
+  });
+
+  it("disables per-event toggles when a digest frequency is selected", async () => {
+    render(
+      <TestWrapper>
+        <NotificationsSection />
+      </TestWrapper>,
+    );
+
+    // Select "Daily digest" for email
+    const dailyRadio = screen.getByTestId("digest-email-daily");
+    await userEvent.click(dailyRadio);
+
+    // Per-event toggles should now be disabled
+    const transactionToggle = screen.getByRole("switch", {
+      name: /Transaction alerts/i,
+    });
+    expect(transactionToggle).toBeDisabled();
+
+    const securityToggle = screen.getByRole("switch", {
+      name: /Security notifications/i,
+    });
+    expect(securityToggle).toBeDisabled();
+  });
+
+  it("re-enables per-event toggles when switching back to immediate", async () => {
+    render(
+      <TestWrapper>
+        <NotificationsSection />
+      </TestWrapper>,
+    );
+
+    // Select "Weekly digest" for email, then back to "Immediate"
+    const weeklyRadio = screen.getByTestId("digest-email-weekly");
+    await userEvent.click(weeklyRadio);
+
+    const transactionToggle = screen.getByRole("switch", {
+      name: /Transaction alerts/i,
+    });
+    expect(transactionToggle).toBeDisabled();
+
+    const immediateRadio = screen.getByTestId("digest-email-immediate");
+    await userEvent.click(immediateRadio);
+
+    expect(transactionToggle).not.toBeDisabled();
+  });
+
+  it("applies digest frequencies to all channels independently", async () => {
+    render(
+      <TestWrapper>
+        <NotificationsSection />
+      </TestWrapper>,
+    );
+
+    // Enable SMS first
+    const smsToggle = screen.getByRole("switch", { name: /SMS fallback/i });
+    await userEvent.click(smsToggle);
+
+    // Email → daily, Push → weekly, SMS → daily
+    await userEvent.click(screen.getByTestId("digest-email-daily"));
+    await userEvent.click(screen.getByTestId("digest-push-weekly"));
+    await userEvent.click(screen.getByTestId("digest-sms-daily"));
+
+    // All three should reflect their selected values
+    expect(screen.getByTestId("digest-email-daily")).toBeChecked();
+    expect(screen.getByTestId("digest-push-weekly")).toBeChecked();
+    expect(screen.getByTestId("digest-sms-daily")).toBeChecked();
+  });
+
+  it("hides digest selector when its channel is disabled", async () => {
+    render(
+      <TestWrapper>
+        <NotificationsSection />
+      </TestWrapper>,
+    );
+
+    // Email has a digest selector visible
+    expect(
+      screen.getByTestId("digest-email-immediate"),
+    ).toBeInTheDocument();
+
+    // Turn off email channel (accessible name is "Email, enabled")
+    const emailToggle = screen.getByRole("switch", { name: /Email/i });
+    await userEvent.click(emailToggle);
+
+    // Digest selector should disappear
+    expect(
+      screen.queryByTestId("digest-email-immediate"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/app/settings/preferences/components/notifications-section.tsx
+++ b/app/settings/preferences/components/notifications-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useId } from "react";
 import ToggleCard from "@/components/common/toggle-card";
 import { Button } from "@/components/ui/button";
 import { FormMessage } from "@/components/ui/form";
@@ -12,6 +12,15 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
+/** Available digest frequency options for each notification channel. */
+export type DigestFrequency = "immediate" | "daily" | "weekly";
+
+export const DIGEST_FREQUENCY_LABELS: Record<DigestFrequency, string> = {
+  immediate: "Immediate",
+  daily: "Daily digest",
+  weekly: "Weekly digest",
+};
+
 export interface NotificationSettingsState {
   transactionAlerts: boolean;
   securityAlerts: boolean;
@@ -20,6 +29,12 @@ export interface NotificationSettingsState {
   emailChannel: boolean;
   pushChannel: boolean;
   smsChannel: boolean;
+  /** Digest frequency for email channel. Defaults to "immediate". */
+  emailDigestFrequency: DigestFrequency;
+  /** Digest frequency for push channel. Defaults to "immediate". */
+  pushDigestFrequency: DigestFrequency;
+  /** Digest frequency for SMS channel. Defaults to "immediate". */
+  smsDigestFrequency: DigestFrequency;
 }
 
 /**
@@ -35,17 +50,119 @@ export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettingsState = {
   emailChannel: true,
   pushChannel: true,
   smsChannel: false,
+  emailDigestFrequency: "immediate",
+  pushDigestFrequency: "immediate",
+  smsDigestFrequency: "immediate",
 };
 
 /**
  * Count how many notification preferences are currently enabled. Used by the
  * settings summary "Alerts enabled" card so the number tracks real state.
+ *
+ * Only counts boolean fields — digest frequency strings are excluded.
  */
 export function countActiveNotifications(
   settings: NotificationSettingsState,
 ): number {
-  return Object.values(settings).filter(Boolean).length;
+  return Object.entries(settings).filter(
+    ([, value]) => typeof value === "boolean" && value === true,
+  ).length;
 }
+
+// ─── Digest Frequency Selector ───────────────────────────────────────────────
+
+interface DigestFrequencySelectorProps {
+  value: DigestFrequency;
+  channel: "email" | "push" | "sms";
+  channelEnabled: boolean;
+  onChange: (freq: DigestFrequency) => void;
+}
+
+/**
+ * Radio-group-style selector for choosing digest frequency per channel.
+ *
+ * Accessibility:
+ * - Uses native radio inputs inside a fieldset for keyboard navigation.
+ * - Visually hidden when the parent channel is disabled.
+ */
+function DigestFrequencySelector({
+  value,
+  channel,
+  channelEnabled,
+  onChange,
+}: DigestFrequencySelectorProps) {
+  const legendId = useId();
+
+  if (!channelEnabled) {
+    return null;
+  }
+
+  const options: DigestFrequency[] = ["immediate", "daily", "weekly"];
+
+  return (
+    <fieldset
+      aria-labelledby={legendId}
+      className="rounded-xl border border-zinc-200/80 bg-white p-3 dark:border-white/10 dark:bg-white/5"
+    >
+      <legend id={legendId} className="sr-only">
+        {channel} digest frequency
+      </legend>
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
+          Frequency:
+        </span>
+        {options.map((freq) => {
+          const inputId = `digest-${channel}-${freq}`;
+          return (
+            <label
+              key={freq}
+              htmlFor={inputId}
+              className={`inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors focus-within:ring-2 focus-within:ring-zinc-900 focus-within:ring-offset-1 dark:focus-within:ring-white ${
+                value === freq
+                  ? "border-zinc-900 bg-zinc-900 text-white dark:border-white dark:bg-white dark:text-zinc-900"
+                  : "border-zinc-300 bg-transparent text-zinc-700 hover:border-zinc-400 dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-zinc-500"
+              }`}
+            >
+              <input
+                type="radio"
+                id={inputId}
+                name={`digest-frequency-${channel}`}
+                value={freq}
+                checked={value === freq}
+                onChange={() => onChange(freq)}
+                data-testid={`digest-${channel}-${freq}`}
+                className="sr-only"
+              />
+              {DIGEST_FREQUENCY_LABELS[freq]}
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true when the given channel has a non-immediate digest frequency
+ * selected, meaning per-event toggles should be visually disabled.
+ */
+function isDigestActive(
+  s: NotificationSettingsState,
+  channel: "email" | "push" | "sms",
+): boolean {
+  switch (channel) {
+    case "email":
+      return s.emailDigestFrequency !== "immediate";
+    case "push":
+      return s.pushDigestFrequency !== "immediate";
+    case "sms":
+      return s.smsDigestFrequency !== "immediate";
+  }
+}
+
+// ─── Notifications Section ───────────────────────────────────────────────────
 
 interface NotificationsSectionProps {
   /**
@@ -72,7 +189,10 @@ export default function NotificationsSection({
     try {
       const stored = localStorage.getItem("notification_preferences");
       if (stored) {
-        setInternalSettings(JSON.parse(stored));
+        const parsed = JSON.parse(stored);
+        // Merge with defaults so new fields (digest frequencies) have
+        // sensible values even when loaded from older stored payloads.
+        setInternalSettings({ ...DEFAULT_NOTIFICATION_SETTINGS, ...parsed });
       }
     } catch (_e) {
       // Ignore parse errors or disabled storage
@@ -126,22 +246,32 @@ export default function NotificationsSection({
     }
   };
 
-const updateSetting = (
-  field: keyof NotificationSettingsState,
-  value: boolean,
-) => {
-  if (settings[field] === value) {
-    return;
-  }
+  const updateSetting = (
+    field: keyof NotificationSettingsState,
+    value: boolean | DigestFrequency,
+  ) => {
+    if (settings[field] === value) {
+      return;
+    }
 
-  const next = { ...settings, [field]: value };
+    const next = { ...settings, [field]: value };
 
-  if (onSettingsChange) {
-    onSettingsChange(next);
-  } else {
-    setInternalSettings(next);
-  }
-};
+    if (onSettingsChange) {
+      onSettingsChange(next);
+    } else {
+      setInternalSettings(next);
+    }
+  };
+
+  /**
+   * Whether per-event notification toggles should be disabled.
+   * When any channel has a digest frequency set, we disable the
+   * individual event toggles because the user prefers summaries.
+   */
+  const eventTogglesDisabled =
+    isDigestActive(settings, "email") ||
+    isDigestActive(settings, "push") ||
+    isDigestActive(settings, "sms");
 
   return (
     <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
@@ -160,6 +290,7 @@ const updateSetting = (
             title="Transaction alerts"
             description="Receive deposits, withdrawals, and transfer status changes as they happen."
             enabled={settings.transactionAlerts}
+            disabled={eventTogglesDisabled}
             onToggle={(value) => updateSetting("transactionAlerts", value)}
           />
           <ToggleCard
@@ -167,18 +298,21 @@ const updateSetting = (
             description="Get alerted for sign-ins, password resets, and suspicious activity."
             badge="Critical"
             enabled={settings.securityAlerts}
+            disabled={eventTogglesDisabled}
             onToggle={(value) => updateSetting("securityAlerts", value)}
           />
           <ToggleCard
             title="Product updates"
             description="Receive updates when new features or policy changes affect your account."
             enabled={settings.productUpdates}
+            disabled={eventTogglesDisabled}
             onToggle={(value) => updateSetting("productUpdates", value)}
           />
           <ToggleCard
             title="Marketing and announcements"
             description="Optional campaigns, launch notes, and educational content."
             enabled={settings.marketing}
+            disabled={eventTogglesDisabled}
             onToggle={(value) => updateSetting("marketing", value)}
           />
 
@@ -193,17 +327,41 @@ const updateSetting = (
                 enabled={settings.emailChannel}
                 onToggle={(value) => updateSetting("emailChannel", value)}
               />
+              <DigestFrequencySelector
+                value={settings.emailDigestFrequency}
+                channel="email"
+                channelEnabled={settings.emailChannel}
+                onChange={(freq) =>
+                  updateSetting("emailDigestFrequency", freq)
+                }
+              />
               <ToggleCard
                 title="Push notifications"
                 description="Fastest way to catch changes while you are signed in."
                 enabled={settings.pushChannel}
                 onToggle={(value) => updateSetting("pushChannel", value)}
               />
+              <DigestFrequencySelector
+                value={settings.pushDigestFrequency}
+                channel="push"
+                channelEnabled={settings.pushChannel}
+                onChange={(freq) =>
+                  updateSetting("pushDigestFrequency", freq)
+                }
+              />
               <ToggleCard
                 title="SMS fallback"
                 description="Reserved for urgent or delivery-critical events."
                 enabled={settings.smsChannel}
                 onToggle={(value) => updateSetting("smsChannel", value)}
+              />
+              <DigestFrequencySelector
+                value={settings.smsDigestFrequency}
+                channel="sms"
+                channelEnabled={settings.smsChannel}
+                onChange={(freq) =>
+                  updateSetting("smsDigestFrequency", freq)
+                }
               />
             </div>
           </details>


### PR DESCRIPTION
## Summary
Closes #910

Adds per-channel digest frequency selectors (Immediate / Daily digest / Weekly digest) to the notifications settings section.

### Changes
- Add `DigestFrequency` type and `DIGEST_FREQUENCY_LABELS` map
- Add `DigestFrequencySelector` component with accessible radio-group UI
- Add `emailDigestFrequency`, `pushDigestFrequency`, `smsDigestFrequency` to state
- Disable per-event toggles when any channel has a digest frequency selected
- Merge digest defaults when loading older stored payloads (backward compat)
- Update `countActiveNotifications` to only count boolean fields
- Comprehensive test coverage (13 tests)

### Testing
- All 13 tests in `notifications-section.test.tsx` pass
- Covers: rendering, save, localStorage persistence, API payload, channel enable/disable, backward compat