### PR TITLE
fix(a11y): restore trigger focus when sign-up email modal closes

### DIFF
--- a/components/auth/sign-up/sign-up-email-modal.tsx
+++ b/components/auth/sign-up/sign-up-email-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -78,6 +78,25 @@ export function SignUpEmailModal({
   };
 
   const isResendDisabled = isResending || isCoolingDown;
+
+  // ── Focus-return-to-trigger ────────────────────────────────────
+  // Capture the previously focused element before the dialog opens
+  // and restore focus to it on every close path so keyboard and
+  // screen-reader users don't lose their place (WCAG 2.1 AA 2.4.3).
+  const prevFocusedRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      prevFocusedRef.current = document.activeElement as HTMLElement;
+    } else if (prevFocusedRef.current) {
+      // Use requestAnimationFrame to ensure the Radix dialog has
+      // fully unmounted before we programmatically move focus.
+      requestAnimationFrame(() => {
+        prevFocusedRef.current?.focus();
+        prevFocusedRef.current = null;
+      });
+    }
+  }, [isOpen]);
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>

--- a/components/auth/sign-up/sign-up-form.test.tsx
+++ b/components/auth/sign-up/sign-up-form.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SignUpForm } from "./sign-up-form";
+import { SignUpEmailModal } from "./sign-up-email-modal";
 
 // Mock ResizeObserver for Radix UI dialog / components
 class ResizeObserverMock {
@@ -72,6 +73,106 @@ describe("SignUpForm", () => {
     await waitFor(() => {
       expect(screen.getByText(/Check your email/i)).toBeInTheDocument();
       expect(screen.getByText("jane@example.com")).toBeInTheDocument();
+    });
+  });
+
+  describe("focus-return-to-trigger", () => {
+    /**
+     * The form enforces a 3-second minimum submission time as an
+     * anti-bot measure which makes form-submission-based tests
+     * impractical with default userEvent timing. We test the focus-
+     * return behavior directly on the SignUpEmailModal component:
+     * the focus restoration logic lives inside the modal itself,
+     * which captures document.activeElement before opening and
+     * restores it on every close path.
+     */
+
+    function renderModal(isOpen: boolean) {
+      return render(
+        <SignUpEmailModal
+          isOpen={isOpen}
+          onClose={vi.fn()}
+          onContinue={vi.fn()}
+          onGoBack={vi.fn()}
+          email="test@example.com"
+        />,
+      );
+    }
+
+    function renderModalInContainer(isOpen: boolean) {
+      return render(
+        <div>
+          <button type="button" data-testid="trigger-btn">
+            Open Modal
+          </button>
+          <SignUpEmailModal
+            isOpen={isOpen}
+            onClose={vi.fn()}
+            onContinue={vi.fn()}
+            onGoBack={vi.fn()}
+            email="test@example.com"
+          />
+        </div>,
+      );
+    }
+
+    it("restores focus to the previously focused element when modal closes via onClose", async () => {
+      const { rerender } = renderModalInContainer(false);
+
+      const triggerBtn = screen.getByTestId("trigger-btn");
+      triggerBtn.focus();
+      expect(document.activeElement).toBe(triggerBtn);
+
+      // Open the modal
+      rerender(
+        <div>
+          <button type="button" data-testid="trigger-btn">
+            Open Modal
+          </button>
+          <SignUpEmailModal
+            isOpen={true}
+            onClose={vi.fn()}
+            onContinue={vi.fn()}
+            onGoBack={vi.fn()}
+            email="test@example.com"
+          />
+        </div>,
+      );
+
+      // Close the modal
+      rerender(
+        <div>
+          <button type="button" data-testid="trigger-btn">
+            Open Modal
+          </button>
+          <SignUpEmailModal
+            isOpen={false}
+            onClose={vi.fn()}
+            onContinue={vi.fn()}
+            onGoBack={vi.fn()}
+            email="test@example.com"
+          />
+        </div>,
+      );
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(triggerBtn);
+      });
+    });
+
+    it("does not throw when no element was focused before modal opened", () => {
+      // Render modal open, close it — should not crash
+      const { rerender } = renderModal(true);
+
+      expect(() => {
+        rerender(<SignUpEmailModal
+          isOpen={false}
+          onClose={vi.fn()}
+          onContinue={vi.fn()}
+          onGoBack={vi.fn()}
+          email="test@example.com"
+        />);
+      }).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
## Description

Closing the sign-up email verification modal (via Escape, backdrop click, close button, Continue, or Go Back) did not return keyboard focus to the element that originally opened it. Keyboard and screen-reader users lost their place in the sign-up flow after the modal dismissed.

## Changes

**`components/auth/sign-up/sign-up-email-modal.tsx`** — Added focus-return logic using `useRef` + `useEffect`:
- Captures `document.activeElement` when `isOpen` transitions to `true`
- Restores focus via `requestAnimationFrame` when `isOpen` transitions to `false`
- Works on ALL close paths since they all set `isOpen` to `false`
- Gracefully handles edge case where no element was focused before modal opened

**`components/auth/sign-up/sign-up-form.test.tsx`** — Added 2 focus-return tests:
- `restores focus to the previously focused element when modal closes`
- `does not throw when no element was focused before modal opened`

## Accessibility

Satisfies **WCAG 2.1 AA Success Criterion 2.4.3 (Focus Order)** — keyboard users retain their place in the sign-up flow after the modal dismisses.

## Test Results

11/12 tests pass. The 1 failure (`opens confirmation modal upon valid form submission`) is a **pre-existing issue** caused by the 3-second anti-bot submission guard — not related to this PR.

## Files Changed

```
 components/auth/sign-up/sign-up-email-modal.tsx | 21 ++++++++++-
 components/auth/sign-up/sign-up-form.test.tsx   | 99 ++++++++++++++++++++++++
 2 files changed, 119 insertions(+), 1 deletion(-)
```

Closes #713