### PR TITLE
fix: polish spacing and icon alignment on the shared FAQ card

### DIFF
--- a/components/common/faq-card.test.tsx
+++ b/components/common/faq-card.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import FaqCard from "./faq-card";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: vi.fn(),
+  }),
+}));
+
+const defaultProps = {
+  title: "Account Management",
+  subtitle: "Update your profile, reset your password, and manage your account.",
+  link: "/help/support/accountManagement",
+};
+
+describe("FaqCard", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it("renders title and subtitle", () => {
+    render(<FaqCard {...defaultProps} />);
+    expect(screen.getByText("Account Management")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Update your profile, reset your password, and manage your account.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the external link icon", () => {
+    const { container } = render(<FaqCard {...defaultProps} />);
+    const icon = container.querySelector("svg.lucide-square-arrow-out-up-right");
+    expect(icon).toBeInTheDocument();
+  });
+
+  it("uses role='button' and is keyboard-focusable", () => {
+    render(<FaqCard {...defaultProps} />);
+    const card = screen.getByRole("button", {
+      name: /Account Management/i,
+    });
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveAttribute("tabIndex", "0");
+  });
+
+  it("has an aria-label that includes title and subtitle", () => {
+    render(<FaqCard {...defaultProps} />);
+    const card = screen.getByRole("button");
+    expect(card).toHaveAttribute(
+      "aria-label",
+      "Account Management: Update your profile, reset your password, and manage your account.",
+    );
+  });
+
+  it("navigates on click", () => {
+    render(<FaqCard {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(mockPush).toHaveBeenCalledWith("/help/support/accountManagement");
+  });
+
+  it("navigates on Enter key", () => {
+    render(<FaqCard {...defaultProps} />);
+    fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
+    expect(mockPush).toHaveBeenCalledWith("/help/support/accountManagement");
+  });
+
+  it("navigates on Space key", () => {
+    render(<FaqCard {...defaultProps} />);
+    fireEvent.keyDown(screen.getByRole("button"), { key: " " });
+    expect(mockPush).toHaveBeenCalledWith("/help/support/accountManagement");
+  });
+
+  it("uses default link when no link is provided", () => {
+    render(<FaqCard title="Test" subtitle="Desc" />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(mockPush).toHaveBeenCalledWith("/settings/preferences");
+  });
+
+  it("clamps subtitle to 2 lines", () => {
+    render(<FaqCard {...defaultProps} />);
+    const subtitle = screen.getByText(
+      "Update your profile, reset your password, and manage your account.",
+    );
+    expect(subtitle.className).toMatch(/line-clamp-2/);
+  });
+
+  it("has hover shadow and border tokens", () => {
+    const { container } = render(<FaqCard {...defaultProps} />);
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toMatch(/hover:shadow-md/);
+    expect(card.className).toMatch(/hover:border-zinc-300/);
+  });
+
+  it("has focus-visible ring styles", () => {
+    const { container } = render(<FaqCard {...defaultProps} />);
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toMatch(/focus-visible:ring-2/);
+  });
+
+  it("has light and dark mode classes", () => {
+    const { container } = render(<FaqCard {...defaultProps} />);
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toMatch(/bg-white/);
+    expect(card.className).toMatch(/dark:bg-\[#121212\]/);
+    expect(card.className).toMatch(/border-zinc-200/);
+    expect(card.className).toMatch(/dark:border-\[#2E2E2E\]/);
+  });
+
+  it("has responsive flex layout", () => {
+    const { container } = render(<FaqCard {...defaultProps} />);
+    const inner = container.firstChild?.firstChild as HTMLElement;
+    expect(inner.className).toMatch(/flex-col/);
+    expect(inner.className).toMatch(/sm:flex-row/);
+    expect(inner.className).toMatch(/items-start/);
+  });
+
+  it("renders text with theme-aware colors", () => {
+    render(<FaqCard {...defaultProps} />);
+    const title = screen.getByText("Account Management");
+    expect(title.className).toMatch(/text-zinc-900/);
+    expect(title.className).toMatch(/dark:text-white/);
+  });
+
+  it("renders long text without layout breakage", () => {
+    render(
+      <FaqCard
+        title="A very long FAQ card title that should still wrap gracefully without breaking the layout"
+        subtitle="This is an extremely long subtitle that goes on and on and on and on and on and on and on and on and on and on and on and on and on and on to test that the card handles overflow gracefully and the icon stays aligned with the title."
+      />,
+    );
+    const card = screen.getByRole("button");
+    expect(card).toBeInTheDocument();
+    const title = screen.getByText(
+      "A very long FAQ card title that should still wrap gracefully without breaking the layout",
+    );
+    expect(title.className).toMatch(/text-base/);
+  });
+});

--- a/components/common/faq-card.tsx
+++ b/components/common/faq-card.tsx
@@ -3,28 +3,51 @@ import { SquareArrowOutUpRight } from "lucide-react";
 import React from "react";
 import { useRouter } from "next/navigation";
 import { FaqCardProps } from "@/types/ui";
+import { cn } from "@/utils/commonUtils";
 
 const FaqCard: React.FC<FaqCardProps> = ({ title, subtitle, link }) => {
   const router = useRouter();
 
-  // Dummy navigation
   const handleCardClick = () => {
     router.push(link || "/settings/preferences");
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleCardClick();
+    }
   };
 
   return (
     <div
       onClick={handleCardClick}
-      className="w-full bg-[#121212] border border-[#2E2E2E] rounded-xl p-4 sm:p-5 md:p-6 hover:shadow-2xl hover:scale-105 transition-all duration-300 ease-in-out cursor-pointer"
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-label={`${title}: ${subtitle}`}
+      className={cn(
+        "w-full rounded-xl border p-5 transition-all duration-200 cursor-pointer",
+        "bg-white dark:bg-[#121212] border-zinc-200 dark:border-[#2E2E2E]",
+        "hover:shadow-md hover:border-zinc-300 dark:hover:border-zinc-600",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#121212]",
+      )}
     >
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-        <div className="flex-1">
-          <h3 className="text-base  font-semibold text-white mb-1">{title}</h3>
-          <p className="line-clamp-2 text-sm  text-[#707070]">{subtitle}</p>
+      <div className="flex flex-col sm:flex-row items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <h3 className="text-base font-semibold text-zinc-900 dark:text-white">
+            {title}
+          </h3>
+          <p className="line-clamp-2 text-sm text-zinc-500 dark:text-[#707070] mt-1">
+            {subtitle}
+          </p>
         </div>
 
-        <div className="flex justify-center items-center border border-[#2E2E2E] rounded-lg w-8 h-8 min-w-[2rem] min-h-[2rem]">
-          <SquareArrowOutUpRight size={18} color="#E5E5E5" />
+        <div className="flex justify-center items-center border border-zinc-200 dark:border-[#2E2E2E] rounded-lg w-8 h-8 min-w-[2rem] min-h-[2rem] shrink-0 mt-0.5">
+          <SquareArrowOutUpRight
+            size={18}
+            className="text-zinc-700 dark:text-[#E5E5E5]"
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Polishes `components/common/faq-card.tsx` — the shared card primitive used in the Help/Support FAQ categories. Fixes inconsistent padding, off-center icon alignment, and aggressive hover animation. Adds light mode support, keyboard accessibility, and 15 unit tests.

## Changes

### Padding (before vs after)
- **Before:** `p-4 sm:p-5 md:p-6` — padding changed at every breakpoint, making collapsed/expanded (or stacked/grid) states look inconsistent
- **After:** `p-5` — single consistent value across all viewports

### Icon alignment
- **Before:** `flex-col sm:flex-row items-start sm:items-center` — icon centered with the text block, which pushed it off-baseline when subtitle wrapped to 2 lines
- **After:** `items-start` always + `mt-0.5` on icon container — icon now visually aligns with the title's first line

### Hover elevation
- **Before:** `hover:shadow-2xl hover:scale-105` — too aggressive, scales the card
- **After:** `hover:shadow-md hover:border-zinc-300 dark:hover:border-zinc-600` — subtle shadow + border change, consistent with `card.tsx` patterns

### Theme awareness
- **Before:** Hardcoded dark-only colors (`bg-[#121212]`, `text-white`, `text-[#707070]`)
- **After:** Light mode defaults (`bg-white`, `text-zinc-900`, `text-zinc-500`) with `dark:` overrides preserving the original dark palette

### Accessibility
- Added `role="button"`, `tabIndex={0}`, `aria-label`
- Keyboard navigation via Enter/Space
- `focus-visible:ring-2` with offset for visible focus indicator

### Tests
15 new tests in `components/common/faq-card.test.tsx` covering:
- Render (title, subtitle, icon)
- Accessibility (role, aria-label, tabIndex, keyboard navigation)
- Navigation (click, Enter, Space, default link fallback)
- Visual tokens (hover shadow, hover border, focus ring, theme classes)
- Responsive layout (flex-col/sm:flex-row, items-start)
- Long text edge case

## Verification
- `npx vitest run components/common/faq-card.test.tsx --no-coverage` → 15/15 passed
- `npx vitest run app/help/support/page.test.tsx --no-coverage` → 20/22 passed (2 pre-existing fragiles unrelated to this change)

Closes #878