### PR TITLE
style: add print stylesheet for the transactions table

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -140,6 +140,43 @@
   @page {
     margin: 16mm;
   }
+
+  /* ── Transactions table print scope ─────────────────────────────────────
+   * When printing the interactive transactions page, hide every control
+   * (filters, search, pagination, sort triggers, checkboxes, density
+   * toggle, receipt download buttons) and show only the data rows in a
+   * legible, grayscale-friendly layout with no page-breaks inside rows.
+   * Fully independent of the reconciliation-statement scope above.      */
+
+  .transactions-print-root,
+  .transactions-print-root * {
+    visibility: visible;
+  }
+
+  .transactions-print-root {
+    position: static;
+    background: #ffffff !important;
+    color: #111827 !important;
+  }
+
+  .transactions-print-root * {
+    color: #111827 !important;
+    background-color: transparent !important;
+    border-color: #d1d5db !important;
+  }
+
+  .transactions-print-root table tr {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .transactions-print-root table thead {
+    display: table-header-group;
+  }
+
+  .transactions-print-root img {
+    filter: grayscale(100%) contrast(1.15);
+  }
 }
 
 @utility text-body-lg {

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -571,7 +571,7 @@ export default function TransactionsContent() {
           : ""}
       </div>
 
-      <div className="w-full max-w-7xl mx-auto mb-4">
+      <div className="w-full max-w-7xl mx-auto mb-4 transactions-print-root">
         <TransactionsHeader
           fromDate={filters.fromDate}
           toDate={filters.toDate}
@@ -579,7 +579,7 @@ export default function TransactionsContent() {
           onToDateChange={(date) => updateFilter("toDate", date)}
         />
 
-        <div className="mb-4 flex justify-end px-4 sm:px-6 lg:px-8">
+        <div className="mb-4 flex justify-end px-4 sm:px-6 lg:px-8 print:hidden">
           <button
             type="button"
             onClick={() =>
@@ -628,14 +628,16 @@ export default function TransactionsContent() {
         </div>
 
         <div className="px-4 sm:px-6 lg:px-8 bg-[#160f17] pt-3 border-[#2D2D2D] border rounded-xl">
-          <TransactionsFilters
-            searchQuery={filters.searchQuery}
-            selectedFilter={filters.selectedFilter}
-            sortConfigs={filters.sortConfigs}
-            onSearchChange={(q) => updateFilter("searchQuery", q)}
-            onFilterChange={(f) => updateFilter("selectedFilter", f)}
-            onSort={handleSort}
-          />
+          <div className="print:hidden">
+            <TransactionsFilters
+              searchQuery={filters.searchQuery}
+              selectedFilter={filters.selectedFilter}
+              sortConfigs={filters.sortConfigs}
+              onSearchChange={(q) => updateFilter("searchQuery", q)}
+              onFilterChange={(f) => updateFilter("selectedFilter", f)}
+              onSort={handleSort}
+            />
+          </div>
 
           <div className="py-4">
             {/* Loading state */}
@@ -659,12 +661,14 @@ export default function TransactionsContent() {
                   onSelectRow={handleSelectRow}
                   onSelectAll={handleSelectAllForPage}
                 />
-                <TransactionsPagination
-                  totalItems={data?.total ?? 0}
-                  currentPage={currentPage}
-                  itemsPerPage={itemsPerPage}
-                  onPageChange={handlePageChange}
-                />
+                <div className="print:hidden">
+                  <TransactionsPagination
+                    totalItems={data?.total ?? 0}
+                    currentPage={currentPage}
+                    itemsPerPage={itemsPerPage}
+                    onPageChange={handlePageChange}
+                  />
+                </div>
               </>
             )}
           </div>
@@ -673,13 +677,15 @@ export default function TransactionsContent() {
 
       {/* Floating bulk-action bar – rendered outside the scrollable content area
           so it always stays anchored to the viewport bottom */}
-      <BulkActionBar
-        selectedCount={selectedIds.size}
-        onExport={handleBulkExport}
-        onTag={handleBulkTag}
-        onArchive={handleBulkArchive}
-        onClearSelection={clearSelection}
-      />
+      <div className="print:hidden">
+        <BulkActionBar
+          selectedCount={selectedIds.size}
+          onExport={handleBulkExport}
+          onTag={handleBulkTag}
+          onArchive={handleBulkArchive}
+          onClearSelection={clearSelection}
+        />
+      </div>
     </div>
   );
 }

--- a/components/transactions/transactions-table.tsx
+++ b/components/transactions/transactions-table.tsx
@@ -336,7 +336,7 @@ export function TransactionsTable({
   return (
     <>
       {/* Density Toggle */}
-      <div className="hidden md:flex items-center gap-2 mb-3">
+      <div className="hidden md:flex items-center gap-2 mb-3 print:hidden">
         <span className="text-xs text-zinc-400">Density:</span>
         <div
           role="radiogroup"
@@ -365,7 +365,7 @@ export function TransactionsTable({
       {/* Desktop Table */}
       <div
         ref={tableWrapperRef}
-        className="hidden md:block w-full rounded-[12px] overflow-auto border border-[#2D2D2D]"
+        className="hidden md:block print:block w-full rounded-[12px] overflow-auto border border-[#2D2D2D]"
       >
         <Table>
           {/* caption is visually hidden but announced by screen readers */}
@@ -377,7 +377,7 @@ export function TransactionsTable({
               {isSelectable && (
                 <TableHead
                   scope="col"
-                  className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-4 w-12"
+                  className="text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 py-4 px-4 w-12 print:hidden"
                 >
                   <Checkbox
                     aria-label={
@@ -389,7 +389,7 @@ export function TransactionsTable({
                     onCheckedChange={(checked) =>
                       onSelectAll?.(checked === true)
                     }
-                    className="border-[#555] data-[state=checked]:border-white data-[state=indeterminate]:border-white"
+                    className="border-[#555] data-[state=checked]:border-white data-[state=indeterminate]:border-white print:hidden"
                   />
                 </TableHead>
               )}
@@ -431,7 +431,7 @@ export function TransactionsTable({
               </TableHead>
               <TableHead
                 scope="col"
-                className={`text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 ${s.head} w-[140px]`}
+                className={`text-white font-bold border-[#2D2D2D] border-y-2 border-t-0 ${s.head} w-[140px] print:hidden`}
               >
                 Receipt
               </TableHead>
@@ -531,7 +531,7 @@ export function TransactionsTable({
                       <span className="text-sm">{transaction.status}</span>
                     </Badge>
                   </TableCell>
-                  <TableCell className={s.cell}>
+                  <TableCell className={`${s.cell} print:hidden`}>
                     <DownloadReceiptButton
                       transaction={{
                         id: transaction.id,
@@ -543,13 +543,13 @@ export function TransactionsTable({
                     />
                   </TableCell>
                 </TableRow>
-              )            ))}
+              )))}
           </TableBody>
         </Table>
       </div>
 
       {/* Mobile Cards */}
-      <div className="md:hidden space-y-4">
+      <div className="md:hidden space-y-4 print:hidden">
         {isLoading ? (
           <div className="p-4 border rounded-lg border-[#2D2D2D]">
             <TransactionTableSkeleton rows={TRANSACTIONS_PAGE_SIZE} />


### PR DESCRIPTION
## Summary

Add print stylesheet rules so `components/transactions/transactions-table.tsx` renders cleanly on paper — hiding all interactive controls, preventing row breaks across pages, and ensuring legibility in grayscale.

## Changes

### `app/globals.css`
- Added `@media print` rules scoped to `.transactions-print-root`
- Overrides `body * { visibility: hidden }` (the existing statement-print pattern) to show the transactions area
- Forces dark theme to black-on-white for grayscale-friendly output
- `break-inside: avoid` / `page-break-inside: avoid` on every table row
- `thead { display: table-header-group }` so column headers repeat across pages
- `filter: grayscale(100%) contrast(1.15)` on images for ink-friendly printing

### `components/transactions/transactions-content.tsx`
- Wrapped main content area with `.transactions-print-root` for print scoping
- `print:hidden` on: Generate statement button, TransactionsFilters, TransactionsPagination, BulkActionBar

### `components/transactions/transactions-table.tsx`
- `print:hidden` on: density toggle, header checkbox cell/input, receipt header cell, receipt download buttons, mobile cards
- `print:block` on the desktop table wrapper so it renders in print (overrides `hidden md:block`)

## Accessibility (WCAG 2.1 AA)
- No information conveyed through colour alone — amounts use `+`/`-` prefix, status is shown as text
- Grayscale images prevent contrast loss from colour-to-greyscale conversion
- `print:hidden` is purely presentational (ignored by screen readers)
- Print media queries do not affect assistive-technology output

## Testing
- `tsc --noEmit` passes with zero errors
- Existing vitest suite: pre-existing parse error in the test file (unclosed `describe` block at line 256) — same failure before and after these changes; no new regressions

Closes #738