### PR TITLE
feat: add search and popular links to the 404 page

### DIFF
--- a/app/not-found.test.tsx
+++ b/app/not-found.test.tsx
@@ -46,4 +46,48 @@ describe("NotFound", () => {
     expect(homeLink).toBeVisible();
     expect(dashboardLink).toBeVisible();
   });
+
+  it("renders a search input for help center search", () => {
+    render(<NotFound />);
+
+    const searchInput = screen.getByPlaceholderText("Search help center…");
+    expect(searchInput).toBeInTheDocument();
+    expect(searchInput).toHaveAttribute("type", "search");
+    expect(searchInput).toHaveAttribute("aria-label", "Search help topics");
+  });
+
+  it("renders popular-destination links", () => {
+    render(<NotFound />);
+
+    expect(screen.getByRole("link", { name: /Transactions/ })).toHaveAttribute(
+      "href",
+      "/transactions",
+    );
+    expect(screen.getByRole("link", { name: /Settings/ })).toHaveAttribute(
+      "href",
+      "/settings",
+    );
+    expect(screen.getByRole("link", { name: /Help & Support/ })).toHaveAttribute(
+      "href",
+      "/help/support",
+    );
+    expect(screen.getByRole("link", { name: /Dashboard/ })).toHaveAttribute(
+      "href",
+      "/dashboard",
+    );
+  });
+
+  it("renders a popular destinations navigation landmark", () => {
+    render(<NotFound />);
+
+    const nav = screen.getByRole("navigation", { name: "Popular destinations" });
+    expect(nav).toBeInTheDocument();
+  });
+
+  it("renders a search landmark", () => {
+    render(<NotFound />);
+
+    const search = screen.getByRole("search", { name: "Search help center" });
+    expect(search).toBeInTheDocument();
+  });
 });

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,11 +1,34 @@
 import Link from "next/link";
+import { ArrowRight, Search } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+/** Popular destinations users might be looking for. */
+const POPULAR_LINKS = [
+  { label: "Transactions", href: "/transactions", description: "View your payment history" },
+  { label: "Settings", href: "/settings", description: "Manage your account" },
+  { label: "Help & Support", href: "/help/support", description: "Get assistance" },
+  { label: "Dashboard", href: "/dashboard", description: "Your overview" },
+];
 
 /**
  * Branded App Router 404 page for unknown Stellopay routes.
+ *
+ * Offers a search input that routes to the help/support search along with
+ * popular-destination links so users who mistyped a URL can quickly find
+ * what they were looking for.
  */
 export default function NotFound() {
+  const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const query = formData.get("search") as string;
+    if (query.trim()) {
+      window.location.href = `/help/support?q=${encodeURIComponent(query.trim())}`;
+    }
+  };
+
   return (
     <main
       id="main-content"
@@ -22,7 +45,28 @@ export default function NotFound() {
           The route you tried to open does not exist. Head back to Stellopay or
           continue from your dashboard.
         </p>
-        <div className="mt-8 flex w-full flex-col items-center justify-center gap-3 sm:w-auto sm:flex-row">
+
+        {/* ── Search input ─────────────────────────────────────────── */}
+        <form
+          onSubmit={handleSearch}
+          className="mt-8 w-full max-w-md"
+          role="search"
+          aria-label="Search help center"
+        >
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
+            <Input
+              type="search"
+              name="search"
+              placeholder="Search help center…"
+              className="h-11 w-full pl-10 pr-4 rounded-xl border-border bg-background text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] transition-[color,box-shadow]"
+              aria-label="Search help topics"
+            />
+          </div>
+        </form>
+
+        {/* ── CTA buttons ──────────────────────────────────────────── */}
+        <div className="mt-6 flex w-full flex-col items-center justify-center gap-3 sm:w-auto sm:flex-row">
           <Button asChild size="lg" className="w-full sm:w-auto">
             <Link href="/">Go home</Link>
           </Button>
@@ -34,6 +78,30 @@ export default function NotFound() {
           >
             <Link href="/dashboard">Open dashboard</Link>
           </Button>
+        </div>
+
+        {/* ── Popular-destination links ────────────────────────────── */}
+        <div className="mt-10 w-full max-w-md">
+          <p className="mb-3 text-sm font-medium text-muted-foreground">
+            Popular destinations
+          </p>
+          <nav aria-label="Popular destinations" className="grid grid-cols-2 gap-2">
+            {POPULAR_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="group flex items-center justify-between rounded-lg border border-border bg-card px-4 py-3 text-left text-sm text-card-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <span>
+                  <span className="block font-medium">{link.label}</span>
+                  <span className="block text-xs text-muted-foreground">
+                    {link.description}
+                  </span>
+                </span>
+                <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+              </Link>
+            ))}
+          </nav>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Description

Enhances the 404 page with a search input that routes to the help center and popular-destination links so users who mistype a URL can quickly find what they need.

### Changes
- Added a search input (routes to `/help/support?q=...`)
- Added 4 popular-destination links: Transactions, Settings, Help & Support, Dashboard
- Updated tests to cover the new search and navigation elements

Closes #809