### PR TITLE
fix: correct low-contrast muted text in dark-mode analytics view

### DIFF
--- a/components/analytics/analytics-chart.tsx
+++ b/components/analytics/analytics-chart.tsx
@@ -31,7 +31,7 @@ export const CustomTooltip = ({
 }: CustomTooltipProps) => {
   if (active && payload && payload.length) {
     return (
-      <div className="bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 p-2 rounded shadow text-sm border border-zinc-200 dark:border-zinc-800 text-center">
+      <div className="bg-background text-foreground p-2 rounded shadow text-sm border border-border text-center">
         <p className="font-semibold">{label}</p>
         <p>{payload[0].value.toLocaleString()} views</p>
       </div>
@@ -61,7 +61,7 @@ export default function AnalyticsChart({
           vertical={false}
           stroke={showNotifications ? "currentColor" : "#1f1b2e"}
           className={
-            showNotifications ? "text-zinc-200 dark:text-zinc-800" : ""
+            showNotifications ? "text-border dark:text-muted" : ""
           }
         />
         <XAxis

--- a/components/analytics/analytics-view.test.tsx
+++ b/components/analytics/analytics-view.test.tsx
@@ -229,12 +229,9 @@ describe("CustomTooltip", () => {
       <CustomTooltip active payload={[{ value: 1234 }]} label="TestMonth" />,
     );
     const tooltipEl = container.firstChild as HTMLElement;
-    expect(tooltipEl).toHaveClass("bg-white");
-    expect(tooltipEl).toHaveClass("dark:bg-zinc-900");
-    expect(tooltipEl).toHaveClass("text-zinc-900");
-    expect(tooltipEl).toHaveClass("dark:text-zinc-100");
-    expect(tooltipEl).toHaveClass("border-zinc-200");
-    expect(tooltipEl).toHaveClass("dark:border-zinc-800");
+    expect(tooltipEl).toHaveClass("bg-background");
+    expect(tooltipEl).toHaveClass("text-foreground");
+    expect(tooltipEl).toHaveClass("border-border");
     expect(tooltipEl).toHaveClass("text-center");
     expect(screen.getByText("TestMonth")).toBeInTheDocument();
     expect(screen.getByText("1,234 views")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Replace raw zinc utilities in CustomTooltip and CartesianGrid with semantic design tokens for WCAG 2.1 AA contrast compliance on dark backgrounds.

### Changes
- `components/analytics/analytics-chart.tsx`: Replaced `bg-white dark:bg-zinc-900`, `text-zinc-900 dark:text-zinc-100`, `border-zinc-200 dark:border-zinc-800` with `bg-background`, `text-foreground`, `border-border` in CustomTooltip
- Replaced `text-zinc-200 dark:text-zinc-800` with `text-border dark:text-muted` in CartesianGrid
- Updated test assertions in `analytics-view.test.tsx` to match semantic tokens

Closes #769