### PR TITLE
feat: add icons and article counts to help center categories

### DIFF
--- a/app/help/support/page.test.tsx
+++ b/app/help/support/page.test.tsx
@@ -29,7 +29,14 @@ vi.mock("@/components/common/support-tabs", () => ({
 }));
 
 vi.mock("@/components/common/faq-card", () => ({
-  default: ({ title }: any) => <div data-testid="faq-card">{title}</div>,
+  default: ({ title, articleCount }: any) => (
+    <div data-testid="faq-card">
+      {title}
+      {articleCount !== undefined && (
+        <span data-testid="faq-article-count">{articleCount}</span>
+      )}
+    </div>
+  ),
 }));
 
 // Mock ticket widget
@@ -106,7 +113,20 @@ describe("Support Page", () => {
     faqButton.click();
 
     const faqCards = screen.getAllByTestId("faq-card");
-    expect(faqCards.length).toBeGreaterThan(0);
+    expect(faqCards.length).toBe(4);
+
+    // Verify all four unique categories are present by checking text content
+    const expectedTitles = ["Account Management", "Transaction Issues", "Security & Privacy", "Payment & Transfers"];
+    expectedTitles.forEach((title) => {
+      expect(screen.getByText(title, { exact: false })).toBeInTheDocument();
+    });
+
+    // Verify article count badges are rendered
+    const badges = screen.getAllByTestId("faq-article-count");
+    expect(badges).toHaveLength(4);
+    badges.forEach((badge) => {
+      expect(badge.textContent).toBe("6");
+    });
   });
 });
 
