### PR TITLE
refactor: tokenize hardcoded dark surface colors in transactions header

### DIFF
--- a/components/transactions/transactions-header.tsx
+++ b/components/transactions/transactions-header.tsx
@@ -47,7 +47,7 @@ export default function TransactionsHeader({
   };
 
   return (
-    <div className="flex flex-col lg:flex-row lg:items-center justify-between px-6 py-4 bg-[#1a0c1d] mb-4">
+    <div className="flex flex-col lg:flex-row lg:items-center justify-between px-6 py-4 bg-card mb-4">
       <h1 className="text-2xl font-semibold mb-4 lg:mb-0 text-white">
         Transactions
       </h1>


### PR DESCRIPTION
## Description

Replaces the literal hex `bg-[#1a0c1d]` in `components/transactions/transactions-header.tsx` with the semantic `bg-card` token so the header follows the design system and responds to theme changes.

Closes #824