### PR TITLE
fix: sync transaction timestamp display with the saved timezone prefe…

### DIFF
--- a/app/settings/preferences/components/account-section.tsx
+++ b/app/settings/preferences/components/account-section.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { saveProfile } from "@/lib/api/profile";
 import { toast } from "sonner";
+import { safeStorage, STORAGE_KEYS } from "@/utils/safeStorage";
 import {
   User,
   Upload,
@@ -133,6 +134,9 @@ export default function AccountSection({
 
     try {
       await saveProfile(profile);
+      // Persist timezone preference to localStorage so other components
+      // (e.g. transaction table) can read it without a server round-trip.
+      safeStorage.setItem(STORAGE_KEYS.TIMEZONE, profile.timezone);
       // Update the last-known-good snapshot on successful save
       lastSavedProfile.current = { ...profile };
       setSaveStatus('success');

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -11,6 +11,7 @@ import type {
   TransactionProps,
 } from "@/types/transaction";
 import { useTransactions } from "@/hooks/useTransactions";
+import { formatTransactionDateTime } from "@/utils/date-utils";
 import { TransactionTableSkeleton } from "@/components/ui/table-skeleton";
 import TransactionsHeader from "./transactions-header";
 import TransactionsFilters from "./transactions-filters";
@@ -262,22 +263,29 @@ const getTokenIcon = (token: string): string => {
 };
 
 /** Convert internal Transaction → display TransactionProps */
-const toTransactionProps = (t: Transaction): TransactionProps => ({
-  id: t.id,
-  type: t.type,
-  txId: t.txId,
-  address: t.address,
-  date: t.date,
-  time: t.time,
-  token: t.token,
-  amount:
-    t.amount >= 0
-      ? `+$${t.amount.toFixed(2)}`
-      : `-$${Math.abs(t.amount).toFixed(2)}`,
-  status: t.status as "Completed" | "Pending" | "Failed",
-  tokenIcon: getTokenIcon(t.token),
-  memo: t.memo,
-});
+const toTransactionProps = (
+  t: Transaction,
+  timezone?: string,
+): TransactionProps => {
+  const formatted = formatTransactionDateTime(t.date, t.time, timezone);
+  return {
+    id: t.id,
+    type: t.type,
+    txId: t.txId,
+    address: t.address,
+    date: formatted.date,
+    time: formatted.time,
+    token: t.token,
+    amount:
+      t.amount >= 0
+        ? `+$${t.amount.toFixed(2)}`
+        : `-$${Math.abs(t.amount).toFixed(2)}`,
+    status: t.status as "Completed" | "Pending" | "Failed",
+    tokenIcon: getTokenIcon(t.token),
+    memo: t.memo,
+    timestamp: formatted.timestamp,
+  };
+};
 
 export default function TransactionsContent() {
   const router = useRouter();

--- a/components/transactions/transactions-table.test.tsx
+++ b/components/transactions/transactions-table.test.tsx
@@ -121,33 +121,43 @@ describe("TransactionsTable — status icons (WCAG 1.4.1)", () => {
 
   it("renders status text alongside the icon in the badge", () => {
     render(<TransactionsTable transactions={mockTransactions} />);
-    expect(screen.getByText("Completed")).toBeInTheDocument();
-    expect(screen.getByText("Pending")).toBeInTheDocument();
-    expect(screen.getByText("Failed")).toBeInTheDocument();
+    // Both desktop and mobile views render, so use getAllByText
+    const completedBadges = screen.getAllByText("Completed");
+    expect(completedBadges.length).toBeGreaterThanOrEqual(1);
+    const pendingBadges = screen.getAllByText("Pending");
+    expect(pendingBadges.length).toBeGreaterThanOrEqual(1);
+    const failedBadges = screen.getAllByText("Failed");
+    expect(failedBadges.length).toBeGreaterThanOrEqual(1);
   });
 
   it("preserves aria-label on the status badge for screen readers", () => {
     render(<TransactionsTable transactions={mockTransactions} />);
-    expect(screen.getByLabelText("Status: Completed")).toBeInTheDocument();
-    expect(screen.getByLabelText("Status: Pending")).toBeInTheDocument();
-    expect(screen.getByLabelText("Status: Failed")).toBeInTheDocument();
+    const completedBadges = screen.getAllByLabelText("Status: Completed");
+    expect(completedBadges.length).toBeGreaterThanOrEqual(1);
+    const pendingBadges = screen.getAllByLabelText("Status: Pending");
+    expect(pendingBadges.length).toBeGreaterThanOrEqual(1);
+    const failedBadges = screen.getAllByLabelText("Status: Failed");
+    expect(failedBadges.length).toBeGreaterThanOrEqual(1);
   });
 
   it("status badge aria-label survives grayscale simulation (no color-only info)", () => {
     render(<TransactionsTable transactions={mockTransactions} />);
 
-    // Completed
-    const completedBadge = screen.getByLabelText("Status: Completed");
+    // Completed - use first badge
+    const completedBadges = screen.getAllByLabelText("Status: Completed");
+    const completedBadge = completedBadges[0];
     expect(completedBadge).toHaveTextContent("Completed");
     expect(completedBadge.querySelector("svg")).toBeInTheDocument();
 
     // Pending
-    const pendingBadge = screen.getByLabelText("Status: Pending");
+    const pendingBadges = screen.getAllByLabelText("Status: Pending");
+    const pendingBadge = pendingBadges[0];
     expect(pendingBadge).toHaveTextContent("Pending");
     expect(pendingBadge.querySelector("svg")).toBeInTheDocument();
 
     // Failed
-    const failedBadge = screen.getByLabelText("Status: Failed");
+    const failedBadges = screen.getAllByLabelText("Status: Failed");
+    const failedBadge = failedBadges[0];
     expect(failedBadge).toHaveTextContent("Failed");
     expect(failedBadge.querySelector("svg")).toBeInTheDocument();
   });
@@ -163,7 +173,8 @@ describe("TransactionsTable — status icons (WCAG 1.4.1)", () => {
     render(<TransactionsTable transactions={mockTransactions} />);
     const viewButtons = screen.getAllByLabelText(/View details for transaction/i);
     fireEvent.click(viewButtons[0]);
-    const dialogBadge = screen.getByLabelText("Status: Completed");
+    const dialogBadges = screen.getAllByLabelText("Status: Completed");
+    const dialogBadge = dialogBadges[dialogBadges.length - 1];
     expect(dialogBadge.querySelector("svg[aria-hidden='true']")).toBeInTheDocument();
     expect(dialogBadge).toHaveTextContent("Completed");
   });

--- a/components/transactions/transactions-table.tsx
+++ b/components/transactions/transactions-table.tsx
@@ -598,7 +598,10 @@ export function TransactionsTable({
                     />
                   </TableCell>
                 </TableRow>
-              )))}
+              );
+            })
+          )
+          }
           </TableBody>
         </Table>
       </div>

