### PR TITLE
Content: Rewrite enterprise section copy with Stellar-specific statements (fix #874)

### DIFF
--- a/components/landing/enterprise-section.test.tsx
+++ b/components/landing/enterprise-section.test.tsx
@@ -10,7 +10,7 @@ vi.mock("next/image", () => ({
 }));
 
 describe("EnterpriseSolutionSection", () => {
-  it("renders the enterprise section with heading and description", () => {
+  it("renders the enterprise section with heading", () => {
     render(<EnterpriseSolutionSection />);
 
     expect(
@@ -18,29 +18,86 @@ describe("EnterpriseSolutionSection", () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText(/blockchain solution/i),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByText(/StelloPay is built for scale/i),
+      screen.getByText(/Stellar-powered payments/i),
     ).toBeInTheDocument();
   });
 
-  it("renders all four enterprise features", () => {
+  it("references the Stellar network in the description", () => {
     render(<EnterpriseSolutionSection />);
 
     expect(
-      screen.getByText(/Advanced API integration/i),
+      screen.getByText(/Stellar network/i),
+    ).toBeInTheDocument();
+  });
+
+  it("quotes concrete Stellar network metrics in the description", () => {
+    render(<EnterpriseSolutionSection />);
+
+    expect(
+      screen.getByText(/3–5 seconds/i),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/\$0\.001/),
+    ).toBeInTheDocument();
+  });
+
+  it("mentions multi-asset support in the description", () => {
+    render(<EnterpriseSolutionSection />);
+
+    const matches = screen.getAllByText(/USDC, XLM/i);
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("mentions Stellar anchors in the description", () => {
+    render(<EnterpriseSolutionSection />);
+
+    expect(
+      screen.getByText(/Stellar anchors/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all four enterprise features with Stellar-specific copy", () => {
+    render(<EnterpriseSolutionSection />);
+
+    expect(
+      screen.getByText(/Horizon API/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Custom payment workflows/i),
+      screen.getByText(/anchor rails/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Dedicated account manager/i),
+      screen.getByText(/Multi-asset settlement/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Priority support/i),
+      screen.getAllByText(/USDC, XLM/i)[0],
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(/3-second transaction finality/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Dedicated enterprise support/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not contain the old generic copy", () => {
+    render(<EnterpriseSolutionSection />);
+
+    expect(
+      screen.queryByText(/built for scale/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Advanced API integration/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Custom payment workflows/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Dedicated account manager/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Priority support/i),
+    ).not.toBeInTheDocument();
   });
 
   it("renders all four stat cards with values", () => {

--- a/components/landing/enterprise-section.tsx
+++ b/components/landing/enterprise-section.tsx
@@ -9,16 +9,16 @@ interface IFeature {
 
 const features: IFeature[] = [
   {
-    text: "Advanced API integration",
+    text: "Horizon API & anchor rails",
   },
   {
-    text: "Custom payment workflows",
+    text: "Multi-asset settlement (USDC, XLM)",
   },
   {
-    text: "Dedicated account manager",
+    text: "3-second transaction finality",
   },
   {
-    text: "Priority support",
+    text: "Dedicated enterprise support",
   },
 ];
 
@@ -60,14 +60,16 @@ const EnterpriseSolutionSection = () => {
           <h4 className="font-bold text-3xl lg:text-5xl leading-12 tracking-[0.35px] text-[#09090B] dark:text-[#FAFAFA] print:text-black">
             Enterprise-ready <br />
             <span className="bg-linear-to-r from-[#83A7FF] to-[#8B5CF6] bg-clip-text text-transparent print:bg-none print:text-[#09090B]">
-              blockchain solution
+              Stellar-powered payments
             </span>
           </h4>
         </div>
         <div className="w-full lg:w-[458.5px]">
           <p className="text-[#52525B] dark:text-[#A1A1AA] text-start font-normal text-xl leading-[32.5px] print:text-black">
-            StelloPay is built for scale. Whether you&apos;re a startup or an
-            enterprise, our platform grows with your business needs.
+            StelloPay settles cross-border payments on the Stellar network in
+            3–5 seconds for less than $0.001 per transaction. Native multi-asset
+            support (USDC, XLM, and more) with built-in fiat on/off ramps via
+            Stellar anchors.
           </p>
         </div>
         <div aria-label="Enterprise features">


### PR DESCRIPTION
Replaces generic SaaS copy in the enterprise section with concrete Stellar network value propositions:

- **Heading**: generic "blockchain solution" → "Stellar-powered payments"
- **Description**: vague scale claims → 3–5s finality, <$0.001/tx, USDC/XLM, Stellar anchors
- **Features**: "Advanced API integration" → "Horizon API & anchor rails"
  "Custom payment workflows" → "Multi-asset settlement (USDC, XLM)"
  "Dedicated account manager" → "3-second transaction finality"
  "Priority support" → "Dedicated enterprise support"

Closes #874

## Testing
- `npx vitest run components/landing/enterprise-section.test.tsx --no-coverage` — 11/11 pass