### PR TITLE
feat(a11y): improve screen reader support for password requirements (…

### DIFF
--- a/app/settings/preferences/components/security-tab.test.tsx
+++ b/app/settings/preferences/components/security-tab.test.tsx
@@ -11,7 +11,11 @@ import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
 import SecurityTab, {
   BACKUP_CODE_COUNT,
   DEFAULT_TWO_FACTOR_ENABLED,
+  NEW_PASSWORD_REQUIREMENTS_ID,
+  NEW_PASSWORD_REQUIREMENTS_STATUS_ID,
+  PASSWORD_REQUIREMENTS_ANNOUNCE_DELAY_MS,
   TWO_FACTOR_CODE_LENGTH,
+  buildPasswordRequirementsAnnouncement,
   getVerificationCodeError,
 } from "./security-tab";
 import { verifyTotpCode } from "@/lib/totp";
@@ -231,6 +235,150 @@ describe("SecurityTab — requirements checklist", () => {
     expect(row?.querySelector("svg")?.classList.toString()).toContain(
       "text-zinc-300",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Password requirements — screen reader association + live announcements
+// ---------------------------------------------------------------------------
+
+describe("buildPasswordRequirementsAnnouncement", () => {
+  const unmetAll = {
+    minLength: false,
+    uppercase: false,
+    specialChar: false,
+  };
+
+  it("returns an empty string when the password field is empty", () => {
+    expect(
+      buildPasswordRequirementsAnnouncement(unmetAll, false, false),
+    ).toBe("");
+  });
+
+  it("lists unmet requirements while the password is incomplete", () => {
+    expect(
+      buildPasswordRequirementsAnnouncement(
+        { minLength: true, uppercase: false, specialChar: false },
+        false,
+        true,
+      ),
+    ).toBe(
+      "Still needed: one uppercase letter, one special character, passwords match.",
+    );
+  });
+
+  it("announces success when every requirement is met", () => {
+    expect(
+      buildPasswordRequirementsAnnouncement(
+        { minLength: true, uppercase: true, specialChar: true },
+        true,
+        true,
+      ),
+    ).toBe("All password requirements met.");
+  });
+});
+
+describe("SecurityTab — password requirements accessibility", () => {
+  it("associates the new-password input with screen-reader requirements helper text", () => {
+    render(<SecurityTab />);
+
+    const helper = document.getElementById(NEW_PASSWORD_REQUIREMENTS_ID);
+    expect(helper).toBeTruthy();
+    expect(helper).toHaveClass("sr-only");
+    expect(helper).toHaveTextContent(/at least 8 characters/i);
+    expect(helper).toHaveTextContent(/one uppercase letter/i);
+    expect(helper).toHaveTextContent(/one special character/i);
+
+    const describedBy = getPasswordInput().getAttribute("aria-describedby");
+    expect(describedBy?.split(/\s+/)).toContain(NEW_PASSWORD_REQUIREMENTS_ID);
+  });
+
+  it("exposes a polite live region for requirement status updates", () => {
+    render(<SecurityTab />);
+
+    const liveRegion = document.getElementById(
+      NEW_PASSWORD_REQUIREMENTS_STATUS_ID,
+    );
+    expect(liveRegion).toBeTruthy();
+    expect(liveRegion).toHaveAttribute("aria-live", "polite");
+    expect(liveRegion).toHaveAttribute("aria-atomic", "true");
+    expect(liveRegion).toHaveClass("sr-only");
+  });
+
+  it("announces unmet requirements after typing pauses (debounced)", async () => {
+    vi.useFakeTimers();
+    render(<SecurityTab />);
+
+    typePassword("short");
+
+    const liveRegion = document.getElementById(
+      NEW_PASSWORD_REQUIREMENTS_STATUS_ID,
+    );
+    expect(liveRegion).toHaveTextContent("");
+
+    await act(async () => {
+      vi.advanceTimersByTime(PASSWORD_REQUIREMENTS_ANNOUNCE_DELAY_MS);
+    });
+
+    expect(liveRegion).toHaveTextContent(
+      /Still needed: at least 8 characters, one uppercase letter, one special character, passwords match\./i,
+    );
+  });
+
+  it("does not re-announce while keystrokes leave the unmet set unchanged", async () => {
+    vi.useFakeTimers();
+    render(<SecurityTab />);
+
+    typePassword("a");
+    await act(async () => {
+      vi.advanceTimersByTime(PASSWORD_REQUIREMENTS_ANNOUNCE_DELAY_MS);
+    });
+
+    const liveRegion = document.getElementById(
+      NEW_PASSWORD_REQUIREMENTS_STATUS_ID,
+    );
+    const firstAnnouncement = liveRegion?.textContent ?? "";
+    expect(firstAnnouncement).toMatch(/Still needed:/i);
+
+    typePassword("ab");
+    await act(async () => {
+      vi.advanceTimersByTime(PASSWORD_REQUIREMENTS_ANNOUNCE_DELAY_MS);
+    });
+
+    expect(liveRegion).toHaveTextContent(firstAnnouncement);
+  });
+
+  it("announces when all password requirements become met", async () => {
+    vi.useFakeTimers();
+    render(<SecurityTab />);
+
+    fillValidPasswords("StrongPass@1");
+
+    await act(async () => {
+      vi.advanceTimersByTime(PASSWORD_REQUIREMENTS_ANNOUNCE_DELAY_MS);
+    });
+
+    expect(
+      document.getElementById(NEW_PASSWORD_REQUIREMENTS_STATUS_ID),
+    ).toHaveTextContent("All password requirements met.");
+  });
+
+  it("marks each visual requirement with met / not-met screen-reader text", () => {
+    render(<SecurityTab />);
+    typePassword("short");
+
+    const unmetRow = screen.getByText("At least 8 characters").closest(
+      "[role='listitem']",
+    );
+    expect(unmetRow).toHaveTextContent(/^Not met:\s*At least 8 characters/);
+
+    typePassword("Abcdefg@1");
+    typeConfirm("Abcdefg@1");
+
+    const metRow = screen.getByText("At least 8 characters").closest(
+      "[role='listitem']",
+    );
+    expect(metRow).toHaveTextContent(/^Met:\s*At least 8 characters/);
   });
 });
 
@@ -525,7 +673,8 @@ describe("SecurityTab — successful password change", () => {
 
     await waitFor(
       () => {
-        const container = screen.getByRole("status");
+        const message = screen.getByText(/password policy satisfied/i);
+        const container = message.closest("[role='status']");
         expect(container).toHaveAttribute("aria-live", "polite");
       },
       { timeout: 3000 },

--- a/app/settings/preferences/components/security-tab.tsx
+++ b/app/settings/preferences/components/security-tab.tsx
@@ -121,6 +121,53 @@ export function createApiKeySecret(name: string): string {
 /** How many single-use two-factor backup codes are issued per set. */
 export const BACKUP_CODE_COUNT = 10;
 
+/** Stable id for the screen-reader password-requirements helper text. */
+export const NEW_PASSWORD_REQUIREMENTS_ID = "new-password-requirements";
+
+/** Stable id for the polite live region that announces requirement changes. */
+export const NEW_PASSWORD_REQUIREMENTS_STATUS_ID =
+  "new-password-requirements-status";
+
+/**
+ * Debounce window (ms) before announcing password-requirement changes.
+ * Long enough to avoid keystroke spam; short enough to feel responsive.
+ */
+export const PASSWORD_REQUIREMENTS_ANNOUNCE_DELAY_MS = 700;
+
+type PasswordRequirementFlags = ReturnType<typeof checkPasswordRequirements>;
+
+/**
+ * Builds a concise screen-reader announcement for the current password
+ * requirement state. Empty string when the field is empty (nothing to announce).
+ *
+ * Exported for unit tests so the announcement copy stays asserted without
+ * relying on debounce timers in the component.
+ */
+export function buildPasswordRequirementsAnnouncement(
+  requirements: PasswordRequirementFlags,
+  passwordsMatch: boolean,
+  hasPassword: boolean,
+): string {
+  if (!hasPassword) {
+    return "";
+  }
+
+  const items = [
+    { label: "at least 8 characters", met: requirements.minLength },
+    { label: "one uppercase letter", met: requirements.uppercase },
+    { label: "one special character", met: requirements.specialChar },
+    { label: "passwords match", met: passwordsMatch },
+  ];
+
+  const unmet = items.filter((item) => !item.met).map((item) => item.label);
+
+  if (unmet.length === 0) {
+    return "All password requirements met.";
+  }
+
+  return `Still needed: ${unmet.join(", ")}.`;
+}
+
 /**
  * Generates a set of single-use two-factor backup (recovery) codes.
  *
@@ -464,6 +511,53 @@ export default function SecurityTab({
   const passwordsMatch =
     watchedPassword.length > 0 && watchedPassword === watchedConfirm;
 
+  const passwordRequirementsAnnouncement = useMemo(
+    () =>
+      buildPasswordRequirementsAnnouncement(
+        {
+          minLength: passwordRequirements.minLength,
+          uppercase: passwordRequirements.uppercase,
+          specialChar: passwordRequirements.specialChar,
+        },
+        passwordsMatch,
+        watchedPassword.length > 0,
+      ),
+    [
+      passwordRequirements.minLength,
+      passwordRequirements.uppercase,
+      passwordRequirements.specialChar,
+      passwordsMatch,
+      watchedPassword.length,
+    ],
+  );
+
+  // Debounced + change-gated live region: announce only after typing pauses
+  // and only when the unmet/met summary actually changes (avoids SR spam).
+  const [liveRequirementsAnnouncement, setLiveRequirementsAnnouncement] =
+    useState("");
+  const lastAnnouncedRequirementsRef = useRef("");
+
+  useEffect(() => {
+    if (!passwordRequirementsAnnouncement) {
+      setLiveRequirementsAnnouncement("");
+      lastAnnouncedRequirementsRef.current = "";
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      if (
+        passwordRequirementsAnnouncement !==
+        lastAnnouncedRequirementsRef.current
+      ) {
+        lastAnnouncedRequirementsRef.current =
+          passwordRequirementsAnnouncement;
+        setLiveRequirementsAnnouncement(passwordRequirementsAnnouncement);
+      }
+    }, PASSWORD_REQUIREMENTS_ANNOUNCE_DELAY_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [passwordRequirementsAnnouncement]);
+
   const canSubmit =
     form.formState.isValid &&
     watchedPassword.length > 0 &&
@@ -721,6 +815,7 @@ export default function SecurityTab({
                   placeholder="Use a strong password"
                   autoComplete="new-password"
                   disabled={isSaving}
+                  ariaDescribedBy={NEW_PASSWORD_REQUIREMENTS_ID}
                 />
                 <div className="space-y-4">
                   <FormFieldPassword
@@ -739,7 +834,25 @@ export default function SecurityTab({
                 </div>
               </div>
 
-              <div className="grid gap-3 sm:grid-cols-2">
+              <p id={NEW_PASSWORD_REQUIREMENTS_ID} className="sr-only">
+                Password requirements: at least 8 characters, one uppercase
+                letter, and one special character. Confirm password must match.
+              </p>
+              <div
+                id={NEW_PASSWORD_REQUIREMENTS_STATUS_ID}
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+                className="sr-only"
+              >
+                {liveRequirementsAnnouncement}
+              </div>
+
+              <div
+                className="grid gap-3 sm:grid-cols-2"
+                role="list"
+                aria-label="Password requirements"
+              >
                 <RequirementItem
                   label="At least 8 characters"
                   met={passwordRequirements.minLength}
@@ -1421,14 +1534,20 @@ export default function SecurityTab({
 
 function RequirementItem({ label, met }: { label: string; met: boolean }) {
   return (
-    <div className="flex items-center gap-2 rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-600 dark:border-white/10 dark:bg-white/5 dark:text-zinc-400">
+    <div
+      role="listitem"
+      className="flex items-center gap-2 rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-600 dark:border-white/10 dark:bg-white/5 dark:text-zinc-400"
+    >
       <CheckCircle2
         className={`size-4 ${
           met ? "text-emerald-500" : "text-zinc-300 dark:text-zinc-600"
         }`}
         aria-hidden="true"
       />
-      <span>{label}</span>
+      <span>
+        <span className="sr-only">{met ? "Met: " : "Not met: "}</span>
+        {label}
+      </span>
     </div>
   );
 }

--- a/components/ui/form-field.test.tsx
+++ b/components/ui/form-field.test.tsx
@@ -2,7 +2,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { useForm } from "react-hook-form";
-import { Form, AuthFormField } from "@/components/ui/form-field";
+import {
+  Form,
+  AuthFormField,
+  FormFieldPassword,
+} from "@/components/ui/form-field";
 
 interface TestFormValues {
   username: string;
@@ -49,6 +53,25 @@ function TestComponent({
         />
         <button type="submit">Submit</button>
       </form>
+    </Form>
+  );
+}
+
+function PasswordWithDescribedBy() {
+  const form = useForm<TestFormValues>({
+    defaultValues: { username: "", email: "", password: "" },
+  });
+
+  return (
+    <Form {...form}>
+      <p id="external-helper">External helper text</p>
+      <FormFieldPassword
+        control={form.control}
+        name="password"
+        label="Password"
+        placeholder="Enter password"
+        ariaDescribedBy="external-helper"
+      />
     </Form>
   );
 }
@@ -127,5 +150,14 @@ describe("AuthFormField Component", () => {
     expect(emailInput).toBeDisabled();
     expect(passwordInput).toBeDisabled();
     expect(toggleButton).toBeDisabled();
+  });
+
+  it("FormFieldPassword merges ariaDescribedBy into aria-describedby", () => {
+    render(<PasswordWithDescribedBy />);
+
+    const passwordInput = screen.getByPlaceholderText("Enter password");
+    const describedBy = passwordInput.getAttribute("aria-describedby");
+
+    expect(describedBy?.split(/\s+/)).toContain("external-helper");
   });
 });

--- a/components/ui/form-field.tsx
+++ b/components/ui/form-field.tsx
@@ -19,6 +19,12 @@ import {
 interface FormFieldBaseProps {
   label?: React.ReactNode;
   description?: string;
+  /**
+   * Extra element id(s) to include in the input's `aria-describedby`
+   * (space-separated). Useful for associating external helper text such as
+   * password-requirement instructions without rendering a FormDescription.
+   */
+  ariaDescribedBy?: string;
   required?: boolean;
   placeholder?: string;
   disabled?: boolean;
@@ -47,6 +53,7 @@ export function FormFieldInput<
 >({
   label,
   description,
+  ariaDescribedBy,
   required,
   placeholder,
   disabled,
@@ -64,6 +71,10 @@ export function FormFieldInput<
   const fieldId = React.useId();
   const descriptionId = `${fieldId}-description`;
   const errorId = `${fieldId}-error`;
+  const describedByIds =
+    [description ? descriptionId : undefined, ariaDescribedBy]
+      .filter(Boolean)
+      .join(" ") || undefined;
 
   return (
     <FormField
@@ -97,7 +108,7 @@ export function FormFieldInput<
                 warning={warning}
                 loading={loading}
                 labelId={label ? `${fieldId}-label` : undefined}
-                descriptionId={description ? descriptionId : undefined}
+                descriptionId={describedByIds}
                 errorId={
                   fieldState.error || successMessage || warningMessage
                     ? errorId
@@ -312,6 +323,7 @@ export function FormFieldPassword<
 >({
   label,
   description,
+  ariaDescribedBy,
   required,
   placeholder,
   disabled,
@@ -329,6 +341,10 @@ export function FormFieldPassword<
   const fieldId = React.useId();
   const descriptionId = `${fieldId}-description`;
   const errorId = `${fieldId}-error`;
+  const describedByIds =
+    [description ? descriptionId : undefined, ariaDescribedBy]
+      .filter(Boolean)
+      .join(" ") || undefined;
 
   return (
     <FormField
@@ -363,7 +379,7 @@ export function FormFieldPassword<
                   warning={warning}
                   loading={loading}
                   labelId={label ? `${fieldId}-label` : undefined}
-                  descriptionId={description ? descriptionId : undefined}
+                  descriptionId={describedByIds}
                   errorId={
                     fieldState.error || successMessage || warningMessage
                       ? errorId


### PR DESCRIPTION
Closes #749


This PR enhances the accessibility of the password requirements section in the Security tab by improving screen reader support, reducing announcement noise, and strengthening the association between password inputs and requirement feedback.

What was implemented
♿ Improved Screen Reader Experience
Added helper text linked to the New Password field using aria-describedby.
Extended FormFieldPassword to support an external ariaDescribedBy prop for associating additional accessibility descriptions.
🔊 Live Announcements
Implemented a 700ms debounced aria-live="polite" region to announce password requirement changes.
Prevents excessive announcements while typing, resulting in a smoother experience for assistive technology users.
Announces both newly met and unmet password requirements.
✅ Accessible Requirement Checklist
Updated visual password requirement checklist items to expose:
"Met:" for satisfied requirements.
"Not met:" for unsatisfied requirements.
Improves clarity for screen reader users without changing the visual UI.
Testing

Added accessibility-focused tests covering:

Correct aria-describedby association between the password field and helper text.
Debounced live region behavior.
Screen reader announcement content and copy.
FormFieldPassword support for external accessibility descriptions.