--- a/types/transaction.ts
+++ b/types/transaction.ts
@@ -62,6 +62,10 @@ export interface TransactionProps {
   fee?: string;
   /** Optional raw transaction hash */
   hash?: string;
+  /** User-assignable category tag names */
+  tags?: string[];
+  /** ISO-8601 timestamp derived from date + time */
+  timestamp?: string;
 }
 
 // Transaction component props

--- a/utils/date-utils.ts
+++ b/utils/date-utils.ts
@@ -1,4 +1,5 @@
 import { format, parse, isValid, startOfDay } from "date-fns";
+import { safeStorage, STORAGE_KEYS } from "@/utils/safeStorage";
 
 /**
  * Single source of truth for date parsing, formatting, and range checks.
@@ -130,6 +131,88 @@ export function isDateInRange(
  */
 export function getCurrentDate(): string {
   return formatDateForInput(new Date());
+}
+
+/**
+ * Reads the user's saved timezone preference from localStorage.
+ * Falls back to the browser's local IANA timezone when no preference is set.
+ */
+export function getSavedTimezone(): string {
+  const saved = safeStorage.getItem(STORAGE_KEYS.TIMEZONE);
+  if (saved) return saved;
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return "UTC";
+  }
+}
+
+/**
+ * Combines a date string and a 12-hour time string into an ISO-8601 UTC
+ * timestamp (e.g. "2023-04-12T09:32:00.000Z").
+ *
+ * Supports times in "hh:mmAM"/"hh:mm PM" format.
+ */
+export function getTransactionTimestamp(date: string, time = ""): string {
+  const fallback = `${date}T00:00:00.000Z`;
+  const trimmed = time.trim();
+  const match = trimmed.match(/^(\d{1,2}):(\d{2})\s*([AP]M)$/i);
+
+  if (!match) return fallback;
+
+  let hour = Number(match[1]);
+  const minute = Number(match[2]);
+  const period = match[3].toUpperCase();
+
+  if (hour < 1 || hour > 12 || minute < 0 || minute > 59) return fallback;
+
+  if (period === "PM" && hour !== 12) hour += 12;
+  if (period === "AM" && hour === 12) hour = 0;
+
+  return `${date}T${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}:00.000Z`;
+}
+
+/**
+ * Formats a date+time pair (as stored in Transaction) using the user's saved
+ * timezone preference (or the browser's local timezone as fallback).
+ *
+ * Returns `{ date, time }` strings suitable for display.
+ *
+ * Falls back to the original date/time strings when the timestamp cannot be parsed.
+ */
+export function formatTransactionDateTime(
+  date: string,
+  time: string,
+  timezone?: string,
+): { date: string; time: string; timestamp: string } {
+  const tz = timezone ?? getSavedTimezone();
+  const timestamp = getTransactionTimestamp(date, time);
+  const parsed = new Date(timestamp);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return { date, time, timestamp };
+  }
+
+  try {
+    const formatted = new Intl.DateTimeFormat("en-US", {
+      dateStyle: "medium",
+      timeStyle: "short",
+      timeZone: tz,
+    }).format(parsed);
+
+    const parts = formatted.split(", ");
+    // "Jul 29, 2026, 10:30 AM" -> datePart: "Jul 29, 2026", timePart: "10:30 AM"
+    const datePart = parts.slice(0, -1).join(", ");
+    const timePart = parts[parts.length - 1] ?? time;
+
+    return {
+      date: datePart || date,
+      time: timePart || time,
+      timestamp,
+    };
+  } catch {
+    return { date, time, timestamp };
+  }
 }
 
 /**

--- a/utils/safeStorage.ts
+++ b/utils/safeStorage.ts
@@ -6,6 +6,7 @@
 export const STORAGE_KEYS = {
   DASHBOARD_TOUR_COMPLETED: "stellopay_dashboard_tour_completed",
   DASHBOARD_WIDGET_ORDER: "stellopay_dashboard_widget_order",
+  TIMEZONE: "stellopay_timezone",
 } as const;
 
 export const safeStorage = {

--- a/utils/transactionUtils.ts
+++ b/utils/transactionUtils.ts
@@ -296,6 +296,8 @@ export const sortAndFilterTransactions = memoizeLast(
     return sortTransactionsMulti(filtered, sortConfigs);
   },
 );
+
+/**
  * Mapping each known transaction status to a distinct lucide-react icon.
  * These icons are paired with color badges so the status is communicated
  * through shape + label, not color alone (WCAG 1.4.1 Use of Color).


### PR DESCRIPTION
closes #911
Description
Syncs transaction timestamp display with the user's saved timezone preference from the Settings → Preferences page, falling back to the browser's local timezone when no preference is saved.
Changes
- utils/date-utils.ts — Added getSavedTimezone() (reads from safeStorage), getTransactionTimestamp() (combines Transaction.date/time into an ISO UTC string), and formatTransactionDateTime() (formats via Intl.DateTimeFormat with the saved timezone).
- utils/safeStorage.ts — Added STORAGE_KEYS.TIMEZONE = "stellopay_timezone".
- app/settings/preferences/components/account-section.tsx — Persists profile.timezone to safeStorage on save.
- components/transactions/transactions-content.tsx — toTransactionProps() now calls formatTransactionDateTime() and attaches the formatted timestamp string.
- types/transaction.ts — Added optional timestamp?: string to TransactionProps.
- Parser fixes — Fixed )))} issue in transactions-table.tsx and missing /** JSDoc in transactionUtils.ts (both broke oxc/vite parsing).
- Test fixes — Switched getBy* → getAllBy* in status-badge tests to handle desktop + mobile card views rendering duplicate DOM.
Testing
All 43 tests in transactions-table.test.tsx pass.

## Checklist

- [x] I have tested the changes locally.
- [x] I have added/updated documentation as needed.
- [x] I have reviewed the code and ensured it follows the project guidelines.
- [x] I have added necessary tests.

## Screenshots/Recordings

<!-- Attach relevant images or videos to show the effect of your changes. -->

## Additional Notes

<!-- Any other information reviewers should be aware of. -->
