### PR TITLE
feat: add hooks/useOnlineStatus.ts with full unit coverage

### DIFF
--- a/components/common/offline-banner.tsx
+++ b/components/common/offline-banner.tsx
@@ -2,14 +2,14 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Wifi, WifiOff, X } from "lucide-react";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
 
 /**
  * Fixed banner that surfaces network-connectivity changes to the user.
  *
  * Behaviour
  * ---------
- * - Detects initial state from `navigator.onLine`.
- * - Subscribes to `online` / `offline` window events.
+ * - Detects initial state from `useOnlineStatus()` hook.
  * - Renders a persistent warning banner while offline.
  * - The banner is dismissible; it reappears on the next `offline` event.
  * - On reconnection, displays a brief success state that auto-dismisses
@@ -30,42 +30,31 @@ import { Wifi, WifiOff, X } from "lucide-react";
  * - All text is constrained to a reasonable measure for readability.
  */
 export function OfflineBanner() {
-  const [isOnline, setIsOnline] = useState<boolean>(true);
+  const isOnline = useOnlineStatus();
   const [dismissed, setDismissed] = useState<boolean>(false);
   const [showReconnected, setShowReconnected] = useState<boolean>(false);
   // Track whether we've ever transitioned offline so we only show the
   // reconnected banner after a genuine offline→online cycle.
   const wasOfflineRef = useRef<boolean>(false);
 
+  // Track online→offline→online transitions to gate reconnected state.
+  const prevOnlineRef = useRef(isOnline);
+
   useEffect(() => {
-    // Hydrate initial state from the browser.
-    setIsOnline(navigator.onLine);
-
-    function handleOffline() {
+    if (prevOnlineRef.current && !isOnline) {
+      // Transition: online → offline
       wasOfflineRef.current = true;
-      setIsOnline(false);
       setDismissed(false);
-      // Clear any lingering reconnected state.
       setShowReconnected(false);
-    }
-
-    function handleOnline() {
-      setIsOnline(true);
+    } else if (!prevOnlineRef.current && isOnline) {
+      // Transition: offline → online
       setDismissed(false);
-      // Only show the reconnected message when we were previously offline.
       if (wasOfflineRef.current) {
         setShowReconnected(true);
       }
     }
-
-    window.addEventListener("offline", handleOffline);
-    window.addEventListener("online", handleOnline);
-
-    return () => {
-      window.removeEventListener("offline", handleOffline);
-      window.removeEventListener("online", handleOnline);
-    };
-  }, []);
+    prevOnlineRef.current = isOnline;
+  }, [isOnline]);
 
   // Auto-dismiss the reconnected success state after a short delay.
   useEffect(() => {

--- a/hooks/useOnlineStatus.test.ts
+++ b/hooks/useOnlineStatus.test.ts
@@ -1,0 +1,129 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useOnlineStatus } from "./useOnlineStatus";
+
+describe("useOnlineStatus", () => {
+  let onlineSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    onlineSpy = vi
+      .spyOn(navigator, "onLine", "get")
+      .mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    onlineSpy.mockRestore();
+  });
+
+  // ------------------------------------------------------------------
+  // SSR-safe initial state
+  // ------------------------------------------------------------------
+
+  it("returns true by default (SSR-safe initial state)", () => {
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+  });
+
+  // ------------------------------------------------------------------
+  // Hydration from navigator.onLine
+  // ------------------------------------------------------------------
+
+  it("returns false when navigator.onLine is false on mount", () => {
+    onlineSpy.mockReturnValue(false);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true when navigator.onLine is true on mount", () => {
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+  });
+
+  // ------------------------------------------------------------------
+  // Reacting to window events
+  // ------------------------------------------------------------------
+
+  it("updates to false when an offline event is dispatched", () => {
+    const { result } = renderHook(() => useOnlineStatus());
+
+    act(() => {
+      window.dispatchEvent(new Event("offline"));
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("updates back to true when an online event follows an offline event", () => {
+    const { result } = renderHook(() => useOnlineStatus());
+
+    act(() => {
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("stays true when online events fire on an already-online browser", () => {
+    const { result } = renderHook(() => useOnlineStatus());
+
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  // ------------------------------------------------------------------
+  // Cleanup
+  // ------------------------------------------------------------------
+
+  it("cleans up event listeners on unmount", () => {
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+
+    const { unmount } = renderHook(() => useOnlineStatus());
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "offline",
+      expect.any(Function),
+    );
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "online",
+      expect.any(Function),
+    );
+
+    removeEventListenerSpy.mockRestore();
+  });
+
+  // ------------------------------------------------------------------
+  // Multiple state transitions
+  // ------------------------------------------------------------------
+
+  it("handles multiple offline → online → offline transitions", () => {
+    const { result } = renderHook(() => useOnlineStatus());
+
+    act(() => {
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/hooks/useOnlineStatus.ts
+++ b/hooks/useOnlineStatus.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Hook that tracks browser online/offline connectivity status.
+ *
+ * Behaviour
+ * ---------
+ * - Returns `true` by default (SSR-safe initial state).
+ * - Hydrates from `navigator.onLine` on mount.
+ * - Subscribes to `online` / `offline` window events and updates reactively.
+ * - Cleans up event listeners on unmount.
+ *
+ * Usage
+ * -----
+ * ```tsx
+ * const isOnline = useOnlineStatus();
+ *
+ * // Disable form submission while offline
+ * <Button disabled={!isOnline}>Submit</Button>
+ *
+ * // Show a warning banner
+ * {!isOnline && <OfflineBanner />}
+ * ```
+ */
+export function useOnlineStatus(): boolean {
+  const [isOnline, setIsOnline] = useState<boolean>(true);
+
+  useEffect(() => {
+    // Hydrate from the browser's actual connectivity state.
+    setIsOnline(navigator.onLine);
+
+    function handleOffline() {
+      setIsOnline(false);
+    }
+
+    function handleOnline() {
+      setIsOnline(true);
+    }
+
+    window.addEventListener("offline", handleOffline);
+    window.addEventListener("online", handleOnline);
+
+    return () => {
+      window.removeEventListener("offline", handleOffline);
+      window.removeEventListener("online", handleOnline);
+    };
+  }, []);
+
+  return isOnline;
+}


### PR DESCRIPTION
## Description

Extracts online/offline detection from the OfflineBanner into a reusable, SSR-safe `useOnlineStatus` hook that wraps `navigator.onLine` and window `online`/`offline` events with proper cleanup.

### Changes
- New `hooks/useOnlineStatus.ts` — SSR-safe hook returning boolean connectivity status
- New `hooks/useOnlineStatus.test.ts` — full unit coverage for SSR safety, event transitions, and cleanup
- Refactored `components/common/offline-banner.tsx` to consume the shared hook

Closes #813