### PR TITLE
perf: lazy-load below-the-fold landing sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,103 @@ npm test -- app/metadata.test.ts
 
 When the product description, pricing model, or feature list changes, update the `landingStructuredData` object in `app/page.tsx` and adjust the corresponding tests.
 
+## Landing Page Code Splitting
+
+`components/landing/landing-page.tsx` eagerly imports only what is above the
+fold. Everything below it is deferred with `next/dynamic`.
+
+### What is eager, and why
+
+| Section | Loading | Reason |
+| --- | --- | --- |
+| `Navbar` | eager | Immediately visible; needed for first interaction |
+| `Hero` | eager | Above the fold and the LCP element |
+| everything else | `next/dynamic` | Below the fold on first paint |
+
+Deferred sections: `stats-cards`, `features-intro`, `how-it-works`,
+`testimonials-section`, `value-propositions`, `enterprise-section`, `benefits`,
+`faq-section`, `get-started-cta`, `footer`.
+
+This matters most for the framer-motion sections. `hero`, `how-it-works` and
+`faq-section` are the only landing modules importing `framer-motion`; two of
+those three are now deferred, so the animation runtime is no longer on the
+critical path to hero interactivity.
+
+### `ssr: true` is deliberate
+
+Every deferred section sets `ssr: true`. The server still renders their markup
+into the initial HTML — only the client JS is split out. This keeps SEO
+crawlability and no-JS rendering intact, and makes the skeleton fallbacks a
+hydration-time state rather than a blank first paint.
+
+Do not switch these to `ssr: false` to chase a smaller bundle. It would remove
+the sections from the server-rendered HTML entirely.
+
+### Adding a new landing section
+
+1. Decide whether it is above the fold. If yes, import it normally.
+2. If not, wrap it in `dynamic(() => import(...), { loading, ssr: true })`.
+3. Build the fallback with the exported `SectionFallback` helper so the busy
+   state stays consistent:
+
+```tsx
+const NewSection = dynamic(() => import("@/components/landing/new-section"), {
+  loading: () => (
+    <SectionFallback
+      label="Loading new section..."
+      className="w-full py-16 sm:py-20 lg:py-24 bg-white dark:bg-[#0D0D0D]"
+    >
+      <Skeleton className="h-64 rounded-3xl" shade="dark" />
+    </SectionFallback>
+  ),
+  ssr: true,
+});
+```
+
+4. Add the module path to `DEFERRED_SECTIONS` in
+   `components/landing/landing-page.test.tsx`.
+
+For a named export, resolve it in the importer:
+`dynamic(() => import("...").then((m) => m.NamedExport), { ... })`.
+
+### Accessibility (WCAG 2.1 AA)
+
+`SectionFallback` renders every skeleton with:
+
+- `role="status"` and `aria-live="polite"` — the pending state is announced
+  without interrupting a screen reader mid-sentence (SC 4.1.3). Deliberately
+  polite, not assertive; a routine section load is not an alert.
+- `aria-busy="true"` — assistive tech can tell the region is incomplete.
+- an `sr-only` label naming the specific section ("Loading testimonials...")
+  rather than a generic "Loading", so the announcement is meaningful out of
+  context (SC 2.4.6).
+- the section's own vertical rhythm classes on the fallback wrapper, so
+  swapping the skeleton for real content does not shift layout (SC 2.2.2).
+
+Deferring does not change heading order. `landing-page.test.tsx` asserts the
+full H1 → H2 → H3 outline with no skipped levels once all sections resolve
+(SC 1.3.1).
+
+Keyboard navigation is unaffected: `ssr: true` means deferred sections exist in
+the DOM in source order, so tab order matches visual order.
+
+### Responsive
+
+Fallbacks reuse the same `py-16 sm:py-20 lg:py-24` rhythm and the same grid
+breakpoints as the sections they stand in for, so the skeleton occupies
+comparable space at sm 640, md 768, lg 1024 and xl 1280.
+
+### Testing
+
+```bash
+npx vitest run components/landing/landing-page.test.tsx
+```
+
+`next/dynamic` is mocked to resolve the real module asynchronously, so tests
+exercise the actual deferred path and assert against real components rather
+than stand-ins. The mock records each importer's source text, which is how the
+suite verifies a section is deferred and that Hero and Navbar are not.
+
 ## Project Structure
 
 ```

--- a/components/common/footer.tsx
+++ b/components/common/footer.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useState, useEffect } from "react";
 import { safeStorage } from "@/utils/safeStorage";
 import { X } from "lucide-react";
+import { messages } from "@/messages";
 
 // Social Media Icons as SVG components
 const TwitterIcon = () => (

--- a/components/landing/enterprise-section.tsx
+++ b/components/landing/enterprise-section.tsx
@@ -73,15 +73,10 @@ const EnterpriseSolutionSection = () => {
             id="enterprise-solution-desc"
             className="text-[#52525B] dark:text-[#A1A1AA] text-start font-normal text-xl leading-[32.5px] print:text-black"
           >
-            StelloPay is built for scale. Whether you&apos;re a startup or an
-            enterprise, our platform grows with your business needs.
-
-          <p className="text-[#52525B] dark:text-[#A1A1AA] text-start font-normal text-xl leading-[32.5px] print:text-black">
             StelloPay settles cross-border payments on the Stellar network in
             3–5 seconds for less than $0.001 per transaction. Native multi-asset
             support (USDC, XLM, and more) with built-in fiat on/off ramps via
             Stellar anchors.
-
           </p>
         </div>
         <div aria-label="Enterprise features">

--- a/components/landing/hero.tsx
+++ b/components/landing/hero.tsx
@@ -117,12 +117,8 @@ const Hero = () => {
           </a>
           {/* header text */}
 
-          <h1 className="font-bold text-4xl lg:text-7xl text-display-2xl">
-            The Future of{" "}
-
           <h1 className="text-display-2xl font-bold">
-            The Future of
-
+            The Future of{" "}
             <span className="bg-gradient-to-r from-[#2563EB] dark:from-[#3B82F6] via-[#7C3AED] dark:via-[#8B5CF6] via-16% lg:via-33% to-[#059669] dark:to-[#10B981] to-33% lg:to-66% bg-clip-text text-transparent block">
               Payroll on
             </span>{" "}
@@ -131,11 +127,7 @@ const Hero = () => {
           {/* paragraph text */}
           <p
             data-testid="hero-subtext"
-
-            className="text-base lg:text-lg font-normal text-[#52525B] dark:text-[#A1A1AA] lg:w-[90%] text-body-lg"
-
             className="text-body-lg font-normal text-[#52525B] dark:text-[#A1A1AA] lg:w-[90%]"
-
           >
             Built for modern businesses. Designed for global payments. Powered
             by blockchain technology.

--- a/components/landing/how-it-works.tsx
+++ b/components/landing/how-it-works.tsx
@@ -6,6 +6,7 @@ import { UserPlus, Wallet, Send } from "lucide-react";
 import { motion } from "framer-motion";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { duration, easing } from "@/lib/motion";
+import { VideoFacade } from "@/components/landing/video-facade";
 
 const steps = [
   {

--- a/components/landing/landing-page.test.tsx
+++ b/components/landing/landing-page.test.tsx
@@ -1,183 +1,63 @@
-
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import React from "react";
-import LandingPage from "./landing-page";
-import { ThemeProvider } from "@/context/theme-context";
-import { WalletProvider } from "@/context/wallet-context";
-
-vi.mock("next/dynamic", () => {
-  return {
-    default: (importFunc: any) => {
-      const fnStr = importFunc.toString();
-      if (fnStr.includes("how-it-works")) {
-        return function DummyHowItWorks() {
-          return (
-            <section>
-              <h2>From crypto to cash — <span className="text-transparent">in just three steps</span></h2>
-              <h3>Connect Your Wallet</h3>
-              <h3>Make Crypto Payments</h3>
-              <h3>Receive in Naira</h3>
-            </section>
-          );
-        };
-      }
-      if (fnStr.includes("enterprise-section")) {
-        return function DummyEnterprise() {
-          return (
-            <section aria-labelledby="enterprise-solution-title" aria-describedby="enterprise-solution-desc">
-              <h2 id="enterprise-solution-title">
-                Enterprise-ready <br />
-                <span>blockchain solution</span>
-              </h2>
-              <p id="enterprise-solution-desc">StelloPay is built for scale.</p>
-            </section>
-          );
-        };
-      }
-      if (fnStr.includes("faq-section")) {
-        return function DummyFAQ() {
-          return (
-            <section>
-              <h2>
-                Have any <span>Questions?</span> We&apos;ve Got Your Answers
-              </h2>
-              <h3>Do I need a crypto wallet?</h3>
-              <h3>What are the supported currencies?</h3>
-            </section>
-          );
-        };
-      }
-      return () => <div data-testid="fallback-mock" />;
-    },
-  };
-});
-
-describe("LandingPage Heading Hierarchy and Outline Validation", () => {
-  it("audits the landing page for exactly one h1 element", () => {
-    render(
-      <WalletProvider>
-        <ThemeProvider>
-          <LandingPage />
-        </ThemeProvider>
-      </WalletProvider>
-    );
-    const h1Elements = screen.getAllByRole("heading", { level: 1 });
-    expect(h1Elements).toHaveLength(1);
-    expect(h1Elements[0]).toHaveTextContent(/The Future of Payroll on Blockchain/i);
-  });
-
-  it("verifies a logically nested h2/h3 tree with no skipped levels", () => {
-    render(
-      <WalletProvider>
-        <ThemeProvider>
-          <LandingPage />
-        </ThemeProvider>
-      </WalletProvider>
-    );
-    
-    // Query all elements with a heading role
-    const headings = screen.getAllByRole("heading");
-    
-    // Extract heading levels in order of document appearance
-    const headingStructure = headings.map((h) => ({
-      text: h.textContent?.trim(),
-      level: parseInt(h.tagName.substring(1), 10),
-    }));
-
-    // Output structure in test logs for audit visibility
-    console.log("Audited Heading Outline:", headingStructure);
-
-    // Assert that the first heading is the H1
-    expect(headingStructure[0].level).toBe(1);
-
-    // Verify there are no skipped levels.
-    // A heading of level N can be followed by any level up to N + 1.
-    // For example, an H2 can be followed by an H3 (nesting down), or another H2 (same level),
-    // or an H1 (if another main part begins, though here we only have one H1), but NOT an H4.
-    let previousLevel = 1;
-    for (let i = 1; i < headingStructure.length; i++) {
-      const currentLevel = headingStructure[i].level;
-      
-      // Ensure we do not skip levels downwards (e.g. from H1 directly to H3, or H2 to H4)
-      expect(currentLevel).toBeLessThanOrEqual(previousLevel + 1);
-      
-      previousLevel = currentLevel;
-    }
-  });
-
-  it("ensures major sections are marked with H2 semantic headings", () => {
-    render(
-      <WalletProvider>
-        <ThemeProvider>
-          <LandingPage />
-        </ThemeProvider>
-      </WalletProvider>
-    );
-    
-    // All top-level landing page sections must use H2
-    const h2Headings = screen.getAllByRole("heading", { level: 2 });
-    const h2Texts = h2Headings.map(h => h.textContent?.trim());
-
-    expect(h2Texts.some(text => text?.includes("Everything you need to"))).toBe(true);
-    expect(h2Texts.some(text => text?.includes("From crypto to cash"))).toBe(true);
-    expect(h2Texts.some(text => text?.includes("Why businesses choose"))).toBe(true);
-    expect(h2Texts.some(text => text?.includes("Enterprise-ready"))).toBe(true);
-    expect(h2Texts.some(text => text?.includes("Benefits"))).toBe(true);
-    expect(h2Texts.some(text => text?.includes("Questions?"))).toBe(true);
-    expect(h2Texts.some(text => text?.includes("Ready to revolutionize"))).toBe(true);
-
 /**
- * Landing-page spacing-rhythm tests
- * ----------------------------------
- * Verifies that every top-level landing section applies the unified
- * three-step responsive vertical-rhythm scale:
- *   py-16 sm:py-20 lg:py-24  (64 px / 80 px / 96 px)
+ * Landing-page tests
+ * ------------------
+ * Covers three concerns for the landing page composition:
  *
- * Why class-name assertions?
- * Tailwind generates CSS at build time, not in jsdom.  The only reliable
- * way to confirm that the correct spacing classes are present — without
- * running a full browser — is to check the rendered element's className.
- * Each test targets the outermost section element of the component under
- * test and asserts on all three breakpoint classes as a group so a partial
- * application (e.g. py-16 without sm/lg variants) also fails.
+ * 1. Below-the-fold code splitting — every section under the hero is loaded
+ *    through `next/dynamic`, while Navbar and Hero stay eagerly imported so
+ *    first paint is not delayed.
+ * 2. Heading hierarchy / outline validation (WCAG 2.1 AA, SC 1.3.1).
+ * 3. The unified responsive vertical-rhythm scale (py-16 sm:py-20 lg:py-24).
  *
- * Accessibility smoke-checks are included for each section to guard the
- * WCAG 2.1 AA landmark requirements while the spacing changes are applied.
+ * Why class-name assertions for spacing?
+ * Tailwind generates CSS at build time, not in jsdom. The only reliable way to
+ * confirm the correct spacing classes are present — without running a full
+ * browser — is to check the rendered element's className. Each spacing test
+ * targets the outermost section element and asserts all three breakpoint
+ * classes as a group, so a partial application (e.g. py-16 without the sm/lg
+ * variants) also fails.
  */
 
-import { render, screen } from "@testing-library/react";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { ThemeProvider } from "@/context/theme-context";
+import { WalletProvider } from "@/context/wallet-context";
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
 // ---------------------------------------------------------------------------
 
-// next/image → plain <img> so tests don't need the Next.js runtime
-vi.mock("next/image", () => ({
-  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img {...props} alt={props.alt ?? ""} />
-  ),
-}));
+// Records the source text of every importer passed to next/dynamic, so the
+// code-splitting tests can assert which sections are deferred without
+// depending on render order.
+const dynamicImports = vi.hoisted(() => [] as string[]);
 
-// next/dynamic → render children synchronously (no lazy-loading in tests)
+// next/dynamic → resolve the real module asynchronously, mirroring the real
+// deferred behaviour. Tests await the loaded content rather than asserting
+// against stand-in components, so the heading outline reflects reality.
 vi.mock("next/dynamic", () => ({
   default: (
-    fn: () => Promise<{ default: React.ComponentType }>,
+    importFunc: () => Promise<{ default: React.ComponentType }>,
     _opts?: unknown,
   ) => {
-    // Return a component that renders the loaded module synchronously.
-    // We use a simple wrapper to make the signature match what Next.js
-    // dynamic() normally returns.
+    dynamicImports.push(importFunc.toString());
+
     const DynamicComponent = (props: Record<string, unknown>) => {
       const [Component, setComponent] =
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        require("react").useState<React.ComponentType | null>(null);
+        React.useState<React.ComponentType | null>(null);
 
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      require("react").useEffect(() => {
-        fn().then((mod) => setComponent(() => mod.default));
+      React.useEffect(() => {
+        let active = true;
+        importFunc().then((mod) => {
+          if (!active) return;
+          const resolved =
+            typeof mod === "function" ? mod : (mod?.default ?? null);
+          setComponent(() => resolved as React.ComponentType);
+        });
+        return () => {
+          active = false;
+        };
       }, []);
 
       return Component ? <Component {...props} /> : null;
@@ -185,6 +65,14 @@ vi.mock("next/dynamic", () => ({
     DynamicComponent.displayName = "DynamicComponent";
     return DynamicComponent;
   },
+}));
+
+// next/image → plain <img> so tests don't need the Next.js runtime
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img {...props} alt={props.alt ?? ""} />
+  ),
 }));
 
 // Framer-motion → identity passthrough to avoid animation overhead
@@ -195,45 +83,286 @@ vi.mock("framer-motion", () => ({
       get:
         (_t, tag: string) =>
         ({ children, ...rest }: React.HTMLAttributes<HTMLElement>) =>
-          require("react").createElement(tag, rest, children),
+          React.createElement(tag, rest, children),
     },
   ),
   AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+  useReducedMotion: () => true,
 }));
 
 // useReducedMotion hook — disable decorative animations in tests
 vi.mock("@/hooks/useReducedMotion", () => ({
   useReducedMotion: () => true,
+  default: () => true,
 }));
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Browser APIs missing from jsdom
+// ---------------------------------------------------------------------------
+
+function stubBrowserApis() {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    }),
+  });
+  Object.defineProperty(window, "requestAnimationFrame", {
+    configurable: true,
+    value: vi.fn((cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    }),
+  });
+  Object.defineProperty(window, "cancelAnimationFrame", {
+    configurable: true,
+    value: vi.fn(),
+  });
+  // Must be constructible — components call `new IntersectionObserver(...)`,
+  // and an arrow function cannot be used with `new`.
+  class MockIntersectionObserver {
+    observe = vi.fn();
+    disconnect = vi.fn();
+    unobserve = vi.fn();
+    takeRecords = vi.fn();
+    root = null;
+    rootMargin = "";
+    thresholds: number[] = [];
+  }
+
+  Object.defineProperty(window, "IntersectionObserver", {
+    configurable: true,
+    writable: true,
+    value: MockIntersectionObserver,
+  });
+  Object.defineProperty(globalThis, "IntersectionObserver", {
+    configurable: true,
+    writable: true,
+    value: MockIntersectionObserver,
+  });
+}
+
+const renderLandingPage = async () => {
+  const LandingPage = (await import("./landing-page")).default;
+  return render(
+    <WalletProvider>
+      <ThemeProvider>
+        <LandingPage />
+      </ThemeProvider>
+    </WalletProvider>,
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Below-the-fold code splitting
+// ---------------------------------------------------------------------------
+
+describe("LandingPage below-the-fold code splitting", () => {
+  beforeEach(() => {
+    stubBrowserApis();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** Every section that must be deferred, by module path fragment. */
+  const DEFERRED_SECTIONS = [
+    "stats-cards",
+    "features-intro",
+    "how-it-works",
+    "testimonials-section",
+    "value-propositions",
+    "enterprise-section",
+    "benefits",
+    "faq-section",
+    "get-started-cta",
+    "footer",
+  ] as const;
+
+  it.each(DEFERRED_SECTIONS)("defers %s through next/dynamic", async (section) => {
+    await renderLandingPage();
+
+    expect(
+      dynamicImports.some((src) => src.includes(section)),
+      `expected "${section}" to be loaded via next/dynamic`,
+    ).toBe(true);
+  });
+
+  it("keeps the hero eagerly imported so first paint is not delayed", async () => {
+    await renderLandingPage();
+
+    expect(dynamicImports.some((src) => src.includes("landing/hero"))).toBe(
+      false,
+    );
+    expect(
+      screen.getByRole("heading", { level: 1 }),
+    ).toHaveTextContent(/The Future of Payroll on Blockchain/i);
+  });
+
+  it("keeps the navbar eagerly imported", async () => {
+    await renderLandingPage();
+
+    expect(dynamicImports.some((src) => src.includes("landing/navbar"))).toBe(
+      false,
+    );
+  });
+
+  it("defers every section below the hero", async () => {
+    await renderLandingPage();
+
+    expect(dynamicImports.length).toBeGreaterThanOrEqual(
+      DEFERRED_SECTIONS.length,
+    );
+  });
+
+  it("renders the deferred sections once their modules resolve", async () => {
+    await renderLandingPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /from crypto to cash/i }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("heading", { name: /enterprise-ready/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("exposes a polite, labelled busy state while a section loads", async () => {
+    const { SectionFallback } = await import("./landing-page");
+
+    render(
+      <SectionFallback
+        label="Loading test section..."
+        className="w-full py-16 sm:py-20 lg:py-24"
+      >
+        <div data-testid="skeleton" />
+      </SectionFallback>,
+    );
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByText("Loading test section...")).toHaveClass("sr-only");
+    expectSectionSpacing(status);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Heading hierarchy / outline validation
+// ---------------------------------------------------------------------------
+
+describe("LandingPage Heading Hierarchy and Outline Validation", () => {
+  beforeEach(() => {
+    stubBrowserApis();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("audits the landing page for exactly one h1 element", async () => {
+    await renderLandingPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /from crypto to cash/i }),
+      ).toBeInTheDocument();
+    });
+
+    const h1Elements = screen.getAllByRole("heading", { level: 1 });
+    expect(h1Elements).toHaveLength(1);
+    expect(h1Elements[0]).toHaveTextContent(
+      /The Future of Payroll on Blockchain/i,
+    );
+  });
+
+  it("verifies a logically nested h2/h3 tree with no skipped levels", async () => {
+    await renderLandingPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /from crypto to cash/i }),
+      ).toBeInTheDocument();
+    });
+
+    const headings = screen.getAllByRole("heading");
+    const headingStructure = headings.map((h) => ({
+      text: h.textContent?.trim(),
+      level: parseInt(h.tagName.substring(1), 10),
+    }));
+
+    expect(headingStructure[0].level).toBe(1);
+
+    // A heading of level N may be followed by any level up to N + 1. Going
+    // from H2 straight to H4 skips a level and fails SC 1.3.1.
+    let previousLevel = 1;
+    for (let i = 1; i < headingStructure.length; i++) {
+      const currentLevel = headingStructure[i].level;
+      expect(currentLevel).toBeLessThanOrEqual(previousLevel + 1);
+      previousLevel = currentLevel;
+    }
+  });
+
+  it("ensures major sections are marked with H2 semantic headings", async () => {
+    await renderLandingPage();
+
+    // Sections resolve on independent microtask ticks, so poll until every
+    // expected H2 has mounted rather than sampling after the first one.
+    for (const expected of [
+      "Everything you need to",
+      "From crypto to cash",
+      "Why businesses choose",
+      "Enterprise-ready",
+      "Benefits",
+      "Questions?",
+      "Ready to revolutionize",
+    ]) {
+      await waitFor(() => {
+        const h2Texts = screen
+          .getAllByRole("heading", { level: 2 })
+          .map((h) => h.textContent?.trim());
+        expect(
+          h2Texts.some((text) => text?.includes(expected)),
+          `expected an H2 containing "${expected}"`,
+        ).toBe(true);
+      });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Spacing rhythm — sections rendered directly
 // ---------------------------------------------------------------------------
 
 /** The canonical three Tailwind classes that encode the unified rhythm. */
 const RHYTHM_CLASSES = ["py-16", "sm:py-20", "lg:py-24"] as const;
 
 /**
- * Assert that an element carries all three rhythm classes.
- * This deliberately checks them together so a partial application (e.g.
- * `py-16` without `sm:py-20`) is caught as an error.
+ * Assert that an element carries all three rhythm classes. This deliberately
+ * checks them together so a partial application (e.g. `py-16` without
+ * `sm:py-20`) is caught as an error.
  */
 function expectSectionSpacing(element: HTMLElement): void {
   for (const cls of RHYTHM_CLASSES) {
-    expect(element.className, `expected section to have class "${cls}"`).toContain(cls);
+    expect(
+      element.className,
+      `expected section to have class "${cls}"`,
+    ).toContain(cls);
   }
 }
-
-// ---------------------------------------------------------------------------
-// BenefitsSection
-// ---------------------------------------------------------------------------
 
 import BenefitsSection from "./benefits";
 
 describe("BenefitsSection — spacing rhythm", () => {
   it("applies the unified py-16 sm:py-20 lg:py-24 scale to the section element", () => {
     render(<BenefitsSection />);
-    // The outermost element rendered by benefits.tsx is a <section>
     const section = document.querySelector("section");
     expect(section).not.toBeNull();
     expectSectionSpacing(section as HTMLElement);
@@ -241,9 +370,9 @@ describe("BenefitsSection — spacing rhythm", () => {
 
   it("has an accessible landmark role (implicit via <section>)", () => {
     render(<BenefitsSection />);
-    // <section> without aria-label is contentinfo/region; with content it
-    // always exists in the DOM — verify we at least render visible headings.
-    expect(screen.getByRole("heading", { name: /benefits/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /benefits/i }),
+    ).toBeInTheDocument();
   });
 
   it("does not use the old asymmetric pt-24 pb-10 classes", () => {
@@ -253,10 +382,6 @@ describe("BenefitsSection — spacing rhythm", () => {
     expect(section.className).not.toContain("pb-10");
   });
 });
-
-// ---------------------------------------------------------------------------
-// HowItWorks
-// ---------------------------------------------------------------------------
 
 import HowItWorks from "./how-it-works";
 
@@ -270,13 +395,7 @@ describe("HowItWorks — spacing rhythm", () => {
 
   it("does not use the unresponsive flat py-20 class", () => {
     render(<HowItWorks />);
-    // Verify the old flat py-20 (without responsive variants) is gone from the
-    // top-level section.  We check the section element specifically because
-    // inner elements may legitimately use py-20 for their own sub-spacing.
     const section = document.querySelector("section") as HTMLElement;
-    // The unified scale uses py-16/sm:py-20/lg:py-24, NOT a bare py-20.
-    // A bare `py-20` at the start of the className string (before a space or
-    // end of string) would indicate the old un-responsive value.
     const firstClasses = section.className.split(" ").filter(Boolean);
     expect(firstClasses).not.toContain("py-20");
   });
@@ -288,10 +407,6 @@ describe("HowItWorks — spacing rhythm", () => {
     ).toBeInTheDocument();
   });
 });
-
-// ---------------------------------------------------------------------------
-// EnterpriseSolutionSection
-// ---------------------------------------------------------------------------
 
 import EnterpriseSolutionSection from "./enterprise-section";
 
@@ -305,8 +420,6 @@ describe("EnterpriseSolutionSection — spacing rhythm", () => {
 
   it("preserves internal card padding (p-10 lg:p-[65px]) independently of section rhythm", () => {
     render(<EnterpriseSolutionSection />);
-    // The inner card div still carries its own padding tokens; spacing
-    // normalization must not strip the card's visual treatment.
     const card = document.querySelector("section > div") as HTMLElement | null;
     expect(card).not.toBeNull();
     expect(card!.className).toContain("p-10");
@@ -316,32 +429,24 @@ describe("EnterpriseSolutionSection — spacing rhythm", () => {
   it("no longer uses the old m-4 margin hack for vertical positioning", () => {
     render(<EnterpriseSolutionSection />);
     const section = document.querySelector("section") as HTMLElement;
-    // Section-level margin was removed; rhythm is now handled by padding.
     expect(section.className).not.toContain("m-4");
   });
 
   it("carries aria-labelledby on the outer section element", () => {
     render(<EnterpriseSolutionSection />);
     const section = document.querySelector("section") as HTMLElement;
-    expect(section).toHaveAttribute("aria-labelledby", "enterprise-solution-title");
+    expect(section).toHaveAttribute(
+      "aria-labelledby",
+      "enterprise-solution-title",
+    );
   });
 });
-
-// ---------------------------------------------------------------------------
-// Hero — typography tokens (pre-existing tests from hero.test.tsx kept in
-// their own file; these complementary assertions verify the hero section
-// does not produce conflicting vertical-rhythm regressions)
-// ---------------------------------------------------------------------------
 
 import Hero from "./hero";
 
 describe("Hero — section structure", () => {
   beforeEach(() => {
-    // IntersectionObserver is not available in jsdom
-    Object.defineProperty(window, "IntersectionObserver", {
-      configurable: true,
-      value: vi.fn(() => ({ observe: vi.fn(), disconnect: vi.fn() })),
-    });
+    stubBrowserApis();
   });
 
   afterEach(() => {
@@ -350,7 +455,6 @@ describe("Hero — section structure", () => {
 
   it("renders a <section> as the outermost landmark", () => {
     render(<Hero />);
-    // Hero uses min-h-screen flex centering — it must still be a landmark.
     const section = document.querySelector("section");
     expect(section).not.toBeNull();
   });
@@ -376,36 +480,12 @@ describe("Hero — section structure", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Stats section — verified via landing-page composition
-// ---------------------------------------------------------------------------
-
 import { ILLUSTRATIVE_STATS } from "@/lib/demo-data";
 import { StatsCards } from "./stats-cards";
 
 describe("StatsCards section wrapper (via landing-page) — spacing rhythm", () => {
   beforeEach(() => {
-    Object.defineProperty(window, "matchMedia", {
-      configurable: true,
-      value: vi.fn().mockReturnValue({ matches: false }),
-    });
-    Object.defineProperty(window, "requestAnimationFrame", {
-      configurable: true,
-      value: vi.fn((cb: FrameRequestCallback) => { cb(0); return 0; }),
-    });
-    Object.defineProperty(window, "cancelAnimationFrame", {
-      configurable: true,
-      value: vi.fn(),
-    });
-    Object.defineProperty(window, "IntersectionObserver", {
-      configurable: true,
-      value: vi.fn(() => ({
-        observe: vi.fn(),
-        disconnect: vi.fn(),
-        unobserve: vi.fn(),
-        takeRecords: vi.fn(),
-      })),
-    });
+    stubBrowserApis();
   });
 
   afterEach(() => {
@@ -414,15 +494,11 @@ describe("StatsCards section wrapper (via landing-page) — spacing rhythm", () 
 
   it("renders all stat cards from ILLUSTRATIVE_STATS", () => {
     render(<StatsCards stats={ILLUSTRATIVE_STATS} />);
-    // At least one stat card value should be visible
     expect(ILLUSTRATIVE_STATS.length).toBeGreaterThan(0);
-    const firstStat = ILLUSTRATIVE_STATS[0];
-    // Label is always rendered as text
-    expect(screen.getByText(firstStat.label)).toBeInTheDocument();
+    expect(screen.getByText(ILLUSTRATIVE_STATS[0].label)).toBeInTheDocument();
   });
 
   it("stats section wrapper uses the unified rhythm classes (py-16 sm:py-20 lg:py-24)", () => {
-    // Render the section wrapper as it appears in landing-page.tsx
     const { container } = render(
       <section className="bg-[#F5F3FF] dark:bg-[#0F0A14] py-16 sm:py-20 lg:py-24 px-4">
         <div className="max-w-6xl mx-auto">
@@ -430,8 +506,7 @@ describe("StatsCards section wrapper (via landing-page) — spacing rhythm", () 
         </div>
       </section>,
     );
-    const section = container.querySelector("section") as HTMLElement;
-    expectSectionSpacing(section);
+    expectSectionSpacing(container.querySelector("section") as HTMLElement);
   });
 
   it("does not use the old py-12 md:py-16 classes on the stats section", () => {
@@ -445,6 +520,5 @@ describe("StatsCards section wrapper (via landing-page) — spacing rhythm", () 
     const section = container.querySelector("section") as HTMLElement;
     expect(section.className).not.toContain("py-12");
     expect(section.className).not.toContain("md:py-16");
-
   });
 });

--- a/components/landing/landing-page.tsx
+++ b/components/landing/landing-page.tsx
@@ -1,24 +1,36 @@
-import { FeaturesIntro } from "@/components/landing/features-intro";
 import Hero from "@/components/landing/hero";
-import Footer from "@/components/common/footer";
-import BenefitsSection from "@/components/landing/benefits";
-import ValuePropositions from "@/components/landing/value-propositions";
-import GetStartedCTA from "@/components/landing/get-started-cta";
-import { StatsCards } from "@/components/landing/stats-cards";
 import Navbar from "@/components/landing/navbar";
 import dynamic from "next/dynamic";
 import Skeleton from "@/components/ui/skeleton";
 import { ILLUSTRATIVE_STATS } from "@/lib/demo-data";
 
+/**
+ * Shared shell for a deferred section's loading fallback.
+ *
+ * Reserves the section's vertical rhythm so swapping the skeleton for real
+ * content does not shift layout, and announces the pending state politely
+ * rather than assertively so it never interrupts a screen reader mid-sentence.
+ */
+export function SectionFallback({
+  label,
+  className,
+  children,
+}: {
+  label: string;
+  className: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={className} aria-busy="true" aria-live="polite" role="status">
+      <span className="sr-only">{label}</span>
+      {children}
+    </div>
+  );
+}
+
 const HowItWorks = dynamic(() => import("@/components/landing/how-it-works"), {
   loading: () => (
-    <div
-      className="w-full py-16 sm:py-20 lg:py-24 bg-white dark:bg-[#0D0D0D]"
-      aria-busy="true"
-      aria-live="polite"
-      role="status"
-    >
-      <span className="sr-only">Loading how it works section...</span>
+    <SectionFallback label="Loading how it works section..." className="w-full py-16 sm:py-20 lg:py-24 bg-white dark:bg-[#0D0D0D]">
       <div className="max-w-6xl mx-auto px-4 space-y-12">
         <div className="flex flex-col items-center space-y-4">
           <Skeleton className="h-6 w-32 rounded-full" shade="dark" />
@@ -30,7 +42,7 @@ const HowItWorks = dynamic(() => import("@/components/landing/how-it-works"), {
           <Skeleton className="h-64 rounded-3xl" shade="dark" />
         </div>
       </div>
-    </div>
+    </SectionFallback>
   ),
   ssr: true,
 });
@@ -39,17 +51,11 @@ const EnterpriseSolutionSection = dynamic(
   () => import("@/components/landing/enterprise-section"),
   {
     loading: () => (
-      <div
-        className="w-full py-16 sm:py-20 lg:py-24 bg-white dark:bg-[#0D0D0D]"
-        aria-busy="true"
-        aria-live="polite"
-        role="status"
-      >
-        <span className="sr-only">Loading enterprise solution...</span>
-        <div className="max-w-[1095px] mx-auto px-4">
+      <SectionFallback label="Loading enterprise solution..." className="w-full py-16 sm:py-20 lg:py-24 bg-white dark:bg-[#0D0D0D]">
+        <div className="max-w-273.75 mx-auto px-4">
           <Skeleton className="h-96 rounded-[48px]" shade="dark" />
         </div>
-      </div>
+      </SectionFallback>
     ),
     ssr: true,
   },
@@ -59,13 +65,7 @@ const TestimonialsSection = dynamic(
   () => import("@/components/landing/testimonials-section"),
   {
     loading: () => (
-      <div
-        className="w-full py-16 sm:py-20 lg:py-24 bg-[#FAFAFA] dark:bg-[#0D0D0D]"
-        aria-busy="true"
-        aria-live="polite"
-        role="status"
-      >
-        <span className="sr-only">Loading testimonials...</span>
+      <SectionFallback label="Loading testimonials..." className="w-full py-16 sm:py-20 lg:py-24 bg-[#FAFAFA] dark:bg-[#0D0D0D]">
         <div className="max-w-6xl mx-auto px-4 space-y-12">
           <div className="flex flex-col items-center space-y-4">
             <Skeleton className="h-6 w-24 rounded-full" shade="dark" />
@@ -77,7 +77,7 @@ const TestimonialsSection = dynamic(
             <Skeleton className="h-56 rounded-2xl" shade="dark" />
           </div>
         </div>
-      </div>
+      </SectionFallback>
     ),
     ssr: true,
   },
@@ -85,13 +85,7 @@ const TestimonialsSection = dynamic(
 
 const FAQSection = dynamic(() => import("@/components/landing/faq-section"), {
   loading: () => (
-    <div
-      className="w-full py-16 sm:py-20 lg:py-24 bg-white dark:bg-[#040404]"
-      aria-busy="true"
-      aria-live="polite"
-      role="status"
-    >
-      <span className="sr-only">Loading frequently asked questions...</span>
+    <SectionFallback label="Loading frequently asked questions..." className="w-full py-16 sm:py-20 lg:py-24 bg-white dark:bg-[#040404]">
       <div className="max-w-4xl mx-auto px-4 space-y-8">
         <div className="flex flex-col items-center space-y-4 mb-12">
           <Skeleton className="h-6 w-16 rounded-full" shade="dark" />
@@ -103,15 +97,144 @@ const FAQSection = dynamic(() => import("@/components/landing/faq-section"), {
           <Skeleton className="h-20 rounded-[20px]" shade="dark" />
         </div>
       </div>
-    </div>
+    </SectionFallback>
+  ),
+  ssr: true,
+});
+
+const StatsCards = dynamic(
+  () => import("@/components/landing/stats-cards").then((m) => m.StatsCards),
+  {
+    loading: () => (
+      <SectionFallback label="Loading statistics..." className="w-full">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          <Skeleton className="h-32 rounded-2xl" shade="dark" />
+          <Skeleton className="h-32 rounded-2xl" shade="dark" />
+          <Skeleton className="h-32 rounded-2xl" shade="dark" />
+          <Skeleton className="h-32 rounded-2xl" shade="dark" />
+        </div>
+      </SectionFallback>
+    ),
+    ssr: true,
+  },
+);
+
+const FeaturesIntro = dynamic(
+  () => import("@/components/landing/features-intro").then((m) => m.FeaturesIntro),
+  {
+    loading: () => (
+      <SectionFallback
+        label="Loading features..."
+        className="w-full py-16 sm:py-20 lg:py-24 bg-white dark:bg-[#0D0D0D]"
+      >
+        <div className="max-w-6xl mx-auto px-4 space-y-12">
+          <div className="flex flex-col items-center space-y-4">
+            <Skeleton className="h-6 w-28 rounded-full" shade="dark" />
+            <Skeleton className="h-10 w-72 rounded-lg" shade="dark" />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+            <Skeleton className="h-56 rounded-3xl" shade="dark" />
+            <Skeleton className="h-56 rounded-3xl" shade="dark" />
+            <Skeleton className="h-56 rounded-3xl" shade="dark" />
+          </div>
+        </div>
+      </SectionFallback>
+    ),
+    ssr: true,
+  },
+);
+
+const ValuePropositions = dynamic(
+  () => import("@/components/landing/value-propositions"),
+  {
+    loading: () => (
+      <SectionFallback
+        label="Loading value propositions..."
+        className="w-full py-16 sm:py-20 lg:py-24 bg-white dark:bg-[#0D0D0D]"
+      >
+        <div className="max-w-6xl mx-auto px-4 space-y-12">
+          <div className="flex flex-col items-center space-y-4">
+            <Skeleton className="h-6 w-24 rounded-full" shade="dark" />
+            <Skeleton className="h-10 w-80 rounded-lg" shade="dark" />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+            <Skeleton className="h-48 rounded-3xl" shade="dark" />
+            <Skeleton className="h-48 rounded-3xl" shade="dark" />
+            <Skeleton className="h-48 rounded-3xl" shade="dark" />
+          </div>
+        </div>
+      </SectionFallback>
+    ),
+    ssr: true,
+  },
+);
+
+const BenefitsSection = dynamic(() => import("@/components/landing/benefits"), {
+  loading: () => (
+    <SectionFallback
+      label="Loading benefits..."
+      className="w-full py-16 sm:py-20 lg:py-24 bg-white dark:bg-[#0D0D0D]"
+    >
+      <div className="max-w-6xl mx-auto px-4 space-y-12">
+        <div className="flex flex-col items-center space-y-4">
+          <Skeleton className="h-6 w-20 rounded-full" shade="dark" />
+          <Skeleton className="h-10 w-72 rounded-lg" shade="dark" />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+          <Skeleton className="h-52 rounded-3xl" shade="dark" />
+          <Skeleton className="h-52 rounded-3xl" shade="dark" />
+          <Skeleton className="h-52 rounded-3xl" shade="dark" />
+        </div>
+      </div>
+    </SectionFallback>
+  ),
+  ssr: true,
+});
+
+const GetStartedCTA = dynamic(
+  () => import("@/components/landing/get-started-cta"),
+  {
+    loading: () => (
+      <SectionFallback
+        label="Loading call to action..."
+        className="w-full py-16 sm:py-20 lg:py-24 bg-white dark:bg-[#0D0D0D]"
+      >
+        <div className="max-w-4xl mx-auto px-4">
+          <Skeleton className="h-64 rounded-4xl" shade="dark" />
+        </div>
+      </SectionFallback>
+    ),
+    ssr: true,
+  },
+);
+
+const Footer = dynamic(() => import("@/components/common/footer"), {
+  loading: () => (
+    <SectionFallback
+      label="Loading footer..."
+      className="w-full py-16 bg-white dark:bg-[#0D0D0D]"
+    >
+      <div className="max-w-6xl mx-auto px-4">
+        <Skeleton className="h-48 rounded-2xl" shade="dark" />
+      </div>
+    </SectionFallback>
   ),
   ssr: true,
 });
 
 /**
  * LandingPage component rendering the StelloPay landing page.
- * Code-splits below-the-fold sections (HowItWorks, EnterpriseSolutionSection, FAQSection)
- * to reduce the initial load bundle size and optimize LCP/TBT metrics.
+ *
+ * Only the two above-the-fold sections — Navbar and Hero — are imported
+ * eagerly. Every section below them is code-split with `next/dynamic` so the
+ * browser does not parse their JS (including the framer-motion trees in
+ * how-it-works and faq-section) before the hero becomes interactive.
+ *
+ * All deferred sections use `ssr: true`, so the server still renders their
+ * markup into the initial HTML. Deferring only the client bundle keeps SEO
+ * crawlability and no-JS rendering intact, and means the skeleton fallbacks
+ * are a hydration-time state rather than a blank first paint.
+ *
  * The statistics are loaded from a centralized demo-data configuration (ILLUSTRATIVE_STATS)
  * and marked as illustrative.
  *

--- a/types/ui.ts
+++ b/types/ui.ts
@@ -29,12 +29,9 @@ export interface FaqCardProps {
   title: string;
   subtitle: string;
   link?: string;
- feat/help-support-search-first
   highlightQuery?: string;
-
   icon?: React.ReactNode;
   articleCount?: number;
- main
 }
 
 export interface SupportTabsProps {


### PR DESCRIPTION
## Description

Closes #781 

`components/landing/landing-page.tsx` eagerly imported every landing section, so the browser parsed all of their JS before the hero became interactive. Only Navbar and Hero are above the fold. Everything below them is now code-split with `next/dynamic`.

## Scope correction

The issue describes `app/page.tsx` importing the sections, but that file only renders `<LandingPage />`. The imports live in `components/landing/landing-page.tsx`, so that is what this PR changes.

The issue also names `how-it-works.tsx`, `stats-cards.tsx` and `faq-section.tsx` as eager. `how-it-works` and `faq-section` were already deferred, along with `testimonials-section` and `enterprise-section`. Of the three named, only `stats-cards` was still eager.

## Changes

Newly deferred: `stats-cards`, `features-intro`, `value-propositions`, `benefits`, `get-started-cta`, `footer`.

Already deferred, refactored onto the shared fallback helper: `how-it-works`, `testimonials-section`, `enterprise-section`, `faq-section`.

Still eager: `Navbar` and `Hero`, so first paint is not delayed.

### On framer-motion specifically

`hero`, `how-it-works` and `faq-section` are the only landing modules importing `framer-motion`. Two of those three were already deferred, so most of the motion-specific win the issue describes was already banked. The remaining gain here is the six non-animated sections coming off the critical path.

### `ssr: true` is deliberate

Every deferred section keeps `ssr: true`. The server still renders their markup into the initial HTML and only the client bundle is split out, so SEO crawlability and no-JS rendering are unchanged and the skeletons are a hydration-time state rather than a blank first paint. Switching these to `ssr: false` would remove the sections from the server-rendered HTML entirely.

### Shared `SectionFallback`

New exported helper so every skeleton announces itself consistently, replacing four hand-rolled copies of the same markup.

## Merge repairs included

Six files were broken on `main`, all unresolved merge conflicts where the markers were deleted but both sides were left in place. Nothing rendered without fixing them:

| File | Breakage |
| --- | --- |
| `landing-page.test.tsx` | Did not parse. Two test files spliced together, with an `import` block landing inside an unclosed `describe`. |
| `hero.tsx` | Two competing `<h1>` elements; duplicated `className` on the subtitle `<p>`. |
| `enterprise-section.tsx` | Two competing `<p>` elements, orphaning the `id="enterprise-solution-desc"` that `aria-describedby` points at. Kept the Stellar-specific copy from dced40f. |
| `types/ui.ts` | Raw branch names left inside `FaqCardProps`. |
| `how-it-works.tsx` | Used `VideoFacade` without importing it. |
| `footer.tsx` | Used `messages` without importing it. |

This takes `tsc --noEmit` from 9 broken files down to 6.

## Accessibility (WCAG 2.1 AA)

`SectionFallback` renders every skeleton with:

- `role="status"` and `aria-live="polite"`, so the pending state is announced without interrupting a screen reader mid-sentence (SC 4.1.3). Polite rather than assertive on purpose: a routine section load is not an alert.
- `aria-busy="true"`, so assistive tech can tell the region is incomplete.
- an `sr-only` label naming the specific section ("Loading testimonials...") rather than a generic "Loading", so the announcement is meaningful out of context (SC 2.4.6).
- the section's own vertical rhythm classes on the fallback wrapper, so swapping the skeleton for real content does not shift layout (SC 2.2.2).

Deferring does not change heading order. The suite asserts the full H1 to H2 to H3 outline with no skipped levels once all sections resolve (SC 1.3.1).

Keyboard navigation is unaffected. Because `ssr: true` keeps deferred sections in the DOM in source order, tab order still matches visual order.

## Responsive

Fallbacks reuse the same `py-16 sm:py-20 lg:py-24` rhythm and the same grid breakpoints as the sections they stand in for, so the skeleton occupies comparable space at sm 640, md 768, lg 1024 and xl 1280. Implemented in code; not visually validated in a browser, for the reason below.

## Testing

```bash
npx vitest run components/landing/landing-page.test.tsx
```

```
Test Files  1 passed (1)
     Tests  35 passed (35)
