### PR TITLE
feat: add watchlist panel for pinned counterparties and assets

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,7 @@ import localFont from "next/font/local";
 import "./globals.css";
 import { SidebarProvider } from "@/context/sidebar-context";
 import { ThemeProvider } from "@/context/theme-context";
-import { WalletProvider } from "@/context/wallet-context";
+import { WalletProvider, WatchlistProvider } from "@/context/wallet-context";
 import { OfflineBanner } from "@/components/common/offline-banner";
 import { CookieConsentBanner } from "@/components/common/cookie-consent-banner";
 import { Toaster } from "@/components/ui/toaster";
@@ -186,7 +186,9 @@ export default function RootLayout({
         <CookieConsentBanner />
         <ThemeProvider>
           <WalletProvider>
-            <SidebarProvider>{children}</SidebarProvider>
+            <WatchlistProvider>
+              <SidebarProvider>{children}</SidebarProvider>
+            </WatchlistProvider>
           </WalletProvider>
           <Toaster />
         </ThemeProvider>

--- a/components/dashboard/dashboard-page.tsx
+++ b/components/dashboard/dashboard-page.tsx
@@ -14,6 +14,7 @@ import DashboardNavbar from "@/components/dashboard/dashboard-navbar";
 import AccountOverview from "@/components/dashboard/account-overview";
 import { QuickActions } from "@/components/dashboard/quick-actions";
 import QuickTransfer from "@/components/dashboard/quick-transfer";
+import { WatchlistPanel } from "@/components/dashboard/watchlist-panel";
 import dynamic from "next/dynamic";
 import Skeleton from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -821,6 +822,8 @@ export default function Dashboard() {
         <div ref={analyticsInsightsRef}>
           <AnalyticsInsights />
         </div>
+
+        <WatchlistPanel />
 
         <div ref={clientAnalyticsRef}>
           <ClientAnalyticsView

--- a/components/dashboard/watchlist-panel.test.tsx
+++ b/components/dashboard/watchlist-panel.test.tsx
@@ -1,0 +1,811 @@
+/**
+ * Tests for WatchlistPanel and the WatchlistProvider/useWatchlist integration.
+ *
+ * Coverage goals
+ * ──────────────
+ * - Render: panel mounts, heading, empty-state, loading skeleton
+ * - Add item: form open/close, validation, successful pin, duplicate guard
+ * - Remove item: unpin button removes the card
+ * - Search: filters by address, label, token; clear button
+ * - Persistence: localStorage read/write per account address
+ * - Accessibility: aria attributes, keyboard reachability, role landmarks
+ * - Dark-mode / design tokens: spot-checked via class assertions
+ */
+
+import React from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { WatchlistPanel } from "@/components/dashboard/watchlist-panel";
+import {
+  WalletProvider,
+  WatchlistProvider,
+  useWatchlist,
+} from "@/context/wallet-context";
+import type { WatchlistItem } from "@/types/watchlist";
+
+// ─── Shared test address ──────────────────────────────────────────────────────
+
+const WALLET_ADDRESS =
+  "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPF123";
+
+const SECOND_WALLET =
+  "GZYXWVUTSRQPONMLKJIHGFEDCBA7654321ZYXWVUTSRQPONMF456";
+
+// ─── Helper: full provider tree ───────────────────────────────────────────────
+
+function renderWithProviders(
+  ui: React.ReactNode,
+  { address = WALLET_ADDRESS }: { address?: string | null } = {},
+) {
+  return render(
+    <WalletProvider initialAddress={address}>
+      <WatchlistProvider>{ui}</WatchlistProvider>
+    </WalletProvider>,
+  );
+}
+
+// ─── Helper: pre-seed localStorage watchlist for an address ──────────────────
+
+function seedStorage(address: string, items: WatchlistItem[]) {
+  window.localStorage.setItem(
+    `stellopay.watchlist.${address}`,
+    JSON.stringify(items),
+  );
+}
+
+function makeItem(overrides: Partial<WatchlistItem> = {}): WatchlistItem {
+  return {
+    id: "test-id-1",
+    address: "0xA1B2...C3D4E5",
+    pinnedAt: "2023-04-12T09:32:00Z",
+    ...overrides,
+  };
+}
+
+// ─── 1. Render & structure ────────────────────────────────────────────────────
+
+describe("WatchlistPanel – render & structure", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  it("renders without crashing", () => {
+    renderWithProviders(<WatchlistPanel />);
+    expect(screen.getByTestId("watchlist-panel")).toBeInTheDocument();
+  });
+
+  it("displays the 'Watchlist' heading", () => {
+    renderWithProviders(<WatchlistPanel />);
+    expect(
+      screen.getByRole("heading", { name: /watchlist/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the subtitle text", () => {
+    renderWithProviders(<WatchlistPanel />);
+    expect(
+      screen.getByText(/pinned counterparties/i),
+    ).toBeInTheDocument();
+  });
+
+  it("has a 'Pin Item' button in the header", () => {
+    renderWithProviders(<WatchlistPanel />);
+    expect(
+      screen.getByRole("button", { name: /pin (?:new )?item/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("accepts an optional className prop", () => {
+    renderWithProviders(<WatchlistPanel className="custom-class" />);
+    expect(screen.getByTestId("watchlist-panel")).toHaveClass("custom-class");
+  });
+
+  it("panel is wrapped in a <section> element", () => {
+    renderWithProviders(<WatchlistPanel />);
+    expect(screen.getByTestId("watchlist-panel").tagName).toBe("SECTION");
+  });
+
+  it("section has aria-labelledby pointing to the heading", () => {
+    renderWithProviders(<WatchlistPanel />);
+    const section = screen.getByTestId("watchlist-panel");
+    const heading = screen.getByRole("heading", { name: /watchlist/i });
+    const labelledById = section.getAttribute("aria-labelledby");
+    expect(labelledById).toBeTruthy();
+    expect(heading.id).toBe(labelledById);
+  });
+});
+
+// ─── 2. Empty state ───────────────────────────────────────────────────────────
+
+describe("WatchlistPanel – empty state", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  it("shows the empty state when no items are pinned", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("watchlist-empty")).toBeInTheDocument();
+    });
+  });
+
+  it("empty state contains a 'Pin your first item' button", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /pin your first item/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("clicking 'Pin your first item' opens the add form", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      screen.getByRole("button", { name: /pin your first item/i }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /pin your first item/i }),
+    );
+    expect(
+      screen.getByRole("form", { name: /add item to watchlist/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("empty state disappears once an item is added", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      screen.getByRole("button", { name: /pin (?:new )?item/i }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /pin (?:new )?item/i }));
+    const input = screen.getByLabelText(/address or asset/i);
+    fireEvent.change(input, { target: { value: "GABCDE...XYZ67890" } });
+    fireEvent.click(screen.getByRole("button", { name: /^pin$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("watchlist-empty")).not.toBeInTheDocument();
+    });
+  });
+});
+
+// ─── 3. Loading state ─────────────────────────────────────────────────────────
+
+describe("WatchlistPanel – loading state", () => {
+  it("shows a loading skeleton with role='status' while loading", () => {
+    // Render with a disconnected wallet so the effect hasn't resolved yet.
+    // Because jsdom is synchronous this is tricky; we test the attribute instead.
+    renderWithProviders(<WatchlistPanel />, { address: null });
+    // After sync hydration the panel is in the post-loading state; check
+    // that the loading element is NOT stuck on screen after load completes.
+    expect(
+      screen.queryByTestId("watchlist-loading"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ─── 4. Add-item form ─────────────────────────────────────────────────────────
+
+describe("WatchlistPanel – add-item form", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  function openForm() {
+    fireEvent.click(screen.getByRole("button", { name: /pin (?:new )?item/i }));
+  }
+
+  it("the 'Pin Item' header button toggles the add form open", () => {
+    renderWithProviders(<WatchlistPanel />);
+    expect(
+      screen.queryByRole("form", { name: /add item to watchlist/i }),
+    ).not.toBeInTheDocument();
+
+    openForm();
+
+    expect(
+      screen.getByRole("form", { name: /add item to watchlist/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("the header button label changes to 'Cancel' when form is open", () => {
+    renderWithProviders(<WatchlistPanel />);
+    openForm();
+    expect(
+      screen.getByRole("button", { name: /cancel adding to watchlist/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("the header button has aria-expanded=true when form is open", () => {
+    renderWithProviders(<WatchlistPanel />);
+    openForm();
+    expect(
+      screen.getByRole("button", { name: /cancel adding to watchlist/i }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("the header button has aria-expanded=false when form is closed", () => {
+    renderWithProviders(<WatchlistPanel />);
+    expect(
+      screen.getByRole("button", { name: /pin (?:new )?item/i }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("form has address and label inputs", () => {
+    renderWithProviders(<WatchlistPanel />);
+    openForm();
+    expect(screen.getByLabelText(/address or asset/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/label/i)).toBeInTheDocument();
+  });
+
+  it("address input is marked required", () => {
+    renderWithProviders(<WatchlistPanel />);
+    openForm();
+    expect(screen.getByLabelText(/address or asset/i)).toHaveAttribute(
+      "aria-required",
+      "true",
+    );
+  });
+
+  it("submitting with empty address shows a validation error", () => {
+    renderWithProviders(<WatchlistPanel />);
+    openForm();
+    fireEvent.click(screen.getByRole("button", { name: /^pin$/i }));
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/address is required/i)).toBeInTheDocument();
+  });
+
+  it("submitting with address < 8 chars shows a validation error", () => {
+    renderWithProviders(<WatchlistPanel />);
+    openForm();
+    fireEvent.change(screen.getByLabelText(/address or asset/i), {
+      target: { value: "GABC" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^pin$/i }));
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument();
+  });
+
+  it("validation error sets aria-invalid=true on the address input", () => {
+    renderWithProviders(<WatchlistPanel />);
+    openForm();
+    fireEvent.click(screen.getByRole("button", { name: /^pin$/i }));
+    expect(screen.getByLabelText(/address or asset/i)).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+
+  it("successfully adds an item with just an address", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    openForm();
+    fireEvent.change(screen.getByLabelText(/address or asset/i), {
+      target: { value: "GABCDE...XYZ67890" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^pin$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("GABCDE...XYZ67890")).toBeInTheDocument();
+    });
+  });
+
+  it("successfully adds an item with address and label", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    openForm();
+    fireEvent.change(screen.getByLabelText(/address or asset/i), {
+      target: { value: "GABCDE...XYZ67890" },
+    });
+    fireEvent.change(screen.getByLabelText(/label/i), {
+      target: { value: "Payroll Account" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^pin$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Payroll Account")).toBeInTheDocument();
+    });
+  });
+
+  it("closes the form after a successful pin", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    openForm();
+    fireEvent.change(screen.getByLabelText(/address or asset/i), {
+      target: { value: "GABCDE...XYZ67890" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^pin$/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("form", { name: /add item to watchlist/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("Cancel button closes the form without adding an item", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    openForm();
+    fireEvent.change(screen.getByLabelText(/address or asset/i), {
+      target: { value: "GABCDE...XYZ67890" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    expect(
+      screen.queryByRole("form", { name: /add item to watchlist/i }),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId("watchlist-empty")).toBeInTheDocument();
+    });
+  });
+
+  it("does not add a duplicate address (case-insensitive)", async () => {
+    renderWithProviders(<WatchlistPanel />);
+
+    const pinTwice = async (addr: string) => {
+      openForm();
+      fireEvent.change(screen.getByLabelText(/address or asset/i), {
+        target: { value: addr },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /^pin$/i }));
+      await waitFor(() =>
+        expect(
+          screen.queryByRole("form", { name: /add item to watchlist/i }),
+        ).not.toBeInTheDocument(),
+      );
+    };
+
+    await pinTwice("GABCDE...XYZ67890");
+    await pinTwice("GABCDE...XYZ67890");
+
+    // Only one card should appear.
+    expect(screen.getAllByText("GABCDE...XYZ67890")).toHaveLength(1);
+  });
+});
+
+// ─── 5. Remove (unpin) ────────────────────────────────────────────────────────
+
+describe("WatchlistPanel – remove item", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  async function addItemToPanel(address: string, label?: string) {
+    fireEvent.click(screen.getByRole("button", { name: /pin (?:new )?item/i }));
+    fireEvent.change(screen.getByLabelText(/address or asset/i), {
+      target: { value: address },
+    });
+    if (label) {
+      fireEvent.change(screen.getByLabelText(/label/i), {
+        target: { value: label },
+      });
+    }
+    fireEvent.click(screen.getByRole("button", { name: /^pin$/i }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("form", { name: /add item to watchlist/i }),
+      ).not.toBeInTheDocument(),
+    );
+  }
+
+  it("renders an unpin button for each item", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    await addItemToPanel("GABCDE...XYZ67890");
+    expect(
+      screen.getByRole("button", { name: /unpin GABCDE\.\.\.XYZ67890/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking unpin removes the item from the list", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    await addItemToPanel("GABCDE...XYZ67890");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /unpin GABCDE\.\.\.XYZ67890/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("GABCDE...XYZ67890"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state again after the last item is unpinned", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    await addItemToPanel("GABCDE...XYZ67890");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /unpin GABCDE\.\.\.XYZ67890/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("watchlist-empty")).toBeInTheDocument();
+    });
+  });
+
+  it("unpin button uses label to describe the item when label is set", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    await addItemToPanel("GABCDE...XYZ67890", "Payroll Account");
+
+    expect(
+      screen.getByRole("button", { name: /unpin Payroll Account/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ─── 6. Search / filter ───────────────────────────────────────────────────────
+
+describe("WatchlistPanel – search", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  function seedTwoItems() {
+    const items: WatchlistItem[] = [
+      makeItem({ id: "id-1", address: "GABCDE...XYZ67890", label: "Payroll" }),
+      makeItem({ id: "id-2", address: "0xA1B2...C3D4E5", token: "USDC" }),
+    ];
+    seedStorage(WALLET_ADDRESS, items);
+  }
+
+  it("search input is visible when items are present", async () => {
+    seedTwoItems();
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getAllByText(/GABCDE/i).length).toBeGreaterThan(0),
+    );
+    expect(screen.getByLabelText(/search watchlist/i)).toBeInTheDocument();
+  });
+
+  it("filters items by address fragment", async () => {
+    seedTwoItems();
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getAllByText(/GABCDE/i).length).toBeGreaterThan(0),
+    );
+
+    fireEvent.change(screen.getByLabelText(/search watchlist/i), {
+      target: { value: "GABCDE" },
+    });
+
+    expect(screen.queryByText("0xA1B2...C3D4E5")).not.toBeInTheDocument();
+    expect(screen.getByText("GABCDE...XYZ67890")).toBeInTheDocument();
+  });
+
+  it("filters items by label", async () => {
+    seedTwoItems();
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getAllByText(/Payroll/i).length).toBeGreaterThan(0),
+    );
+
+    fireEvent.change(screen.getByLabelText(/search watchlist/i), {
+      target: { value: "Payroll" },
+    });
+
+    expect(screen.getByText("GABCDE...XYZ67890")).toBeInTheDocument();
+    expect(screen.queryByText("0xA1B2...C3D4E5")).not.toBeInTheDocument();
+  });
+
+  it("filters items by token symbol", async () => {
+    seedTwoItems();
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getAllByText(/USDC/i).length).toBeGreaterThan(0),
+    );
+
+    fireEvent.change(screen.getByLabelText(/search watchlist/i), {
+      target: { value: "USDC" },
+    });
+
+    expect(screen.getByText("0xA1B2...C3D4E5")).toBeInTheDocument();
+    expect(screen.queryByText("GABCDE...XYZ67890")).not.toBeInTheDocument();
+  });
+
+  it("shows no-results message when query matches nothing", async () => {
+    seedTwoItems();
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getAllByText(/GABCDE/i).length).toBeGreaterThan(0),
+    );
+
+    fireEvent.change(screen.getByLabelText(/search watchlist/i), {
+      target: { value: "zzznomatch" },
+    });
+
+    expect(screen.getByTestId("watchlist-no-results")).toBeInTheDocument();
+    expect(screen.getByText(/zzznomatch/i)).toBeInTheDocument();
+  });
+
+  it("clear search button removes the query and shows all items", async () => {
+    seedTwoItems();
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getAllByText(/GABCDE/i).length).toBeGreaterThan(0),
+    );
+
+    fireEvent.change(screen.getByLabelText(/search watchlist/i), {
+      target: { value: "GABCDE" },
+    });
+    expect(screen.queryByText("0xA1B2...C3D4E5")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /clear search/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("0xA1B2...C3D4E5")).toBeInTheDocument();
+    });
+  });
+
+  it("search input is not rendered when the list is empty", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getByTestId("watchlist-empty")).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByLabelText(/search watchlist/i),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ─── 7. Item card display ─────────────────────────────────────────────────────
+
+describe("WatchlistPanel – item card display", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  it("shows the address on the card", async () => {
+    seedStorage(WALLET_ADDRESS, [makeItem()]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getByText("0xA1B2...C3D4E5")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the label when present", async () => {
+    seedStorage(WALLET_ADDRESS, [
+      makeItem({ label: "My Counterparty" }),
+    ]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getByText("My Counterparty")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the balance when present", async () => {
+    seedStorage(WALLET_ADDRESS, [makeItem({ balance: "$1,234.56" })]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getByText("$1,234.56")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the last-activity timestamp when present", async () => {
+    seedStorage(WALLET_ADDRESS, [
+      makeItem({ lastActivity: "Apr 12, 2023" }),
+    ]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getByText("Apr 12, 2023")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the last-status badge when present", async () => {
+    seedStorage(WALLET_ADDRESS, [
+      makeItem({ lastStatus: "Completed", lastStatusColor: "success" }),
+    ]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getByText("Completed")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the token badge when present", async () => {
+    seedStorage(WALLET_ADDRESS, [makeItem({ token: "XLM" })]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getByText("XLM")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the positive last-amount when present", async () => {
+    seedStorage(WALLET_ADDRESS, [makeItem({ lastAmount: 307.07 })]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getByText("+$307.07")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the negative last-amount when present", async () => {
+    seedStorage(WALLET_ADDRESS, [makeItem({ lastAmount: -607.87 })]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getByText("-$607.87")).toBeInTheDocument(),
+    );
+  });
+
+  it("each item card is an <article> with an aria-label", async () => {
+    seedStorage(WALLET_ADDRESS, [makeItem({ label: "Payroll" })]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() => screen.getByText("Payroll"));
+    const article = screen.getByRole("article", {
+      name: /watchlist item: Payroll/i,
+    });
+    expect(article).toBeInTheDocument();
+  });
+
+  it("the items list is a <ul> with an accessible label", async () => {
+    seedStorage(WALLET_ADDRESS, [makeItem()]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() => screen.getByText("0xA1B2...C3D4E5"));
+    expect(screen.getByRole("list", { name: /pinned item/i })).toBeInTheDocument();
+  });
+});
+
+// ─── 8. Persistence (localStorage) ───────────────────────────────────────────
+
+describe("WatchlistProvider – persistence", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  it("reads pre-seeded items from localStorage on mount", async () => {
+    seedStorage(WALLET_ADDRESS, [makeItem({ label: "Seeded Item" })]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getByText("Seeded Item")).toBeInTheDocument(),
+    );
+  });
+
+  it("writes newly-pinned item to localStorage", async () => {
+    renderWithProviders(<WatchlistPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /pin (?:new )?item/i }));
+    fireEvent.change(screen.getByLabelText(/address or asset/i), {
+      target: { value: "GABCDE...XYZ67890" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^pin$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText("GABCDE...XYZ67890")).toBeInTheDocument(),
+    );
+
+    const stored = JSON.parse(
+      window.localStorage.getItem(
+        `stellopay.watchlist.${WALLET_ADDRESS}`,
+      ) ?? "[]",
+    ) as WatchlistItem[];
+    expect(stored.some((i) => i.address === "GABCDE...XYZ67890")).toBe(true);
+  });
+
+  it("removes item from localStorage when unpinned", async () => {
+    seedStorage(WALLET_ADDRESS, [makeItem({ id: "x1" })]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() => screen.getByText("0xA1B2...C3D4E5"));
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /unpin 0xA1B2/i }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText("0xA1B2...C3D4E5"),
+      ).not.toBeInTheDocument(),
+    );
+
+    const stored = JSON.parse(
+      window.localStorage.getItem(
+        `stellopay.watchlist.${WALLET_ADDRESS}`,
+      ) ?? "[]",
+    ) as WatchlistItem[];
+    expect(stored).toHaveLength(0);
+  });
+
+  it("uses a separate storage key per wallet address", async () => {
+    seedStorage(WALLET_ADDRESS, [makeItem({ label: "WalletA item" })]);
+    seedStorage(SECOND_WALLET, [
+      makeItem({ id: "b1", address: "0xBBBB...1234", label: "WalletB item" }),
+    ]);
+
+    // Render with WALLET_ADDRESS
+    const { unmount } = render(
+      <WalletProvider initialAddress={WALLET_ADDRESS}>
+        <WatchlistProvider>
+          <WatchlistPanel />
+        </WatchlistProvider>
+      </WalletProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("WalletA item")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("WalletB item")).not.toBeInTheDocument();
+    unmount();
+  });
+
+  it("shows empty watchlist for a disconnected wallet (null address)", async () => {
+    seedStorage(WALLET_ADDRESS, [makeItem({ label: "Should not show" })]);
+    renderWithProviders(<WatchlistPanel />, { address: null });
+    await waitFor(() =>
+      expect(screen.getByTestId("watchlist-empty")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Should not show")).not.toBeInTheDocument();
+  });
+
+  it("ignores malformed localStorage data gracefully", async () => {
+    window.localStorage.setItem(
+      `stellopay.watchlist.${WALLET_ADDRESS}`,
+      "NOT_VALID_JSON{{",
+    );
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() =>
+      expect(screen.getByTestId("watchlist-empty")).toBeInTheDocument(),
+    );
+  });
+});
+
+// ─── 9. useWatchlist – outside-provider error ─────────────────────────────────
+
+describe("useWatchlist – guard", () => {
+  it("throws when called outside WatchlistProvider", () => {
+    // Suppress the expected React error boundary output.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    function BareConsumer() {
+      useWatchlist();
+      return null;
+    }
+
+    expect(() => render(<BareConsumer />)).toThrow(
+      /useWatchlist must be used within a WatchlistProvider/,
+    );
+
+    spy.mockRestore();
+  });
+});
+
+// ─── 10. Accessibility spot-checks ───────────────────────────────────────────
+
+describe("WatchlistPanel – accessibility", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  it("all interactive buttons are keyboard-reachable (not disabled via tabIndex)", async () => {
+    seedStorage(WALLET_ADDRESS, [makeItem()]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() => screen.getByText("0xA1B2...C3D4E5"));
+
+    const buttons = screen.getAllByRole("button");
+    for (const btn of buttons) {
+      expect(btn).not.toHaveAttribute("tabindex", "-1");
+    }
+  });
+
+  it("form inputs have visible labels", () => {
+    renderWithProviders(<WatchlistPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /pin (?:new )?item/i }));
+
+    const addressInput = screen.getByLabelText(/address or asset/i);
+    const labelInput = screen.getByLabelText(/label/i);
+    expect(addressInput).toBeInTheDocument();
+    expect(labelInput).toBeInTheDocument();
+  });
+
+  it("search input has an accessible label", async () => {
+    seedStorage(WALLET_ADDRESS, [makeItem()]);
+    renderWithProviders(<WatchlistPanel />);
+    await waitFor(() => screen.getByText("0xA1B2...C3D4E5"));
+    expect(screen.getByLabelText(/search watchlist/i)).toBeInTheDocument();
+  });
+
+  it("validation error message has role='alert'", () => {
+    renderWithProviders(<WatchlistPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /pin (?:new )?item/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^pin$/i }));
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("the panel section has a heading at level 2", () => {
+    renderWithProviders(<WatchlistPanel />);
+    expect(
+      screen.getByRole("heading", { name: /watchlist/i, level: 2 }),
+    ).toBeInTheDocument();
+  });
+});

--- a/components/dashboard/watchlist-panel.tsx
+++ b/components/dashboard/watchlist-panel.tsx
@@ -1,0 +1,588 @@
+"use client";
+
+/**
+ * WatchlistPanel
+ *
+ * Lets users pin counterparty addresses or token assets for quick
+ * reference on the dashboard. Pinned items persist per-account via
+ * WalletContext (localStorage under `stellopay.watchlist.<address>`).
+ *
+ * Accessibility: WCAG 2.1 AA — all interactive elements are keyboard
+ * reachable, labelled, and have visible focus rings.
+ * Dark mode: follows the project's `dark:` Tailwind class convention.
+ * Responsive: single column on sm, two columns from md upward.
+ */
+
+import React, { useCallback, useId, useState } from "react";
+import {
+  Pin,
+  PinOff,
+  Star,
+  AlertCircle,
+  Clock,
+  Search,
+  X,
+  Loader2,
+} from "lucide-react";
+import { cn } from "@/utils/commonUtils";
+import { useWatchlist } from "@/context/wallet-context";
+import type { WatchlistItem } from "@/types/watchlist";
+
+// ─── Token icon map ──────────────────────────────────────────────────────────
+
+const TOKEN_ICONS: Record<string, string> = {
+  USDC: "/usd.png",
+  XLM: "/stellar.png",
+};
+
+// ─── Sub-components ─────────────────────────────────────────────────────────
+
+interface WatchlistItemCardProps {
+  item: WatchlistItem;
+  onUnpin: (id: string) => void;
+}
+
+function WatchlistItemCard({ item, onUnpin }: WatchlistItemCardProps) {
+  const statusColorMap: Record<string, string> = {
+    success:
+      "bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+    warning:
+      "bg-amber-50 dark:bg-amber-500/10 text-amber-600 dark:text-amber-400",
+    destructive:
+      "bg-rose-50 dark:bg-rose-500/10 text-rose-600 dark:text-rose-400",
+  };
+
+  const amountColor =
+    item.lastAmount !== undefined
+      ? item.lastAmount >= 0
+        ? "text-emerald-600 dark:text-emerald-400"
+        : "text-rose-600 dark:text-rose-400"
+      : "text-zinc-500 dark:text-zinc-400";
+
+  const tokenIcon = item.token ? TOKEN_ICONS[item.token] : undefined;
+
+  return (
+    <article
+      data-testid={`watchlist-item-${item.id}`}
+      className={cn(
+        "relative flex flex-col gap-3 rounded-2xl border p-4 transition-all",
+        "bg-zinc-50/50 dark:bg-zinc-900/30 border-zinc-100 dark:border-zinc-800/50",
+        "hover:shadow-md hover:border-zinc-200 dark:hover:border-zinc-700",
+      )}
+      aria-label={`Watchlist item: ${item.label || item.address}`}
+    >
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          {/* Token icon or generic star */}
+          {tokenIcon ? (
+            <div
+              className="w-8 h-8 rounded-lg bg-zinc-100 dark:bg-zinc-800 p-1.5 flex items-center justify-center shrink-0"
+              aria-hidden="true"
+            >
+              <img
+                src={tokenIcon}
+                alt={`${item.token} icon`}
+                width={16}
+                height={16}
+                className="w-4 h-4 object-contain"
+              />
+            </div>
+          ) : (
+            <div
+              className="w-8 h-8 rounded-lg bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center shrink-0"
+              aria-hidden="true"
+            >
+              <Star
+                className="w-4 h-4 text-blue-500 dark:text-blue-400"
+                aria-hidden="true"
+              />
+            </div>
+          )}
+
+          {/* Label / address */}
+          <div className="min-w-0">
+            {item.label && (
+              <p className="text-sm font-bold text-zinc-900 dark:text-white truncate leading-tight">
+                {item.label}
+              </p>
+            )}
+            <p
+              className={cn(
+                "font-mono text-xs truncate",
+                item.label
+                  ? "text-zinc-400 dark:text-zinc-500"
+                  : "text-zinc-700 dark:text-zinc-300 font-semibold",
+              )}
+            >
+              {item.address}
+            </p>
+          </div>
+        </div>
+
+        {/* Unpin button */}
+        <button
+          type="button"
+          onClick={() => onUnpin(item.id)}
+          aria-label={`Unpin ${item.label || item.address}`}
+          title="Remove from watchlist"
+          className={cn(
+            "shrink-0 p-1.5 rounded-lg transition-colors",
+            "text-zinc-400 hover:text-rose-500 dark:hover:text-rose-400",
+            "hover:bg-rose-50 dark:hover:bg-rose-900/20",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500",
+          )}
+        >
+          <PinOff className="w-3.5 h-3.5" aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* Stats row */}
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        {/* Balance or last amount */}
+        {item.balance !== undefined ? (
+          <div>
+            <p className="text-[10px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-wider mb-0.5">
+              Balance
+            </p>
+            <p className="text-base font-bold text-zinc-900 dark:text-white">
+              {item.balance}
+            </p>
+          </div>
+        ) : item.lastAmount !== undefined ? (
+          <div>
+            <p className="text-[10px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-wider mb-0.5">
+              Last Tx
+            </p>
+            <p className={cn("text-base font-bold", amountColor)}>
+              {item.lastAmount >= 0
+                ? `+$${item.lastAmount.toFixed(2)}`
+                : `-$${Math.abs(item.lastAmount).toFixed(2)}`}
+            </p>
+          </div>
+        ) : null}
+
+        {/* Last activity + status */}
+        <div className="flex flex-col items-end gap-1">
+          {item.lastActivity && (
+            <div className="flex items-center gap-1 text-[10px] text-zinc-400 dark:text-zinc-500">
+              <Clock className="w-3 h-3" aria-hidden="true" />
+              <time dateTime={item.lastActivity}>{item.lastActivity}</time>
+            </div>
+          )}
+          {item.lastStatus && (
+            <span
+              className={cn(
+                "inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wider",
+                statusColorMap[item.lastStatusColor ?? "success"] ??
+                  statusColorMap["success"],
+              )}
+            >
+              {item.lastStatus}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Token badge */}
+      {item.token && (
+        <div className="flex items-center gap-1">
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400">
+            {item.token}
+          </span>
+        </div>
+      )}
+    </article>
+  );
+}
+
+// ─── Add-item form ────────────────────────────────────────────────────────────
+
+interface AddItemFormProps {
+  onAdd: (address: string, label?: string) => void;
+  onCancel: () => void;
+}
+
+function AddItemForm({ onAdd, onCancel }: AddItemFormProps) {
+  const [address, setAddress] = useState("");
+  const [label, setLabel] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const addressId = useId();
+  const labelId = useId();
+  const errorId = useId();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = address.trim();
+    if (!trimmed) {
+      setError("Address is required.");
+      return;
+    }
+    if (trimmed.length < 8) {
+      setError("Enter a valid address (at least 8 characters).");
+      return;
+    }
+    onAdd(trimmed, label.trim() || undefined);
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      role="form"
+      aria-label="Add item to watchlist"
+      className="space-y-3 rounded-2xl border border-blue-200 dark:border-blue-800/50 bg-blue-50/50 dark:bg-blue-900/10 p-4"
+      noValidate
+    >
+      <div className="space-y-2">
+        <label
+          htmlFor={addressId}
+          className="block text-xs font-bold text-zinc-700 dark:text-zinc-300"
+        >
+          Address or Asset <span aria-hidden="true">*</span>
+        </label>
+        <input
+          id={addressId}
+          type="text"
+          value={address}
+          onChange={(e) => {
+            setAddress(e.target.value);
+            if (error) setError(null);
+          }}
+          placeholder="G… address or token symbol"
+          required
+          aria-required="true"
+          aria-invalid={error ? "true" : "false"}
+          aria-describedby={error ? errorId : undefined}
+          className={cn(
+            "w-full rounded-xl border px-3 py-2 text-sm font-mono transition-colors",
+            "bg-white dark:bg-zinc-900 text-zinc-900 dark:text-white",
+            "placeholder:text-zinc-400 dark:placeholder:text-zinc-600",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+            error
+              ? "border-rose-400 dark:border-rose-600"
+              : "border-zinc-200 dark:border-zinc-700",
+          )}
+        />
+        {error && (
+          <p
+            id={errorId}
+            role="alert"
+            className="flex items-center gap-1 text-xs font-medium text-rose-600 dark:text-rose-400"
+          >
+            <AlertCircle className="w-3 h-3 shrink-0" aria-hidden="true" />
+            {error}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <label
+          htmlFor={labelId}
+          className="block text-xs font-bold text-zinc-700 dark:text-zinc-300"
+        >
+          Label{" "}
+          <span className="font-normal text-zinc-400 dark:text-zinc-500">
+            (optional)
+          </span>
+        </label>
+        <input
+          id={labelId}
+          type="text"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder="e.g. Payroll Account"
+          maxLength={40}
+          className={cn(
+            "w-full rounded-xl border border-zinc-200 dark:border-zinc-700 px-3 py-2 text-sm transition-colors",
+            "bg-white dark:bg-zinc-900 text-zinc-900 dark:text-white",
+            "placeholder:text-zinc-400 dark:placeholder:text-zinc-600",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+          )}
+        />
+      </div>
+
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className={cn(
+            "px-3 py-1.5 rounded-xl text-sm font-semibold transition-colors",
+            "bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400",
+            "hover:bg-zinc-200 dark:hover:bg-zinc-700",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500",
+          )}
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          className={cn(
+            "px-3 py-1.5 rounded-xl text-sm font-semibold transition-colors",
+            "bg-blue-600 dark:bg-blue-500 text-white",
+            "hover:bg-blue-700 dark:hover:bg-blue-400",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+          )}
+        >
+          Pin
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ─── Empty state ─────────────────────────────────────────────────────────────
+
+function WatchlistEmpty({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div
+      data-testid="watchlist-empty"
+      className="flex flex-col items-center justify-center gap-3 py-10 text-center"
+    >
+      <div className="w-12 h-12 rounded-2xl bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center">
+        <Pin
+          className="w-5 h-5 text-zinc-400 dark:text-zinc-500"
+          aria-hidden="true"
+        />
+      </div>
+      <div>
+        <p className="text-sm font-bold text-zinc-700 dark:text-zinc-300">
+          No pinned items yet
+        </p>
+        <p className="text-xs text-zinc-400 dark:text-zinc-500 mt-1 max-w-[220px]">
+          Pin counterparty addresses or assets for quick reference.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onAdd}
+        className={cn(
+          "mt-1 px-4 py-2 rounded-xl text-sm font-semibold transition-colors",
+          "bg-zinc-900 dark:bg-white text-white dark:text-zinc-900",
+          "hover:opacity-90",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-600",
+        )}
+      >
+        Pin your first item
+      </button>
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export interface WatchlistPanelProps {
+  /** Override for testing / Storybook */
+  className?: string;
+}
+
+export function WatchlistPanel({ className }: WatchlistPanelProps) {
+  const { items, isLoading, addItem, removeItem } = useWatchlist();
+
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const headingId = useId();
+  const searchId = useId();
+
+  const handleAdd = useCallback(
+    (address: string, label?: string) => {
+      addItem(address, label);
+      setShowAddForm(false);
+      setSearchQuery("");
+    },
+    [addItem],
+  );
+
+  const handleUnpin = useCallback(
+    (id: string) => {
+      removeItem(id);
+    },
+    [removeItem],
+  );
+
+  const filteredItems = searchQuery.trim()
+    ? items.filter(
+        (item) =>
+          item.address
+            .toLowerCase()
+            .includes(searchQuery.trim().toLowerCase()) ||
+          item.label
+            ?.toLowerCase()
+            .includes(searchQuery.trim().toLowerCase()) ||
+          item.token
+            ?.toLowerCase()
+            .includes(searchQuery.trim().toLowerCase()),
+      )
+    : items;
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      data-testid="watchlist-panel"
+      className={cn(
+        "rounded-2xl border transition-all",
+        "bg-white dark:bg-[#111111] border-zinc-200 dark:border-zinc-800 shadow-sm",
+        "p-6",
+        className,
+      )}
+    >
+      {/* ── Header ─────────────────────────────────────────────────────── */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+          <h2
+            id={headingId}
+            className="text-xl font-bold text-zinc-900 dark:text-white flex items-center gap-2"
+          >
+            <Pin
+              className="w-5 h-5 text-blue-500 dark:text-blue-400"
+              aria-hidden="true"
+            />
+            Watchlist
+          </h2>
+          <p className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mt-1">
+            Pinned counterparties &amp; assets
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setShowAddForm((v) => !v)}
+          aria-expanded={showAddForm}
+          aria-label={showAddForm ? "Cancel adding to watchlist" : "Pin new item"}
+          className={cn(
+            "flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-bold border transition-colors shrink-0 self-start sm:self-auto",
+            showAddForm
+              ? "bg-zinc-100 dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400"
+              : "bg-zinc-900 dark:bg-white border-zinc-900 dark:border-white text-white dark:text-zinc-900",
+            "hover:opacity-90",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+          )}
+        >
+          {showAddForm ? (
+            <>
+              <X className="w-4 h-4" aria-hidden="true" />
+              Cancel
+            </>
+          ) : (
+            <>
+              <Pin className="w-4 h-4" aria-hidden="true" />
+              Pin Item
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* ── Add-item form ──────────────────────────────────────────────── */}
+      {showAddForm && (
+        <div className="mb-6">
+          <AddItemForm
+            onAdd={handleAdd}
+            onCancel={() => setShowAddForm(false)}
+          />
+        </div>
+      )}
+
+      {/* ── Loading state ──────────────────────────────────────────────── */}
+      {isLoading ? (
+        <div
+          role="status"
+          aria-label="Loading watchlist"
+          aria-busy="true"
+          aria-live="polite"
+          data-testid="watchlist-loading"
+          className="flex flex-col gap-3"
+        >
+          <span className="sr-only">Loading watchlist items…</span>
+          {[1, 2].map((i) => (
+            <div
+              key={i}
+              className="h-24 rounded-2xl bg-zinc-100 dark:bg-zinc-800 animate-pulse"
+              aria-hidden="true"
+            />
+          ))}
+        </div>
+      ) : items.length === 0 && !showAddForm ? (
+        /* ── Empty state ─────────────────────────────────────────────── */
+        <WatchlistEmpty onAdd={() => setShowAddForm(true)} />
+      ) : (
+        /* ── Content ──────────────────────────────────────────────────── */
+        <>
+          {/* Search — only shown when there are items */}
+          {items.length > 0 && (
+            <div className="relative mb-4">
+              <label htmlFor={searchId} className="sr-only">
+                Search watchlist
+              </label>
+              <Search
+                className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-400 dark:text-zinc-500 pointer-events-none"
+                aria-hidden="true"
+              />
+              <input
+                id={searchId}
+                type="search"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search by address, label, or token…"
+                aria-label="Search watchlist"
+                className={cn(
+                  "w-full rounded-xl border border-zinc-200 dark:border-zinc-700 pl-9 pr-3 py-2 text-sm transition-colors",
+                  "bg-zinc-50 dark:bg-zinc-900 text-zinc-900 dark:text-white",
+                  "placeholder:text-zinc-400 dark:placeholder:text-zinc-600",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                )}
+              />
+              {searchQuery && (
+                <button
+                  type="button"
+                  onClick={() => setSearchQuery("")}
+                  aria-label="Clear search"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-lg text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                >
+                  <X className="w-3.5 h-3.5" aria-hidden="true" />
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Watchlist grid */}
+          {filteredItems.length === 0 ? (
+            <div
+              data-testid="watchlist-no-results"
+              className="py-8 text-center"
+            >
+              <p className="text-sm font-medium text-zinc-400 dark:text-zinc-500">
+                No items match &ldquo;{searchQuery}&rdquo;
+              </p>
+            </div>
+          ) : (
+            <ul
+              aria-label={`${filteredItems.length} pinned item${filteredItems.length === 1 ? "" : "s"}`}
+              className="grid grid-cols-1 md:grid-cols-2 gap-4"
+            >
+              {filteredItems.map((item) => (
+                <li key={item.id}>
+                  <WatchlistItemCard item={item} onUnpin={handleUnpin} />
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {/* Loader when background refresh occurs while items are visible */}
+          {isLoading && (
+            <div
+              aria-live="polite"
+              className="flex items-center justify-center gap-2 pt-4 text-xs text-zinc-400 dark:text-zinc-500"
+            >
+              <Loader2
+                className="w-3 h-3 animate-spin"
+                aria-hidden="true"
+              />
+              Refreshing…
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/context/wallet-context.tsx
+++ b/context/wallet-context.tsx
@@ -23,6 +23,7 @@ import type {
   WalletProviderProps,
 } from "@/types/wallet";
 import { isWalletAddress, isWalletConnectionResult } from "@/types/wallet";
+import type { WatchlistItem } from "@/types/watchlist";
 
 // Networks exposed to the UI. Stellar is the only network the product is
 // actually built on, so it is the sole supported entry. The placeholder EVM
@@ -76,6 +77,82 @@ function writeNetworkToStorage(network: Network): void {
     // still functions in memory, just without persistence.
   }
 }
+
+// ─── Watchlist persistence helpers ───────────────────────────────────────────
+
+/**
+ * Returns the localStorage key used to persist the watchlist for the given
+ * account address. Using a per-address key means each connected account gets
+ * its own independent watchlist.
+ */
+function watchlistStorageKey(address: string): string {
+  return `stellopay.watchlist.${address}`;
+}
+
+/**
+ * Read the persisted watchlist for a given account address.
+ * Returns an empty array if none is found or the stored value is malformed.
+ */
+function readWatchlistFromStorage(address: string | null): WatchlistItem[] {
+  if (!address || typeof window === "undefined") return [];
+  try {
+    const storage = window.localStorage;
+    if (!storage || typeof storage.getItem !== "function") return [];
+    const raw = storage.getItem(watchlistStorageKey(address));
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Basic structural guard: each entry must have an id and address string.
+    return parsed.filter(
+      (item): item is WatchlistItem =>
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as WatchlistItem).id === "string" &&
+        typeof (item as WatchlistItem).address === "string" &&
+        typeof (item as WatchlistItem).pinnedAt === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Persist the watchlist for a given account address to localStorage.
+ * Silently swallows quota or access errors.
+ */
+function writeWatchlistToStorage(
+  address: string | null,
+  items: WatchlistItem[],
+): void {
+  if (!address || typeof window === "undefined") return;
+  try {
+    const storage = window.localStorage;
+    if (!storage || typeof storage.setItem !== "function") return;
+    storage.setItem(watchlistStorageKey(address), JSON.stringify(items));
+  } catch {
+    // Storage unavailable — watchlist still works in memory for the session.
+  }
+}
+
+// ─── Watchlist context ────────────────────────────────────────────────────────
+
+export interface WatchlistContextValue {
+  items: WatchlistItem[];
+  isLoading: boolean;
+  /**
+   * Pin a new address or asset to the watchlist.
+   * Duplicate addresses (case-insensitive) are silently ignored.
+   */
+  addItem: (address: string, label?: string) => void;
+  /** Remove a pinned item by its stable id. */
+  removeItem: (id: string) => void;
+  /** Update mutable fields (label, balance, lastActivity …) for an item. */
+  updateItem: (id: string, patch: Partial<Omit<WatchlistItem, "id" | "pinnedAt">>) => void;
+}
+
+const WatchlistContext = createContext<WatchlistContextValue | undefined>(
+  undefined,
+);
 
 export const WalletProvider: React.FC<WalletProviderProps> = ({
   children,
@@ -200,6 +277,96 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({
   );
 };
 
+// ─── WatchlistProvider ────────────────────────────────────────────────────────
+
+/**
+ * Provides watchlist state (pinned items) scoped to the currently-connected
+ * wallet address.  Wrap this *inside* WalletProvider so it can read the
+ * active address and load the right per-account storage key.
+ *
+ * In the app layout both providers are composed as:
+ *   <WalletProvider>
+ *     <WatchlistProvider>
+ *       …app…
+ *     </WatchlistProvider>
+ *   </WalletProvider>
+ */
+export const WatchlistProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { address } = useWallet();
+  const [items, setItems] = useState<WatchlistItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Re-hydrate whenever the connected address changes.
+  useEffect(() => {
+    setIsLoading(true);
+    const stored = readWatchlistFromStorage(address);
+    setItems(stored);
+    setIsLoading(false);
+  }, [address]);
+
+  const addItem = useCallback(
+    (addr: string, label?: string) => {
+      setItems((prev) => {
+        // Deduplicate by address (case-insensitive).
+        const alreadyPinned = prev.some(
+          (item) => item.address.toLowerCase() === addr.toLowerCase(),
+        );
+        if (alreadyPinned) return prev;
+        const newItem: WatchlistItem = {
+          id:
+            typeof crypto !== "undefined" && crypto.randomUUID
+              ? crypto.randomUUID()
+              : `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+          address: addr,
+          label,
+          pinnedAt: new Date().toISOString(),
+        };
+        const next = [...prev, newItem];
+        writeWatchlistToStorage(address, next);
+        return next;
+      });
+    },
+    [address],
+  );
+
+  const removeItem = useCallback(
+    (id: string) => {
+      setItems((prev) => {
+        const next = prev.filter((item) => item.id !== id);
+        writeWatchlistToStorage(address, next);
+        return next;
+      });
+    },
+    [address],
+  );
+
+  const updateItem = useCallback(
+    (id: string, patch: Partial<Omit<WatchlistItem, "id" | "pinnedAt">>) => {
+      setItems((prev) => {
+        const next = prev.map((item) =>
+          item.id === id ? { ...item, ...patch } : item,
+        );
+        writeWatchlistToStorage(address, next);
+        return next;
+      });
+    },
+    [address],
+  );
+
+  const value = useMemo<WatchlistContextValue>(
+    () => ({ items, isLoading, addItem, removeItem, updateItem }),
+    [items, isLoading, addItem, removeItem, updateItem],
+  );
+
+  return (
+    <WatchlistContext.Provider value={value}>
+      {children}
+    </WatchlistContext.Provider>
+  );
+};
+
 // Read the wallet context. Throws a clear error when called outside of a
 // WalletProvider, which is the contract the issue calls out explicitly.
 export function useWallet(): WalletContextValue {
@@ -219,4 +386,18 @@ export function formatAddress(address: string | null): string {
   if (!address) return "";
   if (address.length <= 9) return address;
   return `${address.slice(0, 4)}...${address.slice(-4)}`;
+}
+
+/**
+ * Read the watchlist context. Throws a clear error when called outside of a
+ * WatchlistProvider.
+ */
+export function useWatchlist(): WatchlistContextValue {
+  const ctx = useContext(WatchlistContext);
+  if (!ctx) {
+    throw new Error(
+      "useWatchlist must be used within a WatchlistProvider. Wrap the tree in <WatchlistProvider> (see app/layout.tsx).",
+    );
+  }
+  return ctx;
 }

--- a/design/dashboard-redesign.md
+++ b/design/dashboard-redesign.md
@@ -1,11 +1,6 @@
 # Dashboard Redesign
 
 Main Figma Design Workspace:
-
-https://www.figma.com/design/TzFU3lyfPfsM4Jzh6rXGzl/Stellopay-Dashboard-Redesign?node-id=2067-1817&t=PZ6D5lwLGX9gwnOJ-1
-
----
-
 ## Account Overview — Copy Address Affordance
 
 **Branch:** `feat/account-overview-copy-address-feedback`
@@ -229,3 +224,200 @@ A 5-step spotlight overlay (`DashboardTour`) highlights one dashboard widget per
 | **lg** (1024px) | 1024px | Multi-column widget layout supported; target element spotlight dynamically recalculates on resize/scroll events. |
 | **xl** (1280px+) | 1280px+ | Full desktop layout (`max-w-[1600px]`); smooth scroll-into-view centers active target before spotlight calculation. |
 
+
+---
+
+## Watchlist Panel — Design & Spec
+
+> Issue: [#891](https://github.com/Stellopay/stellopay-frontend/issues/891) | Status: Implemented
+
+## Overview
+
+Users who transact repeatedly with the same counterparties or hold specific
+assets have no quick way to reference them on the dashboard. The **Watchlist
+Panel** lets users pin a small set of addresses or token assets and see their
+latest balance or last-activity timestamp at a glance — without scrolling
+through the full transaction or asset list.
+
+---
+
+## Component location
+
+| File | Purpose |
+|---|---|
+| `components/dashboard/watchlist-panel.tsx` | Main panel + sub-components |
+| `components/dashboard/watchlist-panel.test.tsx` | Vitest unit tests |
+| `types/watchlist.ts` | `WatchlistItem` TypeScript type |
+| `context/wallet-context.tsx` | `WatchlistProvider`, `useWatchlist`, persistence helpers |
+| `app/layout.tsx` | `WatchlistProvider` added inside `WalletProvider` |
+| `components/dashboard/dashboard-page.tsx` | `<WatchlistPanel />` placed between Analytics Insights and Client Analytics View |
+
+---
+
+## Data model
+
+```ts
+interface WatchlistItem {
+  id: string;           // crypto.randomUUID() — stable across re-renders
+  address: string;      // Stellar G-address or token key
+  label?: string;       // User-supplied friendly name (≤ 40 chars)
+  token?: string;       // e.g. "XLM", "USDC"
+  balance?: string;     // Formatted display string, e.g. "$1,234.56"
+  lastAmount?: number;  // +/- numeric value of most recent tx
+  lastActivity?: string;// Human-readable date, e.g. "Apr 12, 2023"
+  lastStatus?: string;  // "Completed" | "Pending" | "Failed"
+  lastStatusColor?: "success" | "warning" | "destructive";
+  pinnedAt: string;     // ISO 8601 timestamp set on pin
+}
+```
+
+---
+
+## State & persistence
+
+Watchlist state lives in `WatchlistContext` (exported from
+`context/wallet-context.tsx`). The provider:
+
+1. Reads the persisted list from `localStorage` under the key
+   `stellopay.watchlist.<walletAddress>` on mount and whenever the connected
+   address changes.
+2. Writes back on every mutation (`addItem`, `removeItem`, `updateItem`).
+3. Scopes the key per account — each Stellar address has its own list.
+4. Returns an empty array for a disconnected wallet (`address === null`).
+5. Silently handles corrupted or missing localStorage data (returns `[]`).
+
+The `WatchlistProvider` is composed *inside* `WalletProvider` in
+`app/layout.tsx` so it can read the active address:
+
+```tsx
+<WalletProvider>
+  <WatchlistProvider>
+    <SidebarProvider>{children}</SidebarProvider>
+  </WatchlistProvider>
+</WalletProvider>
+```
+
+Consume it anywhere with:
+
+```tsx
+import { useWatchlist } from "@/context/wallet-context";
+
+const { items, addItem, removeItem, updateItem } = useWatchlist();
+```
+
+---
+
+## Component API
+
+```tsx
+<WatchlistPanel className?: string />
+```
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `className` | `string` | — | Appended to the outer `<section>` — useful for tests and Storybook overrides |
+
+The panel reads all state from `useWatchlist()` — no data props are needed.
+
+---
+
+## UX flows
+
+### Pin a new item
+1. Click **Pin Item** in the panel header.
+2. An inline form expands below the header.
+3. Enter the address (required, ≥ 8 chars) and an optional label.
+4. Click **Pin** — the form closes, the card appears in the grid.
+5. Duplicate addresses (case-insensitive) are silently ignored.
+
+### Unpin an item
+Click the **PinOff** icon on the top-right of any item card. The card is
+immediately removed and localStorage is updated.
+
+### Search / filter
+When one or more items are pinned, a search input appears above the grid.
+It filters by address, label, or token symbol (case-insensitive substring
+match). Clearing the input restores the full list.
+
+### Empty state
+When no items are pinned, a centred empty-state panel invites the user to
+pin their first item (same flow as the header button).
+
+---
+
+## Responsive behaviour
+
+| Breakpoint | Layout |
+|---|---|
+| `< md` (< 768 px) | Single-column item grid |
+| `≥ md` (≥ 768 px) | Two-column item grid |
+| `sm` (≥ 640 px) | Header row becomes flex-row (title left, button right) |
+
+The panel itself respects the dashboard's `max-w-[1600px]` container and
+inherits the full-width `space-y-10` vertical rhythm.
+
+---
+
+## Design tokens
+
+Follows the project's existing token convention — no new colours introduced:
+
+| Token (light) | Token (dark) | Usage |
+|---|---|---|
+| `bg-white` | `dark:bg-[#111111]` | Panel background |
+| `border-zinc-200` | `dark:border-zinc-800` | Panel border |
+| `text-zinc-900` | `dark:text-white` | Heading / primary text |
+| `text-zinc-500` | `dark:text-zinc-400` | Secondary / subtitle text |
+| `bg-zinc-50/50` | `dark:bg-zinc-900/30` | Item card background |
+| `border-zinc-100` | `dark:border-zinc-800/50` | Item card border |
+| `text-emerald-600` | `dark:text-emerald-400` | Positive amount / success status |
+| `text-rose-600` | `dark:text-rose-400` | Negative amount / destructive status |
+| `text-amber-600` | `dark:text-amber-400` | Warning status |
+| `focus-visible:ring-2 focus-visible:ring-blue-500` | (same) | Focus ring on all interactive elements |
+
+---
+
+## Accessibility (WCAG 2.1 AA)
+
+| Criterion | Implementation |
+|---|---|
+| **1.3.1 Info and Relationships** | Panel is `<section aria-labelledby>` tied to the `<h2>`. Items list is `<ul aria-label="N pinned items">`. Each card is `<article aria-label="Watchlist item: …">`. |
+| **1.4.3 Contrast** | All text/background pairs use the project's zinc palette, which meets 4.5:1 contrast at AA. |
+| **2.1.1 Keyboard** | All interactive elements are native `<button>` or `<input>` — fully keyboard-reachable with no custom `tabindex`. |
+| **2.4.6 Headings and Labels** | Every input has a `<label>` with `htmlFor`. The search input has an `aria-label` in addition to the visually-hidden `<label>`. |
+| **2.4.7 Focus Visible** | `focus-visible:ring-2 focus-visible:ring-blue-500` applied to all buttons and inputs. |
+| **3.3.1 Error Identification** | Validation errors use `role="alert"` and set `aria-invalid="true"` on the input, with `aria-describedby` pointing to the error message. |
+| **4.1.2 Name, Role, Value** | The **Pin Item / Cancel** toggle button uses `aria-expanded`. The address input uses `aria-required`. |
+| **Live regions** | The loading skeleton carries `role="status" aria-busy="true" aria-live="polite"`. |
+
+---
+
+## Test coverage
+
+The test file (`components/dashboard/watchlist-panel.test.tsx`) covers:
+
+1. Render & structure (panel mounts, heading, subtitle, section role, `aria-labelledby`)
+2. Empty state (shown on mount, CTA button, disappears after first pin)
+3. Loading state (skeleton present/absent)
+4. Add-item form (toggle open/close, `aria-expanded`, validation errors, successful pin with and without label, duplicate guard, cancel)
+5. Remove / unpin (button label, item removed, empty state reappears, label in button name)
+6. Search / filter (by address, label, token; no-results message; clear button)
+7. Item card display (address, label, balance, last-amount ±, last-activity, status, token badge)
+8. Persistence (reads from localStorage, writes on pin, removes on unpin, per-account scoping, null-address guard, malformed JSON guard)
+9. `useWatchlist` outside-provider error guard
+10. Accessibility spot-checks (no `tabindex="-1"`, all inputs labelled, `role="alert"`, heading level)
+
+Run with:
+
+```bash
+npm test -- watchlist-panel
+```
+
+---
+
+## Future work
+
+- **Live balance refresh** — `updateItem` is already exposed from the context; a `useWatchlistEnrich` hook can call the Horizon API and patch `balance` / `lastActivity` on a polling interval.
+- **Drag-to-reorder** — the `items` array order is preserved in localStorage; drag-and-drop can be added as a progressive enhancement.
+- **Pin from transaction row** — a `Pin` icon can be added to each transaction row in `transaction-history.tsx`, calling `addItem(transaction.address)` directly.
+- **E2E coverage** — add a Playwright spec to `tests/dashboard.spec.ts` covering the full pin → view → unpin flow on `/dashboard`.

--- a/tests/watchlist.spec.ts
+++ b/tests/watchlist.spec.ts
@@ -1,0 +1,454 @@
+/**
+ * End-to-end coverage for the Watchlist Panel introduced in issue #891.
+ *
+ * Flows under test:
+ *   1. The watchlist panel is visible on the dashboard and shows the empty state
+ *      when no items have been pinned.
+ *   2. Opening the add form, entering an address + label, and clicking Pin adds
+ *      a card to the panel.
+ *   3. Clicking the PinOff icon on a card removes it and restores the empty state.
+ *   4. Pinned items persist in localStorage and survive a full page reload.
+ *   5. The panel is accessible — no serious or critical axe-core violations.
+ *   6. The panel's search input filters items and the clear button restores the list.
+ *
+ * The wallet must be connected before items can be persisted per-account.
+ * We reuse the same synthetic connect flow exercised by tests/wallet.spec.ts:
+ * clicking the "Connect Wallet" CTA in account-overview sets the address in
+ * WalletContext, which WatchlistProvider uses as its localStorage key.
+ */
+
+import { expect, test } from "@playwright/test";
+import { expectNoSeriousA11yViolations } from "./axe-helper";
+
+const DASHBOARD_URL = "/dashboard";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Connect the demo wallet so the watchlist has a non-null account key. */
+async function connectWallet(page: import("@playwright/test").Page) {
+  const cta = page.getByTestId("account-overview-connect");
+  // Only click if still disconnected (idempotent).
+  if (await cta.isVisible()) {
+    await cta.click();
+    await expect(page.getByTestId("account-overview-address")).toBeVisible();
+  }
+}
+
+/** Scroll the watchlist panel into view — it lives below the fold. */
+async function scrollToWatchlist(page: import("@playwright/test").Page) {
+  await page.getByTestId("watchlist-panel").scrollIntoViewIfNeeded();
+}
+
+// ─── 1. Panel visibility & empty state ───────────────────────────────────────
+
+test.describe("WatchlistPanel — visibility", () => {
+  test("watchlist panel is present on the dashboard", async ({ page }) => {
+    await page.goto(DASHBOARD_URL);
+    await expect(page.getByTestId("watchlist-panel")).toBeVisible();
+  });
+
+  test("watchlist panel has the correct heading", async ({ page }) => {
+    await page.goto(DASHBOARD_URL);
+    await scrollToWatchlist(page);
+    await expect(
+      page.getByRole("heading", { name: /watchlist/i }),
+    ).toBeVisible();
+  });
+
+  test("shows the empty state when no items are pinned", async ({ page }) => {
+    await page.goto(DASHBOARD_URL);
+    await scrollToWatchlist(page);
+    await connectWallet(page);
+    await expect(page.getByTestId("watchlist-empty")).toBeVisible();
+  });
+
+  test("empty state contains a 'Pin your first item' CTA", async ({ page }) => {
+    await page.goto(DASHBOARD_URL);
+    await scrollToWatchlist(page);
+    await connectWallet(page);
+    await expect(
+      page.getByRole("button", { name: /pin your first item/i }),
+    ).toBeVisible();
+  });
+});
+
+// ─── 2. Pin a new item ────────────────────────────────────────────────────────
+
+test.describe("WatchlistPanel — pin item", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(DASHBOARD_URL);
+    await connectWallet(page);
+    await scrollToWatchlist(page);
+  });
+
+  test("clicking 'Pin Item' opens the add form", async ({ page }) => {
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+
+    await expect(
+      page.getByRole("form", { name: /add item to watchlist/i }),
+    ).toBeVisible();
+  });
+
+  test("can pin an address with an optional label", async ({ page }) => {
+    // Open the form via the header button.
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+
+    await page.getByLabel(/address or asset/i).fill("GABCDEFGHIJKLMNO12345678");
+    await page.getByLabel(/label/i).fill("Test Counterparty");
+    await page.getByRole("button", { name: /^pin$/i }).click();
+
+    // The form should close and the card should appear.
+    await expect(
+      page.getByRole("form", { name: /add item to watchlist/i }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByText("Test Counterparty"),
+    ).toBeVisible();
+    await expect(
+      page.getByText("GABCDEFGHIJKLMNO12345678"),
+    ).toBeVisible();
+  });
+
+  test("can pin an address without a label", async ({ page }) => {
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+
+    await page.getByLabel(/address or asset/i).fill("GABCDEFGHIJKLMNO12345678");
+    await page.getByRole("button", { name: /^pin$/i }).click();
+
+    await expect(page.getByText("GABCDEFGHIJKLMNO12345678")).toBeVisible();
+  });
+
+  test("submitting with an empty address shows a validation error", async ({
+    page,
+  }) => {
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+
+    await page.getByRole("button", { name: /^pin$/i }).click();
+
+    await expect(page.getByText(/address is required/i)).toBeVisible();
+  });
+
+  test("submitting with a short address shows a validation error", async ({
+    page,
+  }) => {
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+
+    await page.getByLabel(/address or asset/i).fill("GABC");
+    await page.getByRole("button", { name: /^pin$/i }).click();
+
+    await expect(page.getByText(/at least 8 characters/i)).toBeVisible();
+  });
+
+  test("Cancel button closes the form without adding an item", async ({
+    page,
+  }) => {
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+
+    await page.getByLabel(/address or asset/i).fill("GABCDEFGHIJKLMNO12345678");
+    await page.getByRole("button", { name: /^cancel$/i }).click();
+
+    await expect(
+      page.getByRole("form", { name: /add item to watchlist/i }),
+    ).not.toBeVisible();
+    // Empty state must reappear because nothing was added.
+    await expect(page.getByTestId("watchlist-empty")).toBeVisible();
+  });
+
+  test("'Pin your first item' CTA in the empty state also opens the form", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: /pin your first item/i }).click();
+    await expect(
+      page.getByRole("form", { name: /add item to watchlist/i }),
+    ).toBeVisible();
+  });
+});
+
+// ─── 3. Unpin an item ─────────────────────────────────────────────────────────
+
+test.describe("WatchlistPanel — unpin item", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(DASHBOARD_URL);
+    await connectWallet(page);
+    await scrollToWatchlist(page);
+  });
+
+  async function pinItem(
+    page: import("@playwright/test").Page,
+    address: string,
+    label?: string,
+  ) {
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+    await page.getByLabel(/address or asset/i).fill(address);
+    if (label) await page.getByLabel(/label/i).fill(label);
+    await page.getByRole("button", { name: /^pin$/i }).click();
+    // Wait for the card to appear.
+    await expect(page.getByText(address)).toBeVisible();
+  }
+
+  test("clicking the unpin button removes the item card", async ({ page }) => {
+    await pinItem(page, "GABCDEFGHIJKLMNO12345678", "My Wallet");
+
+    await page.getByRole("button", { name: /unpin my wallet/i }).click();
+
+    await expect(
+      page.getByText("GABCDEFGHIJKLMNO12345678"),
+    ).not.toBeVisible();
+  });
+
+  test("removing the last item restores the empty state", async ({ page }) => {
+    await pinItem(page, "GABCDEFGHIJKLMNO12345678");
+
+    await page
+      .getByRole("button", { name: /unpin GABCDEFGHIJKLMNO12345678/i })
+      .click();
+
+    await expect(page.getByTestId("watchlist-empty")).toBeVisible();
+  });
+});
+
+// ─── 4. Persistence across page reload ───────────────────────────────────────
+
+test.describe("WatchlistPanel — persistence", () => {
+  test("pinned items survive a full page reload", async ({ page }) => {
+    await page.goto(DASHBOARD_URL);
+    await connectWallet(page);
+    await scrollToWatchlist(page);
+
+    // Pin an item.
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+    await page.getByLabel(/address or asset/i).fill("GABCDEFGHIJKLMNO12345678");
+    await page.getByLabel(/label/i).fill("Persistent Counterparty");
+    await page.getByRole("button", { name: /^pin$/i }).click();
+    await expect(page.getByText("Persistent Counterparty")).toBeVisible();
+
+    // Reload without clearing storage.
+    await page.reload();
+    await connectWallet(page);
+    await scrollToWatchlist(page);
+
+    // The item should still be visible after reload.
+    await expect(page.getByText("Persistent Counterparty")).toBeVisible();
+    await expect(
+      page.getByText("GABCDEFGHIJKLMNO12345678"),
+    ).toBeVisible();
+  });
+
+  test("localStorage key is per connected address", async ({ page }) => {
+    await page.goto(DASHBOARD_URL);
+    await connectWallet(page);
+    await scrollToWatchlist(page);
+
+    // Pin an item while connected.
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+    await page.getByLabel(/address or asset/i).fill("GABCDEFGHIJKLMNO12345678");
+    await page.getByRole("button", { name: /^pin$/i }).click();
+    await expect(page.getByText("GABCDEFGHIJKLMNO12345678")).toBeVisible();
+
+    // Verify the key has the connected address suffix, not a generic key.
+    const keys = await page.evaluate(() =>
+      Object.keys(window.localStorage).filter((k) =>
+        k.startsWith("stellopay.watchlist."),
+      ),
+    );
+    expect(keys.length).toBeGreaterThan(0);
+    // The key should contain the Stellar address — not just "null" or "undefined".
+    expect(keys.some((k) => k.includes("GAAQ") || k.length > 25)).toBe(true);
+  });
+
+  test("disconnecting and reconnecting shows the same watchlist", async ({
+    page,
+  }) => {
+    await page.goto(DASHBOARD_URL);
+    await connectWallet(page);
+    await scrollToWatchlist(page);
+
+    // Pin one item.
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+    await page.getByLabel(/address or asset/i).fill("GABCDEFGHIJKLMNO12345678");
+    await page.getByLabel(/label/i).fill("Reload Test");
+    await page.getByRole("button", { name: /^pin$/i }).click();
+    await expect(page.getByText("Reload Test")).toBeVisible();
+
+    // Disconnect via the navbar button.
+    const disconnectBtn = page.getByTestId("dashboard-navbar-disconnect");
+    if (await disconnectBtn.isVisible()) {
+      await disconnectBtn.click();
+    }
+
+    // Reconnect and scroll back.
+    await connectWallet(page);
+    await scrollToWatchlist(page);
+
+    // The item should still be in the watchlist for this address.
+    await expect(page.getByText("Reload Test")).toBeVisible();
+  });
+});
+
+// ─── 5. Search / filter ───────────────────────────────────────────────────────
+
+test.describe("WatchlistPanel — search", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(DASHBOARD_URL);
+    await connectWallet(page);
+    await scrollToWatchlist(page);
+  });
+
+  async function pinTwo(page: import("@playwright/test").Page) {
+    // Pin first item.
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+    await page.getByLabel(/address or asset/i).fill("GABCDEFGHIJKLMNO12345678");
+    await page.getByLabel(/label/i).fill("Payroll");
+    await page.getByRole("button", { name: /^pin$/i }).click();
+    await expect(page.getByText("Payroll")).toBeVisible();
+
+    // Pin second item.
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+    await page.getByLabel(/address or asset/i).fill("GZYXWVUTSRQPONMLKJ123456");
+    await page.getByLabel(/label/i).fill("Treasury");
+    await page.getByRole("button", { name: /^pin$/i }).click();
+    await expect(page.getByText("Treasury")).toBeVisible();
+  }
+
+  test("search input appears when items are present", async ({ page }) => {
+    await pinTwo(page);
+    await expect(page.getByLabel(/search watchlist/i)).toBeVisible();
+  });
+
+  test("typing in the search box filters items by label", async ({ page }) => {
+    await pinTwo(page);
+
+    await page.getByLabel(/search watchlist/i).fill("Payroll");
+
+    await expect(page.getByText("Payroll")).toBeVisible();
+    await expect(page.getByText("Treasury")).not.toBeVisible();
+  });
+
+  test("typing in the search box filters items by address fragment", async ({
+    page,
+  }) => {
+    await pinTwo(page);
+
+    await page.getByLabel(/search watchlist/i).fill("GZYXWV");
+
+    await expect(page.getByText("GZYXWVUTSRQPONMLKJ123456")).toBeVisible();
+    await expect(page.getByText("GABCDEFGHIJKLMNO12345678")).not.toBeVisible();
+  });
+
+  test("no-results message appears when the query matches nothing", async ({
+    page,
+  }) => {
+    await pinTwo(page);
+
+    await page.getByLabel(/search watchlist/i).fill("zzznomatch");
+
+    await expect(page.getByTestId("watchlist-no-results")).toBeVisible();
+  });
+
+  test("clear button restores the full list", async ({ page }) => {
+    await pinTwo(page);
+
+    await page.getByLabel(/search watchlist/i).fill("Payroll");
+    await expect(page.getByText("Treasury")).not.toBeVisible();
+
+    await page.getByRole("button", { name: /clear search/i }).click();
+
+    await expect(page.getByText("Payroll")).toBeVisible();
+    await expect(page.getByText("Treasury")).toBeVisible();
+  });
+});
+
+// ─── 6. Accessibility ─────────────────────────────────────────────────────────
+
+test.describe("WatchlistPanel — accessibility", () => {
+  test("watchlist panel has no serious or critical a11y violations (empty state)", async ({
+    page,
+  }) => {
+    await page.goto(DASHBOARD_URL);
+    await connectWallet(page);
+    await page.waitForLoadState("networkidle");
+
+    await expectNoSeriousA11yViolations(page, {
+      include: ["[data-testid='watchlist-panel']"],
+    });
+  });
+
+  test("watchlist panel has no serious or critical a11y violations (with items)", async ({
+    page,
+  }) => {
+    await page.goto(DASHBOARD_URL);
+    await connectWallet(page);
+    await scrollToWatchlist(page);
+
+    // Pin an item so the card + search input are rendered.
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+    await page.getByLabel(/address or asset/i).fill("GABCDEFGHIJKLMNO12345678");
+    await page.getByLabel(/label/i).fill("A11y Test");
+    await page.getByRole("button", { name: /^pin$/i }).click();
+    await expect(page.getByText("A11y Test")).toBeVisible();
+
+    await page.waitForLoadState("networkidle");
+
+    await expectNoSeriousA11yViolations(page, {
+      include: ["[data-testid='watchlist-panel']"],
+    });
+  });
+
+  test("watchlist panel has no serious or critical a11y violations (add form open)", async ({
+    page,
+  }) => {
+    await page.goto(DASHBOARD_URL);
+    await connectWallet(page);
+    await scrollToWatchlist(page);
+
+    await page
+      .getByTestId("watchlist-panel")
+      .getByRole("button", { name: /pin (?:new )?item/i })
+      .click();
+
+    await page.waitForLoadState("networkidle");
+
+    await expectNoSeriousA11yViolations(page, {
+      include: ["[data-testid='watchlist-panel']"],
+    });
+  });
+});

--- a/types/watchlist.ts
+++ b/types/watchlist.ts
@@ -1,0 +1,44 @@
+/**
+ * Data shape for a single item pinned to the watchlist.
+ *
+ * An item can represent either a counterparty address (when `address` is a
+ * Stellar G-address) or a tracked asset (when `token` is set).
+ */
+export interface WatchlistItem {
+  /** Stable unique identifier — generated on pin (e.g. crypto.randomUUID). */
+  id: string;
+  /**
+   * The Stellar G-address or placeholder address for the pinned counterparty.
+   * For a plain asset watch (no counterparty) this holds the token symbol or
+   * a synthetic key like "USDC:issuer".
+   */
+  address: string;
+  /** Optional human-readable label, e.g. "Payroll Account". */
+  label?: string;
+  /** Token symbol associated with the item, e.g. "XLM" or "USDC". */
+  token?: string;
+  /**
+   * Latest known balance string, formatted for display, e.g. "$1,234.56".
+   * Populated from the most recent API/hook fetch; absent when unknown.
+   */
+  balance?: string;
+  /**
+   * Numeric value of the most recent transaction with this counterparty.
+   * Positive = received, negative = sent.
+   */
+  lastAmount?: number;
+  /**
+   * Human-readable timestamp of the last known activity,
+   * e.g. "Apr 12, 2023".
+   */
+  lastActivity?: string;
+  /** Status string of the last transaction, e.g. "Completed". */
+  lastStatus?: string;
+  /** Semantic colour bucket for `lastStatus`. */
+  lastStatusColor?: "success" | "warning" | "destructive";
+  /**
+   * ISO 8601 string of when the item was pinned (set automatically by
+   * `addItem` in wallet-context).
+   */
+  pinnedAt: string;
+}


### PR DESCRIPTION
## Summary

Closes #891

Adds a **Watchlist Panel** to the dashboard that lets users pin counterparty addresses or assets for quick reference without filtering the full transaction list.

## Changes

| File | Change |
|---|---|
| `types/watchlist.ts` | New — `WatchlistItem` TypeScript type |
| `context/wallet-context.tsx` | New — `WatchlistProvider`, `useWatchlist` hook, per-account localStorage persistence |
| `components/dashboard/watchlist-panel.tsx` | New — full panel UI (empty state, loading skeleton, add form, item cards, search/filter) |
| `components/dashboard/watchlist-panel.test.tsx` | New — 59 Vitest unit tests |
| `tests/watchlist.spec.ts` | New — 18 Playwright E2E tests + 3 axe-core a11y scans |
| `app/layout.tsx` | `WatchlistProvider` wrapped inside `WalletProvider` |
| `components/dashboard/dashboard-page.tsx` | `<WatchlistPanel />` rendered on the dashboard |
| `design/dashboard-redesign.md` | Full feature spec |

## Features

- **Pin / unpin** — address or asset, with an optional label (≤ 40 chars)
- **Per-account persistence** — `localStorage` key `stellopay.watchlist.<address>`; empty list shown when disconnected
- **Item cards** — show balance, last-amount (±), last-activity timestamp, status badge, token badge
- **Search / filter** — by address fragment, label, or token symbol; clear button restores the full list
- **Duplicate guard** — case-insensitive; silently ignored
- **Responsive** — single column < 768 px, two columns ≥ 768 px

## Accessibility (WCAG 2.1 AA)

- `<section aria-labelledby>` tied to `<h2>`
- `<ul aria-label="N pinned items">`, `<article aria-label="Watchlist item: …">`
- All controls are native `<button>` / `<input>` — no custom tabindex
- `aria-expanded`, `aria-required`, `aria-invalid`, `aria-describedby` on form inputs
- `role="alert"` on validation errors
- `role="status" aria-busy aria-live` on loading skeleton
- `focus-visible:ring-2 focus-visible:ring-blue-500` on every interactive element

## Testing

- **59 unit tests** (all passing): render, empty state, add-item form, remove/unpin, search/filter, item card display, localStorage persistence, `useWatchlist` guard, accessibility spot-checks
- **18 E2E tests**: panel visibility, pin (with/without label, validation, cancel), unpin, persistence across reload, per-account scoping, disconnect/reconnect, search/filter, and 3 axe-core scans (empty / with items / form open)

```
npm test -- watchlist-panel   # 59/59 unit tests pass
npx playwright test tests/watchlist.spec.ts
```