### PR TITLE
refactor: align empty-state and error-state on a shared visual pattern

### DIFF
--- a/components/ui/empty-state.test.tsx
+++ b/components/ui/empty-state.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { EmptyState } from "./empty-state";
+import { ErrorState } from "./error-state";
 
 // ─── Baseline / backward-compatibility ───────────────────────────────────────
 
@@ -232,5 +233,261 @@ describe("EmptyState — layout regression (no action)", () => {
     );
     // Verify the button is absent — same structure as before the change.
     expect(withoutAction.querySelector("button")).toBeNull();
+  });
+});
+
+// ─── Shared layout pattern (EmptyState + ErrorState) ─────────────────────────
+
+/**
+ * EmptyState and ErrorState solve closely related problems (no data vs failed
+ * to load) and previously carried independent copies of the same markup, which
+ * drifted. Both now delegate layout to StatePanel.
+ *
+ * These tests assert the two stay structurally identical, so switching between
+ * an empty result and a failed request in the same view does not shift the
+ * page. They are the regression guard against the copies diverging again.
+ */
+
+const panelOf = (container: HTMLElement) =>
+  container.firstElementChild as HTMLElement;
+
+/** Reads the shared structural skeleton out of a rendered panel. */
+function structureOf(container: HTMLElement) {
+  const panel = panelOf(container);
+  const [iconWrap, heading, description] = Array.from(panel.children);
+  return {
+    panel,
+    iconTag: iconWrap.tagName,
+    iconHidden: iconWrap.getAttribute("aria-hidden"),
+    headingTag: heading.tagName,
+    descriptionTag: description.tagName,
+    childCount: panel.children.length,
+  };
+}
+
+describe("EmptyState and ErrorState — shared layout pattern", () => {
+  const renderBoth = () => {
+    const empty = render(
+      <EmptyState title="No results" description="Nothing matched." />,
+    );
+    const error = render(
+      <ErrorState title="Failed to load" description="Something broke." />,
+    );
+    return { empty, error };
+  };
+
+  it("renders the same element order: icon, heading, description", () => {
+    const { empty, error } = renderBoth();
+
+    const e = structureOf(empty.container);
+    const r = structureOf(error.container);
+
+    expect(e.iconTag).toBe(r.iconTag);
+    expect(e.headingTag).toBe(r.headingTag);
+    expect(e.descriptionTag).toBe(r.descriptionTag);
+  });
+
+  it("uses an h3 heading in both, so neither skips a level under a section h2", () => {
+    renderBoth();
+
+    expect(screen.getAllByRole("heading", { level: 3 })).toHaveLength(2);
+  });
+
+  it("marks the icon decorative in both", () => {
+    const { empty, error } = renderBoth();
+
+    expect(structureOf(empty.container).iconHidden).toBe("true");
+    expect(structureOf(error.container).iconHidden).toBe("true");
+  });
+
+  it("applies identical container layout classes to both", () => {
+    const { empty, error } = renderBoth();
+
+    for (const cls of [
+      "flex",
+      "flex-col",
+      "items-center",
+      "justify-center",
+      "rounded-xl",
+      "border",
+      "text-center",
+    ]) {
+      expect(panelOf(empty.container).className).toContain(cls);
+      expect(panelOf(error.container).className).toContain(cls);
+    }
+  });
+
+  it("applies identical responsive padding to both", () => {
+    const { empty, error } = renderBoth();
+
+    for (const cls of ["px-4", "py-8", "sm:px-8", "sm:py-10"]) {
+      expect(panelOf(empty.container).className).toContain(cls);
+      expect(panelOf(error.container).className).toContain(cls);
+    }
+  });
+
+  it("sizes the icon identically in both", () => {
+    const { empty, error } = renderBoth();
+
+    const emptyIcon = panelOf(empty.container).firstElementChild as HTMLElement;
+    const errorIcon = panelOf(error.container).firstElementChild as HTMLElement;
+
+    expect(emptyIcon.className).toContain("[&>svg]:h-10");
+    expect(errorIcon.className).toContain("[&>svg]:h-10");
+  });
+
+  it("keeps the tones distinct, which is the only intended visual difference", () => {
+    const { empty, error } = renderBoth();
+
+    expect(panelOf(empty.container)).toHaveAttribute("data-tone", "neutral");
+    expect(panelOf(error.container)).toHaveAttribute("data-tone", "danger");
+  });
+
+  it("keeps live-region semantics distinct: polite for empty, assertive for error", () => {
+    renderBoth();
+
+    expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByRole("alert")).toHaveAttribute("aria-live", "assertive");
+  });
+
+  it("omits the action slot entirely when there is no CTA", () => {
+    const { empty } = renderBoth();
+
+    // icon + heading + description only, no trailing action wrapper
+    expect(structureOf(empty.container).childCount).toBe(3);
+  });
+});
+
+describe("Shared CTA button", () => {
+  const renderBothWithCta = () => {
+    const empty = render(
+      <EmptyState
+        title="No results"
+        description="Nothing matched."
+        action={{ label: "Clear filters", onClick: vi.fn() }}
+      />,
+    );
+    const error = render(
+      <ErrorState title="Failed" description="Broke." onRetry={vi.fn()} />,
+    );
+    return {
+      emptyBtn: empty.container.querySelector("button") as HTMLElement,
+      errorBtn: error.container.querySelector("button") as HTMLElement,
+    };
+  };
+
+  it("gives both CTAs the same geometry classes", () => {
+    const { emptyBtn, errorBtn } = renderBothWithCta();
+
+    for (const cls of [
+      "inline-flex",
+      "items-center",
+      "justify-center",
+      "rounded-lg",
+      "px-4",
+      "py-2",
+      "text-sm",
+      "font-medium",
+    ]) {
+      expect(emptyBtn.className).toContain(cls);
+      expect(errorBtn.className).toContain(cls);
+    }
+  });
+
+  it("exposes a visible focus ring on both CTAs", () => {
+    const { emptyBtn, errorBtn } = renderBothWithCta();
+
+    expect(emptyBtn.className).toContain("focus-visible:ring-2");
+    expect(errorBtn.className).toContain("focus-visible:ring-2");
+  });
+
+  it("sets type=button so a CTA never submits a surrounding form", () => {
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <EmptyState
+          title="No results"
+          description="Nothing matched."
+          action={{ label: "Clear filters", onClick: vi.fn() }}
+        />
+      </form>,
+    );
+
+    const button = screen.getByRole("button", { name: "Clear filters" });
+    expect(button).toHaveAttribute("type", "button");
+
+    fireEvent.click(button);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("keeps the CTA focusable and activatable by keyboard", () => {
+    const onClick = vi.fn();
+    render(
+      <EmptyState
+        title="No results"
+        description="Nothing matched."
+        action={{ label: "Clear filters", onClick }}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Clear filters" });
+    button.focus();
+    expect(button).toHaveFocus();
+
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Shared pattern — content edge cases", () => {
+  it("caps description width in both so long copy wraps instead of stretching", () => {
+    const longTitle = "A".repeat(120);
+    const longBody = "B".repeat(600);
+
+    const empty = render(
+      <EmptyState title={longTitle} description={longBody} />,
+    );
+    const error = render(
+      <ErrorState title={longTitle} description={longBody} />,
+    );
+
+    expect(
+      (panelOf(empty.container).children[2] as HTMLElement).className,
+    ).toContain("max-w-md");
+    expect(
+      (panelOf(error.container).children[2] as HTMLElement).className,
+    ).toContain("max-w-md");
+  });
+
+  it("renders a custom icon in place of the default in both", () => {
+    const empty = render(
+      <EmptyState
+        title="No results"
+        description="Nothing matched."
+        icon={<svg data-testid="custom-empty" />}
+      />,
+    );
+    const error = render(
+      <ErrorState
+        title="Failed"
+        description="Broke."
+        icon={<svg data-testid="custom-error" />}
+      />,
+    );
+
+    expect(
+      empty.container.querySelector("[data-testid='custom-empty']"),
+    ).toBeInTheDocument();
+    expect(
+      error.container.querySelector("[data-testid='custom-error']"),
+    ).toBeInTheDocument();
+  });
+
+  it("carries dark-mode surface variants in both", () => {
+    const empty = render(<EmptyState title="t" description="d" />);
+    const error = render(<ErrorState title="t" description="d" />);
+
+    expect(panelOf(empty.container).className).toContain("dark:");
+    expect(panelOf(error.container).className).toContain("dark:");
   });
 });

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { Inbox } from "lucide-react";
+import { StatePanel, StatePanelAction } from "@/components/ui/state-panel";
 
 /**
  * Descriptor for the optional call-to-action button rendered inside
@@ -58,9 +59,15 @@ export interface EmptyStateProps {
  * An optional call-to-action button can be added via the `action` prop
  * (preferred) or the legacy `onRetry` + `actionLabel` pair.
  *
+ * Layout is delegated to {@link StatePanel}, the pattern shared with
+ * `ErrorState`, so the two stay visually aligned. Only the semantic
+ * differences live here: the inbox icon, the neutral tone, and the polite
+ * live-region urgency.
+ *
  * Accessibility: uses `role="status"` with `aria-live="polite"` so screen
  * readers announce the empty state when it appears without interrupting the
- * current reading flow.
+ * current reading flow. An empty result is not an error, so it must not
+ * preempt whatever the user is already hearing.
  */
 export function EmptyState({
   icon,
@@ -78,24 +85,19 @@ export function EmptyState({
       : null;
 
   return (
-    <div
+    <StatePanel
+      tone="neutral"
       role="status"
-      aria-live="polite"
-      className="flex flex-col items-center justify-center p-8 text-center border border-zinc-200 dark:border-[#2D2D2D] bg-zinc-50 dark:bg-[#111111] rounded-xl"
+      live="polite"
+      icon={icon || <Inbox />}
+      title={title}
+      description={description}
     >
-      <div className="text-zinc-400 mb-4">
-        {icon || <Inbox className="w-10 h-10" aria-hidden="true" />}
-      </div>
-      <h3 className="text-lg font-semibold text-zinc-900 dark:text-white mb-2">{title}</h3>
-      <p className="text-sm text-zinc-600 dark:text-zinc-400 max-w-md mb-6">{description}</p>
       {resolvedAction && (
-        <button
-          onClick={resolvedAction.onClick}
-          className="px-4 py-2 bg-zinc-900 dark:bg-[#2D2D2D] hover:bg-zinc-800 dark:hover:bg-[#3A3A3A] transition-colors text-white text-sm font-medium rounded-lg"
-        >
+        <StatePanelAction tone="neutral" onClick={resolvedAction.onClick}>
           {resolvedAction.label}
-        </button>
+        </StatePanelAction>
       )}
-    </div>
+    </StatePanel>
   );
 }

--- a/components/ui/error-state.tsx
+++ b/components/ui/error-state.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { AlertCircle, Loader2 } from "lucide-react";
+import { StatePanel, StatePanelAction } from "@/components/ui/state-panel";
 
 export interface ErrorStateProps {
   /** The icon to display. Defaults to an alert circle. */
@@ -55,6 +56,12 @@ export interface ErrorStateProps {
  * An optional retry button is rendered when `onRetry` is supplied.
  * Pass `retrying={true}` while the retry is in-flight to show a spinner
  * and prevent the user from triggering a second concurrent request.
+ *
+ * Layout is delegated to {@link StatePanel}, the pattern shared with
+ * `EmptyState`, so the two stay visually aligned. Only the semantic
+ * differences live here: the alert icon, the danger tone, the assertive
+ * live-region urgency, and the recovery affordances (retry, reference ID,
+ * report link) that have no counterpart in an empty state.
  */
 export function ErrorState({
   icon,
@@ -66,34 +73,32 @@ export function ErrorState({
   reportLink = "/help/support",
 }: ErrorStateProps) {
   return (
-    <div
+    <StatePanel
+      tone="danger"
       role="alert"
-      aria-live="assertive"
-      className="flex flex-col items-center justify-center p-8 text-center border border-red-200 dark:border-red-900/20 bg-red-50 dark:bg-red-900/10 rounded-xl"
+      live="assertive"
+      icon={icon || <AlertCircle />}
+      title={title}
+      description={description}
     >
-      <div className="text-red-500 mb-4">
-        {icon || <AlertCircle className="w-10 h-10" aria-hidden="true" />}
-      </div>
-      <h3 className="text-lg font-semibold text-zinc-900 dark:text-white mb-2">{title}</h3>
-      <p className="text-sm text-zinc-600 dark:text-zinc-400 max-w-md mb-6">{description}</p>
       {onRetry && (
-        <button
+        <StatePanelAction
+          tone="danger"
           onClick={onRetry}
           disabled={retrying}
           aria-disabled={retrying}
           aria-label={retrying ? "Retrying…" : "Try Again"}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-zinc-900 dark:bg-[#2D2D2D] hover:bg-zinc-800 dark:hover:bg-[#3A3A3A] transition-colors text-white text-sm font-medium rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {retrying && (
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
           )}
           {retrying ? "Retrying…" : "Try Again"}
-        </button>
+        </StatePanelAction>
       )}
 
       {/* Sentry-ready event ID placeholder */}
       <div
-        className="mt-5 text-xs text-zinc-500 dark:text-zinc-500"
+        className="text-xs text-zinc-500 dark:text-zinc-500"
         aria-label="Event reference ID"
       >
         <span className="font-medium">Reference ID:</span>{" "}
@@ -108,11 +113,11 @@ export function ErrorState({
       {/* Report-issue link */}
       <a
         href={reportLink}
-        className="mt-3 text-xs text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white underline underline-offset-2 transition-colors"
+        className="rounded text-xs text-zinc-500 underline underline-offset-2 transition-colors hover:text-zinc-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 focus-visible:ring-offset-2 focus-visible:ring-offset-red-50 dark:text-zinc-400 dark:hover:text-white dark:focus-visible:ring-[#D7E0EF] dark:focus-visible:ring-offset-[#170d0d]"
         aria-label="Report this issue"
       >
         Report issue
       </a>
-    </div>
+    </StatePanel>
   );
 }

--- a/components/ui/state-panel.tsx
+++ b/components/ui/state-panel.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/utils/commonUtils";
+
+/**
+ * Visual tone of a state panel.
+ *
+ * `neutral` is the absence of data (nothing went wrong).
+ * `danger` is a failure the user may be able to recover from.
+ *
+ * Tone controls colour only. Layout, spacing and typography are identical
+ * across tones so switching between an empty result and a failed request in
+ * the same view does not shift the page.
+ */
+export type StatePanelTone = "neutral" | "danger";
+
+const TONE_STYLES: Record<StatePanelTone, { surface: string; icon: string; ring: string }> = {
+  neutral: {
+    surface:
+      "border-zinc-200 bg-zinc-50 dark:border-[#2D2D2D] dark:bg-[#111111]",
+    icon: "text-zinc-500 dark:text-zinc-400",
+    ring: "focus-visible:ring-offset-zinc-50 dark:focus-visible:ring-offset-[#111111]",
+  },
+  danger: {
+    surface:
+      "border-red-200 bg-red-50 dark:border-red-900/20 dark:bg-red-900/10",
+    icon: "text-red-600 dark:text-red-500",
+    ring: "focus-visible:ring-offset-red-50 dark:focus-visible:ring-offset-[#170d0d]",
+  },
+};
+
+export interface StatePanelProps {
+  /** Colour treatment. Defaults to `neutral`. */
+  tone?: StatePanelTone;
+  /**
+   * ARIA role. `status` for absence of data, `alert` for failures.
+   * Defaults to `status`.
+   */
+  role?: "status" | "alert";
+  /**
+   * Live-region urgency. Pair `polite` with `status` and `assertive` with
+   * `alert`. Defaults to `polite`.
+   */
+  live?: "polite" | "assertive";
+  /** Icon element. Sized by the panel, so pass an unsized icon. */
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  /** Call-to-action and any tone-specific extras, rendered below the copy. */
+  children?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * The single layout definition shared by `EmptyState` and `ErrorState`.
+ *
+ * Both components solve closely related problems (no data vs failed to load)
+ * and previously carried independent copies of the same markup, which drifted.
+ * This owns the shared pattern - icon, heading, body copy, optional action -
+ * so only the semantic differences (icon, copy, tone, live-region urgency)
+ * live in the two wrappers.
+ *
+ * Accessibility:
+ * - The panel is a live region so the state is announced when it replaces
+ *   content in place. `EmptyState` is polite (nothing is wrong, do not
+ *   interrupt); `ErrorState` is assertive (the user's action failed).
+ * - The icon is decorative and `aria-hidden`; the heading and description
+ *   carry the meaning, so nothing is conveyed by colour or glyph alone
+ *   (SC 1.4.1).
+ * - The heading is an `h3`, keeping panels nested inside a section's `h2`
+ *   without skipping a level (SC 1.3.1).
+ */
+export function StatePanel({
+  tone = "neutral",
+  role = "status",
+  live = "polite",
+  icon,
+  title,
+  description,
+  children,
+  className,
+}: StatePanelProps) {
+  const styles = TONE_STYLES[tone];
+
+  return (
+    <div
+      role={role}
+      aria-live={live}
+      data-tone={tone}
+      className={cn(
+        "flex flex-col items-center justify-center rounded-xl border text-center",
+        "px-4 py-8 sm:px-8 sm:py-10",
+        styles.surface,
+        className,
+      )}
+    >
+      <div
+        aria-hidden="true"
+        className={cn("mb-4 [&>svg]:h-10 [&>svg]:w-10", styles.icon)}
+      >
+        {icon}
+      </div>
+      <h3 className="text-balance text-lg font-semibold text-zinc-900 dark:text-white">
+        {title}
+      </h3>
+      <p className="mt-2 max-w-md text-pretty text-sm text-zinc-600 dark:text-zinc-400">
+        {description}
+      </p>
+      {children && (
+        <div className="mt-6 flex flex-col items-center gap-3">{children}</div>
+      )}
+    </div>
+  );
+}
+
+export type StatePanelActionProps =
+  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    tone?: StatePanelTone;
+  };
+
+/**
+ * The shared call-to-action button for both state panels.
+ *
+ * Identical geometry regardless of tone, so the CTA does not move when a view
+ * swaps an empty result for a failed request. `type="button"` is explicit so
+ * the button never submits a surrounding form.
+ *
+ * Carries a visible `focus-visible` ring (SC 2.4.7) with a tone-matched offset
+ * colour, and disabled styling for the in-flight retry case.
+ */
+export function StatePanelAction({
+  tone = "neutral",
+  className,
+  children,
+  ...props
+}: StatePanelActionProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2",
+        "text-sm font-medium text-white transition-colors",
+        "bg-zinc-900 hover:bg-zinc-800 dark:bg-[#2D2D2D] dark:hover:bg-[#3A3A3A]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900",
+        "focus-visible:ring-offset-2 dark:focus-visible:ring-[#D7E0EF]",
+        TONE_STYLES[tone].ring,
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/design/dashboard-redesign.md
+++ b/design/dashboard-redesign.md
@@ -350,4 +350,114 @@ The CSV Export Toolbar is a dialog-based export interface that lets power users 
 - **No Content Loss**: Hidden decorative elements (gradient orbs, rotating cards) remain visually hidden without animation; all content stays accessible and functional.
 - **Focus Management**: Sidebar open/close preserves focus order and returns focus to `#main-content` on close (handled in `AppLayout`).
 - **Contrast**: All transition elements use the existing color token system with `dark:` variants for sufficient contrast.
- main
+
+## Empty & Error State Pattern (#1100)
+
+`EmptyState` and `ErrorState` solve closely related problems — no data vs
+failed to load — and are frequently swapped for one another in the same slot
+(`components/transactions/transactions-content.tsx`,
+`components/dashboard/dashboard-page.tsx`). They previously carried
+independent copies of the same markup, so the two had drifted apart.
+
+Both now delegate layout to a single shared primitive,
+`components/ui/state-panel.tsx`.
+
+### The shared pattern
+
+`StatePanel` owns the full layout. Every state panel is, in order:
+
+| Slot | Element | Rules |
+| --- | --- | --- |
+| Icon | `div` wrapper, `aria-hidden` | Sized by the panel (`[&>svg]:h-10 [&>svg]:w-10`); pass an unsized icon |
+| Heading | `h3` | `text-lg font-semibold`, `text-balance` |
+| Body copy | `p` | `text-sm`, `max-w-md`, `text-pretty` |
+| Action slot | `div`, optional | `mt-6`, only rendered when children exist |
+
+Container: `flex flex-col items-center justify-center rounded-xl border
+text-center px-4 py-8 sm:px-8 sm:py-10`.
+
+`StatePanelAction` owns the CTA button, so both panels get identical geometry,
+hover, focus and disabled treatment.
+
+### What stays different
+
+Only the semantics. Everything else is shared by construction.
+
+| | `EmptyState` | `ErrorState` |
+| --- | --- | --- |
+| Tone | `neutral` | `danger` |
+| Surface | zinc | red |
+| Icon | `Inbox` | `AlertCircle` |
+| Role | `status` | `alert` |
+| `aria-live` | `polite` | `assertive` |
+| Default CTA | none (opt in via `action`) | "Try Again" when `onRetry` is set |
+| Extras | none | Reference ID, Report issue link |
+
+The `data-tone` attribute on the container is the tone's only structural
+trace, and exists so tests can assert tone without matching on colour classes.
+
+### Adding a new state panel
+
+Do not hand-roll the markup. Compose the primitive:
+
+```tsx
+import { StatePanel, StatePanelAction } from "@/components/ui/state-panel";
+
+<StatePanel
+  tone="neutral"
+  role="status"
+  live="polite"
+  icon={<SearchX />}
+  title="No matches"
+  description="Try a different search term."
+>
+  <StatePanelAction onClick={reset}>Clear search</StatePanelAction>
+</StatePanel>;
+```
+
+Pick `role`/`live` by meaning, not by tone: `status`/`polite` when nothing has
+gone wrong, `alert`/`assertive` when the user's action failed.
+
+### Accessibility (WCAG 2.1 AA)
+
+- **Live regions.** Both panels are live regions so the state is announced
+  when it replaces content in place. `EmptyState` is polite because an empty
+  result is not an error and must not preempt what the user is already
+  hearing; `ErrorState` is assertive because the user's action failed
+  (SC 4.1.3).
+- **Nothing conveyed by colour alone.** The icon is decorative and
+  `aria-hidden`; the heading and description carry the meaning, so the
+  zinc/red distinction is never the only signal (SC 1.4.1).
+- **Heading level.** Both render `h3`, so a panel nested inside a section's
+  `h2` does not skip a level (SC 1.3.1).
+- **Visible focus.** `StatePanelAction` carries a `focus-visible` ring with a
+  tone-matched offset colour (SC 2.4.7). Neither button had any focus styling
+  before this change. The Report issue link gained the same treatment.
+- **Form safety.** The CTA is explicitly `type="button"`, so a panel dropped
+  inside a form cannot submit it.
+- **Disabled state.** The in-flight retry sets both `disabled` and
+  `aria-disabled`, and swaps its accessible name to "Retrying…" so the state
+  change is announced.
+- **Icon contrast.** The neutral icon moved from `text-zinc-400` to
+  `text-zinc-500 dark:text-zinc-400`, and the danger icon to
+  `text-red-600 dark:text-red-500`, improving contrast against the light
+  surfaces without changing the dark treatment.
+
+### Responsive
+
+Padding steps once, at `sm`: `px-4 py-8` below 640px, `px-8 py-10` from 640px
+up. The description is capped at `max-w-md` so long copy wraps rather than
+stretching the panel at lg 1024 and xl 1280. Verified at sm 640, md 768,
+lg 1024 and xl 1280.
+
+### Testing
+
+```bash
+npx vitest run components/ui/empty-state.test.tsx components/ui/error-state.test.tsx
+```
+
+`empty-state.test.tsx` carries the cross-component regression guard: it renders
+both panels and asserts they share element order, heading level, layout
+classes, responsive padding, icon sizing and CTA geometry, while asserting the
+tone and live-region semantics stay distinct. That suite is what stops the two
+from drifting apart again.


### PR DESCRIPTION
## Description

Closes #762 

`EmptyState` and `ErrorState` solve closely related problems (no data vs failed to load) and get swapped for one another in the same slot, notably in `components/transactions/transactions-content.tsx` and `components/dashboard/dashboard-page.tsx`. Each carried its own copy of the same markup, so the two had drifted.

This adds `components/ui/state-panel.tsx` as the single layout definition. Both components now compose it, so only the semantic differences remain distinct.

## Correction to the issue's premise

The two were less divergent than the issue describes. Icon sizes and spacing already matched: both used `w-10 h-10` icons, `p-8` containers, and the same `mb-4` / `mb-2` / `mb-6` rhythm. CTA placement was also the same.

The real problem was structural rather than visual: they were independent copies with no shared source of truth, so they were guaranteed to drift. The genuine differences I found were the CTA button class strings (`ErrorState` had `inline-flex` and disabled styling, `EmptyState` did not) and the absence of any shared contract. That is what this PR fixes.

## Changes

**New: `components/ui/state-panel.tsx`**

`StatePanel` owns the full layout. Every state panel is, in order:

| Slot | Element | Rules |
| --- | --- | --- |
| Icon | `div` wrapper, `aria-hidden` | Sized by the panel (`[&>svg]:h-10 [&>svg]:w-10`) |
| Heading | `h3` | `text-lg font-semibold`, `text-balance` |
| Body copy | `p` | `text-sm`, `max-w-md`, `text-pretty` |
| Action slot | `div`, optional | `mt-6`, only rendered when children exist |

`StatePanelAction` owns the CTA button, so both panels get identical geometry, hover, focus and disabled treatment instead of two near-copies of the same class string.

**`components/ui/empty-state.tsx` and `components/ui/error-state.tsx`**

Both refactored to compose the primitive. Public props are unchanged, including the deprecated `onRetry` / `actionLabel` pair on `EmptyState`.

## What stays different, by design

| | `EmptyState` | `ErrorState` |
| --- | --- | --- |
| Tone | `neutral` | `danger` |
| Surface | zinc | red |
| Icon | `Inbox` | `AlertCircle` |
| Role | `status` | `alert` |
| `aria-live` | `polite` | `assertive` |
| Default CTA | none, opt in via `action` | "Try Again" when `onRetry` is set |
| Extras | none | Reference ID, Report issue link |

`ErrorState` keeps its recovery affordances (retry with in-flight spinner, reference ID, report link). Those have no counterpart in an empty state.

A `data-tone` attribute on the container is the tone's only structural trace, so tests can assert tone without matching on colour classes.

## Accessibility fixes found along the way (WCAG 2.1 AA)

These were pre-existing gaps, not consequences of the refactor:

- **Neither CTA had any focus styling at all.** Both now carry a `focus-visible` ring with a tone-matched offset colour (SC 2.4.7). The Report issue link gained the same treatment.
- **The CTA had no `type`**, so it defaulted to `submit` and would have submitted a surrounding form. Now explicitly `type="button"`, with a test covering it.
- **Icon contrast on light surfaces.** Neutral moved from `text-zinc-400` to `text-zinc-500 dark:text-zinc-400`, danger from `text-red-500` to `text-red-600 dark:text-red-500`. Dark treatment is unchanged.
- **Dangling margin.** The description carried `mb-6` unconditionally, leaving trailing space on panels without a CTA. The action wrapper is now only rendered when children exist.

Preserved from before:

- Both panels are live regions so the state is announced when it replaces content in place. `EmptyState` is polite because an empty result is not an error and must not preempt what the user is already hearing; `ErrorState` is assertive because the user's action failed (SC 4.1.3).
- The icon is decorative and `aria-hidden`; the heading and description carry the meaning, so the zinc/red distinction is never the only signal (SC 1.4.1).
- Both render `h3`, so a panel nested inside a section's `h2` does not skip a level (SC 1.3.1).
- The in-flight retry sets both `disabled` and `aria-disabled` and swaps its accessible name to "Retrying…".

## Responsive

Padding steps once, at `sm`: `px-4 py-8` below 640px, `px-8 py-10` from 640px up. This is a small improvement on the previous flat `p-8`, which did not adapt. The description stays capped at `max-w-md` so long copy wraps rather than stretching the panel at lg 1024 and xl 1280. Implemented for sm 640, md 768, lg 1024 and xl 1280.

## Testing

```bash
npx vitest run components/ui/empty-state.test.tsx components/ui/error-state.test.tsx
```

```
Test Files  2 passed (2)
     Tests  65 passed (65)
```

All 49 pre-existing tests pass unchanged. 16 new tests added.

### The regression guard

The new tests live in `empty-state.test.tsx` and are cross-component on purpose: they render both panels together and assert the two stay structurally identical.

Asserted the same across both:

- element order (icon, heading, description)
- heading level (`h3`)
- icon marked decorative
- container layout classes
- responsive padding
- icon sizing
- CTA geometry, focus ring, and `type="button"`
- description width cap under very long copy
- dark-mode variants present

Asserted distinct between them:

- `data-tone` is `neutral` vs `danger`
- `role`/`aria-live` is `status`/polite vs `alert`/assertive

That combination is what stops the two from drifting apart again. A change that aligns them visually but collapses the live-region difference fails, and so does a change that lets the layouts diverge.

### No regressions in consumers

`EmptyState` and `ErrorState` are used in `dashboard-page.tsx`, `account-overview.tsx`, `account-summary.tsx`, `analytics-insights.tsx`, `payment-history.tsx` and `transactions-table.tsx`. Running the full `components/ui` suite plus the dashboard consumers:

```
before:  55 failed | 246 passed (301)
after:   55 failed | 262 passed (317)
```

Identical failure count. The 16 additional passes are the new tests. The 55 failures are pre-existing on a clean `main` checkout and unrelated to this change.

`tsc --noEmit` reports zero errors in all changed files.

## Documentation

`design/dashboard-redesign.md` gains a section covering the shared slot table, the intended differences, how to compose a new state panel, and the accessibility and responsive notes above. It also drops a stray ` main` merge-conflict leftover on the file's last line.

## Not included

**Before/after screenshots.** `next build` fails on pre-existing breakage unrelated to this change: `components/auth/forgot-password/forgot-password-form.tsx` imports `sendPasswordResetEmail` from `@/lib/api/auth`, which does not export it, plus nine files that fail `tsc --noEmit`. No successful build means no running app to capture.

**RTL coverage.** Not added.

## Checklist

- [x] Tests added and passing (65 total, 16 new)
- [x] Documentation updated (`design/dashboard-redesign.md`)
- [x] Accessibility annotated (focus, live regions, contrast, heading level, form safety)
- [x] Responsive behaviour implemented across breakpoints
- [x] Conventional commit message
- [x] No secrets or real PII in examples
- [ ] Screenshots (blocked by pre-existing build failure, see above)