```

Across all affected suites (`landing-page`, `hero`, `enterprise-section`, `how-it-works`): 55 passed.

`next/dynamic` is mocked to resolve the real module asynchronously, so the suite exercises the actual deferred path and asserts against real components rather than stand-ins. The mock records each importer's source text, which is how the suite verifies a section is deferred and that Hero and Navbar are not.

Coverage added: which sections are deferred (one case per section), that Hero and Navbar stay eager, that deferred sections render once their modules resolve, and the fallback's busy semantics and spacing.

## Not included: TTI measurement

The issue asks for before/after Time to Interactive. I could not produce it, and this is not a gap I can close in this PR.

`next build` fails on pre-existing breakage unrelated to the landing page:

- `components/auth/forgot-password/forgot-password-form.tsx` imports `sendPasswordResetEmail` from `@/lib/api/auth`, which does not export it (and no such function exists anywhere in `lib/`)
- six files still fail `tsc --noEmit`: `app/help/support/page.tsx`, `app/settings/preferences/components/notifications-section.tsx`, `components/common/faq-card.tsx`, `components/dashboard/RechartsMiniBarChart.tsx`, `components/dashboard/summary-data.tsx`, `components/transactions/transactions-content.tsx`

No successful build means no bundle numbers and no Lighthouse run. These are source-level faults, not stale build artifacts. Once the build is green, TTI and bundle deltas should be captured against this branch.

Also pre-existing and unchanged by this PR: `components/landing/benefits.test.tsx` fails 4 tests and `components/landing/video-facade.test.tsx` does not parse. Both fail identically on a clean `main` checkout.

## Checklist

- [x] Tests added and passing (35 landing, 55 across affected suites)
- [x] Documentation updated (README.md)
- [x] Accessibility annotated (ARIA, live-region politeness, heading order, keyboard order)
- [x] Responsive behaviour implemented across breakpoints
- [x] Conventional commit message
- [x] No secrets or real PII in examples
- [ ] TTI measured (blocked by pre-existing build failure, see above)