@@ -182,11 +202,12 @@ describe("Support Page - Empty State Handling", () => {
 
 describe("Support Page - Responsive Layout", () => {
   it("should render full width ticket widget", () => {
-    const { container } = render(<SupportPage />);
-    const widget = screen.getByTestId("ticket-widget").closest("div");
+    render(<SupportPage />);
+    const widget = screen.getByTestId("ticket-widget");
 
-    // Check that widget container has full width class
-    expect(widget?.className).toMatch(/w-full/);
+    // Check that widget's parent has full width class
+    const wrapper = widget.parentElement;
+    expect(wrapper?.className).toMatch(/w-full/);
   });
 
   it("should have responsive gap and padding", () => {
@@ -205,20 +226,18 @@ describe("Support Page - Responsive Layout", () => {
 describe("Support Page - Integration", () => {
   it("should render ticket widget before tabs", () => {
     const { container } = render(<SupportPage />);
-    const widget = screen.getByTestId("ticket-widget");
-    const tabs = screen.getByTestId("support-tabs");
+    const mainContainer = container.querySelector(".min-h-screen");
+    const widgetElem = mainContainer?.querySelector(
+      '[data-testid="ticket-widget"]',
+    );
+    const tabsElem = mainContainer?.querySelector(
+      '[data-testid="support-tabs"]',
+    );
 
-    const widgetPosition = container.querySelector(
-      `[data-testid="ticket-widget"]`,
-    )?.parentElement;
-    const tabsPosition = container.querySelector(
-      `[data-testid="support-tabs"]`,
-    )?.parentElement;
-
-    // Widget parent should come before tabs parent in document order
-    if (widgetPosition && tabsPosition) {
+    // Ticket widget should appear before support tabs in document order
+    if (widgetElem && tabsElem) {
       expect(
-        widgetPosition.compareDocumentPosition(tabsPosition) &
+        widgetElem.compareDocumentPosition(tabsElem) &
           Node.DOCUMENT_POSITION_FOLLOWING,
       ).toBeTruthy();
     }

--- a/app/help/support/page.tsx
+++ b/app/help/support/page.tsx
@@ -4,7 +4,16 @@ import FaqCard from "@/components/common/faq-card";
 import SupportTabs from "@/components/common/support-tabs";
 import TicketStatusWidget from "@/components/help-support/ticket-status-widget";
 import CoachMarkOverlay from "@/components/ui/coach-mark-overlay";
-import { CircleHelp, Search, Grid3X3, MessageSquareText } from "lucide-react";
+import {
+  CircleHelp,
+  Search,
+  Grid3X3,
+  MessageSquareText,
+  UserCog,
+  ArrowRightLeft,
+  Shield,
+  CreditCard,
+} from "lucide-react";
 import { useState, useEffect, useRef } from "react";
 import { getDemoSupportTickets } from "@/lib/demo-data-support";
 import { safeStorage } from "@/utils/safeStorage";
@@ -104,36 +113,34 @@ const SupportPage = () => {
             </div>
 
             {/* FAQ Cards */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-4">
               <FaqCard
                 title="Account Management"
                 subtitle="Update your profile, reset your password, and manage your account"
                 link="/help/support/accountManagement"
+                icon={<UserCog size={18} color="#E5E5E5" aria-hidden="true" />}
+                articleCount={6}
               />
               <FaqCard
                 title="Transaction Issues"
                 subtitle="Resolve payment failures, track transactions, and dispute unauthorized charges."
                 link="/help/support/transactionIssues"
+                icon={<ArrowRightLeft size={18} color="#E5E5E5" aria-hidden="true" />}
+                articleCount={6}
               />
               <FaqCard
                 title="Security & Privacy"
                 subtitle="Keep your account safe with 2FA, fraud prevention, and privacy controls."
                 link="/help/support/securityPrivacy"
+                icon={<Shield size={18} color="#E5E5E5" aria-hidden="true" />}
+                articleCount={6}
               />
               <FaqCard
                 title="Payment & Transfers"
                 subtitle="Learn how to send, receive, and manage payments securely and efficiently."
                 link="/help/support/paymentTransfers"
-              />
-              <FaqCard
-                title="Payment & Transfers"
-                subtitle="Learn how to send, receive, and manage payments securely and efficiently."
-                link="/help/support/paymentTransfers"
-              />
-              <FaqCard
-                title="Account Management"
-                subtitle="Update your profile, reset your password, and manage your account."
-                link="/help/support/accountManagement"
+                icon={<CreditCard size={18} color="#E5E5E5" aria-hidden="true" />}
+                articleCount={6}
               />
             </div>
           </div>

--- a/components/common/faq-card.tsx
+++ b/components/common/faq-card.tsx
@@ -4,7 +4,13 @@ import React from "react";
 import { useRouter } from "next/navigation";
 import { FaqCardProps } from "@/types/ui";
 
-const FaqCard: React.FC<FaqCardProps> = ({ title, subtitle, link }) => {
+const FaqCard: React.FC<FaqCardProps> = ({
+  title,
+  subtitle,
+  link,
+  icon,
+  articleCount,
+}) => {
   const router = useRouter();
 
   // Dummy navigation
@@ -15,16 +21,48 @@ const FaqCard: React.FC<FaqCardProps> = ({ title, subtitle, link }) => {
   return (
     <div
       onClick={handleCardClick}
+      role="link"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleCardClick();
+        }
+      }}
+      aria-label={
+        articleCount !== undefined
+          ? `${title}: ${articleCount} article${articleCount !== 1 ? "s" : ""}`
+          : title
+      }
       className="w-full bg-[#121212] border border-[#2E2E2E] rounded-xl p-4 sm:p-5 md:p-6 hover:shadow-2xl hover:scale-105 transition-all duration-300 ease-in-out cursor-pointer"
     >
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-        <div className="flex-1">
-          <h3 className="text-base  font-semibold text-white mb-1">{title}</h3>
-          <p className="line-clamp-2 text-sm  text-[#707070]">{subtitle}</p>
+        <div className="flex items-start gap-3 flex-1 min-w-0">
+          {icon && (
+            <div
+              className="flex-shrink-0 flex justify-center items-center border border-[#2E2E2E] rounded-lg w-10 h-10"
+              aria-hidden="true"
+            >
+              {icon}
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <h3 className="text-base font-semibold text-white mb-1">
+              {title}
+            </h3>
+            <p className="line-clamp-2 text-sm text-[#707070]">{subtitle}</p>
+          </div>
         </div>
 
-        <div className="flex justify-center items-center border border-[#2E2E2E] rounded-lg w-8 h-8 min-w-[2rem] min-h-[2rem]">
-          <SquareArrowOutUpRight size={18} color="#E5E5E5" />
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {articleCount !== undefined && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-[#1A1A2E] text-[#A0A0A0] border border-[#2E2E2E]">
+              {articleCount} article{articleCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          <div className="flex justify-center items-center border border-[#2E2E2E] rounded-lg w-8 h-8 min-w-[2rem] min-h-[2rem]">
+            <SquareArrowOutUpRight size={18} color="#E5E5E5" />
+          </div>
         </div>
       </div>
     </div>

--- a/types/ui.ts
+++ b/types/ui.ts
@@ -29,6 +29,8 @@ export interface FaqCardProps {
   title: string;
   subtitle: string;
   link?: string;
+  icon?: React.ReactNode;
+  articleCount?: number;
 }
 
 export interface SupportTabsProps {


### PR DESCRIPTION
## Summary

Add representative lucide icons and article-count badges to FAQ category cards on the help/support page. Removes duplicate category entries and improves the grid layout.

### Changes
- Add `icon` and `articleCount` props to `FaqCardProps` type
- `FaqCard` now renders category icon, article-count badge with aria-label for accessibility
- Added keyboard navigation (Enter/Space) to FaqCard
- Removed duplicate Account Management and Payment & Transfers cards
- Updated grid to 4-column layout (`lg:grid-cols-4`) for 4 unique categories
- Updated tests to verify 4 unique categories and article-count badges

Closes #799