### PR TITLE
feat: add a bulk sign-out-all-other-sessions action to security settings

### DIFF
--- a/app/settings/preferences/components/destructive-action-dialog.tsx
+++ b/app/settings/preferences/components/destructive-action-dialog.tsx
@@ -16,6 +16,13 @@ import { Input } from "@/components/ui/input";
 
 interface DestructiveActionDialogProps {
   triggerLabel: string;
+  /**
+   * Accessible name for the trigger button. Use when several dialogs share the
+   * same visible `triggerLabel` (e.g. a "Sign out" button per session) so
+   * screen-reader users can tell the controls apart. Falls back to the visible
+   * label when omitted.
+   */
+  triggerAriaLabel?: string;
   title: string;
   description: string;
   impactItems: string[];
@@ -81,6 +88,7 @@ function getConfirmationError(value: string, token: string): string | null {
  */
 export default function DestructiveActionDialog({
   triggerLabel,
+  triggerAriaLabel,
   title,
   description,
   impactItems,
@@ -122,7 +130,9 @@ export default function DestructiveActionDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button variant="destructive">{triggerLabel}</Button>
+        <Button variant="destructive" aria-label={triggerAriaLabel}>
+          {triggerLabel}
+        </Button>
       </DialogTrigger>
 
       <DialogContent

--- a/app/settings/preferences/components/security-tab.test.tsx
+++ b/app/settings/preferences/components/security-tab.test.tsx
@@ -5,6 +5,7 @@ import {
   fireEvent,
   waitFor,
   act,
+  within,
 } from "@testing-library/react";
 import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
 
@@ -127,10 +128,10 @@ describe("SecurityTab — initial render", () => {
     expect(screen.getByText("Large transfer approval")).toBeInTheDocument();
   });
 
-  it("renders the sign-out-all-sessions trigger", () => {
+  it("renders the sign-out-all-other-sessions trigger", () => {
     render(<SecurityTab />);
     expect(
-      screen.getByRole("button", { name: /sign out all sessions/i }),
+      screen.getByRole("button", { name: /sign out all other sessions/i }),
     ).toBeInTheDocument();
   });
 
@@ -1426,5 +1427,145 @@ describe("SecurityTab — 2FA verification security", () => {
     const err = getVerificationCodeError("12345678");
     expect(err).not.toContain("12345678");
     expect(err).not.toContain("12345");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Active sessions — per-session revoke + bulk "sign out all other sessions"
+// ---------------------------------------------------------------------------
+
+describe("SecurityTab — active sessions revocation", () => {
+  /**
+   * Drives a `DestructiveActionDialog` to completion: opens it via its trigger,
+   * types the confirmation token, and clicks the confirm button.
+   */
+  function confirmDestructiveAction(
+    triggerName: RegExp,
+    token: string,
+    confirmName: RegExp,
+  ) {
+    fireEvent.click(screen.getByRole("button", { name: triggerName }));
+    const input = screen.getByPlaceholderText(token);
+    fireEvent.change(input, { target: { value: token } });
+    fireEvent.click(screen.getByRole("button", { name: confirmName }));
+  }
+
+  const getBulkTrigger = () =>
+    screen.getByRole("button", { name: /^sign out all other sessions$/i });
+
+  it("marks the current session with a 'This device' badge and no sign-out control", () => {
+    render(<SecurityTab />);
+
+    const currentRow = screen
+      .getByText("Chrome on Windows")
+      .closest("li") as HTMLElement;
+    expect(currentRow).not.toBeNull();
+    expect(within(currentRow).getByText(/this device/i)).toBeInTheDocument();
+    // The current session must NOT expose a revoke control.
+    expect(
+      within(currentRow).queryByRole("button", { name: /sign out/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a distinctly-labelled sign-out control for each non-current session", () => {
+    render(<SecurityTab />);
+
+    expect(
+      screen.getByRole("button", { name: /sign out iphone 15 pro/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /sign out firefox on macos/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("bulk trigger is distinct from the per-session controls", () => {
+    render(<SecurityTab />);
+
+    const bulk = getBulkTrigger();
+    const perSession = screen.getByRole("button", {
+      name: /sign out iphone 15 pro/i,
+    });
+    expect(bulk).not.toBe(perSession);
+  });
+
+  it("bulk confirmation copy explicitly says the current device stays signed in", () => {
+    render(<SecurityTab />);
+
+    fireEvent.click(getBulkTrigger());
+
+    // The dialog spells out that the current session is excluded.
+    expect(
+      screen.getByText(/your current session on this device stays signed in/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/keeps this device signed in/i),
+    ).toBeInTheDocument();
+  });
+
+  it("revoking a single session removes only that session and keeps the rest", () => {
+    render(<SecurityTab />);
+
+    confirmDestructiveAction(
+      /sign out iphone 15 pro/i,
+      "REVOKE",
+      /sign out session/i,
+    );
+
+    expect(screen.queryByText("iPhone 15 Pro")).not.toBeInTheDocument();
+    // Current session and the other device remain.
+    expect(screen.getByText("Chrome on Windows")).toBeInTheDocument();
+    expect(screen.getByText("Firefox on macOS")).toBeInTheDocument();
+  });
+
+  it("the bulk action signs out every other session but keeps the current one", () => {
+    render(<SecurityTab />);
+
+    confirmDestructiveAction(
+      /^sign out all other sessions$/i,
+      "LOGOUT",
+      /sign out other sessions/i,
+    );
+
+    expect(screen.getByText("Chrome on Windows")).toBeInTheDocument();
+    expect(screen.queryByText("iPhone 15 Pro")).not.toBeInTheDocument();
+    expect(screen.queryByText("Firefox on macOS")).not.toBeInTheDocument();
+  });
+
+  it("shows an empty-state message and hides the bulk action once no other sessions remain", () => {
+    render(<SecurityTab />);
+
+    confirmDestructiveAction(
+      /^sign out all other sessions$/i,
+      "LOGOUT",
+      /sign out other sessions/i,
+    );
+
+    expect(
+      screen.getByText(/only signed in on this device/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^sign out all other sessions$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("announces a success status after the bulk sign-out", () => {
+    render(<SecurityTab />);
+
+    confirmDestructiveAction(
+      /^sign out all other sessions$/i,
+      "LOGOUT",
+      /sign out other sessions/i,
+    );
+
+    expect(
+      screen.getByText(/signed out of all other sessions/i),
+    ).toBeInTheDocument();
+  });
+
+  it("the sessions list is exposed as an accessible list", () => {
+    render(<SecurityTab />);
+    expect(
+      screen.getByRole("list", { name: /signed-in sessions/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/app/settings/preferences/components/security-tab.tsx
+++ b/app/settings/preferences/components/security-tab.tsx
@@ -18,6 +18,7 @@ import {
   Loader2,
   Link2,
   ShieldOff,
+  LogOut,
 } from "lucide-react";
 import { ErrorSummary } from "@/components/ui/error-summary";
 import ToggleCard from "@/components/common/toggle-card";
@@ -41,22 +42,48 @@ import {
 } from "@/utils/authUtils";
 import DestructiveActionDialog from "./destructive-action-dialog";
 import { DEMO_SECURITY, DEMO_CONNECTED_APPS } from "@/lib/demo-data";
-import { DEMO_SECURITY } from "@/lib/demo-data";
 import { generateTotpSecret, verifyTotpCode } from "@/lib/totp";
 import QRCode from "qrcode";
 
-const sessions = [
+/** A single signed-in device/session shown in the "Active sessions" card. */
+interface SessionRecord {
+  id: string;
+  name: string;
+  location: string;
+  status: string;
+  icon: typeof Monitor;
+  /**
+   * Marks the browser the user is currently viewing this page from. The current
+   * session is deliberately excluded from every revoke action so a user can
+   * never accidentally sign themselves out of the device they are on.
+   */
+  isCurrent: boolean;
+}
+
+const initialSessions: SessionRecord[] = [
   {
+    id: "session-chrome-windows",
     name: "Chrome on Windows",
     location: "Lagos, Nigeria",
     status: "Current session",
     icon: Monitor,
+    isCurrent: true,
   },
   {
+    id: "session-iphone",
     name: "iPhone 15 Pro",
     location: "Mobile app",
     status: "Last active 2 hours ago",
     icon: Smartphone,
+    isCurrent: false,
+  },
+  {
+    id: "session-firefox-macos",
+    name: "Firefox on macOS",
+    location: "Berlin, Germany",
+    status: "Last active yesterday",
+    icon: Monitor,
+    isCurrent: false,
   },
 ];
 
@@ -336,6 +363,47 @@ export default function SecurityTab({
   const [connectedApps, setConnectedApps] = useState(() => [
     ...DEMO_CONNECTED_APPS,
   ]);
+
+  // --- Active sessions -----------------------------------------------------
+  // The current session (the device the user is on) is never removable, so
+  // both the per-session revoke and the bulk "sign out all other sessions"
+  // action operate only on sessions where `isCurrent` is false.
+  const [sessions, setSessions] = useState<SessionRecord[]>(initialSessions);
+
+  const otherSessions = useMemo(
+    () => sessions.filter((session) => !session.isCurrent),
+    [sessions],
+  );
+
+  /** Signs out a single non-current session. The current session is a no-op. */
+  const handleRevokeSession = (sessionId: string) => {
+    const target = sessions.find((session) => session.id === sessionId);
+    if (!target || target.isCurrent) {
+      return;
+    }
+
+    setSessions((current) =>
+      current.filter((session) => session.id !== sessionId),
+    );
+    setStatus({
+      message: `Signed out of ${target.name}. That device must log in again to regain access.`,
+      type: "success",
+    });
+  };
+
+  /**
+   * Signs out every session except the current one. The current session is
+   * preserved explicitly so the user is never logged out of the device they
+   * are actively using — this is stated in the confirmation dialog copy.
+   */
+  const handleRevokeAllOtherSessions = () => {
+    setSessions((current) => current.filter((session) => session.isCurrent));
+    setStatus({
+      message:
+        "Signed out of all other sessions. Only this device stays signed in.",
+      type: "success",
+    });
+  };
 
   const handleRevokeApp = (appId: string) => {
     setConnectedApps((current) => current.filter((app) => app.id !== appId));
@@ -1518,53 +1586,116 @@ export default function SecurityTab({
             </div>
           </CardHeader>
           <CardContent className="space-y-4 pt-6">
-            {sessions.map((session) => {
-              const SessionIcon = session.icon;
+            <ul className="space-y-4" aria-label="Signed-in sessions">
+              {sessions.map((session) => {
+                const SessionIcon = session.icon;
 
-              return (
-                <div
-                  key={session.name}
-                  className="flex items-start gap-3 rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-white/10 dark:bg-white/5"
-                >
-                  <span className="mt-0.5 flex h-10 w-10 items-center justify-center rounded-2xl bg-zinc-900 text-white dark:bg-white dark:text-zinc-900">
-                    <SessionIcon className="size-4" />
-                  </span>
-                  <div className="space-y-1">
-                    <p className="font-medium text-zinc-900 dark:text-white">
-                      {session.name}
-                    </p>
-                    <p className="text-sm text-zinc-500 dark:text-zinc-400">
-                      {session.location}
-                    </p>
-                    <p className="text-xs text-zinc-400 dark:text-zinc-500">
-                      {session.status}
-                    </p>
+                return (
+                  <li
+                    key={session.id}
+                    className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-white/10 dark:bg-white/5 sm:flex-row sm:items-start sm:justify-between"
+                  >
+                    <div className="flex items-start gap-3">
+                      <span className="mt-0.5 flex h-10 w-10 items-center justify-center rounded-2xl bg-zinc-900 text-white dark:bg-white dark:text-zinc-900">
+                        <SessionIcon className="size-4" aria-hidden="true" />
+                      </span>
+                      <div className="space-y-1">
+                        <p className="flex flex-wrap items-center gap-2 font-medium text-zinc-900 dark:text-white">
+                          {session.name}
+                          {session.isCurrent && (
+                            <Badge
+                              variant="outline"
+                              className="border-emerald-500/20 bg-emerald-500/10 text-xs font-medium text-emerald-700 dark:text-emerald-300"
+                            >
+                              This device
+                            </Badge>
+                          )}
+                        </p>
+                        <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                          {session.location}
+                        </p>
+                        <p className="text-xs text-zinc-400 dark:text-zinc-500">
+                          {session.status}
+                        </p>
+                      </div>
+                    </div>
+
+                    {session.isCurrent ? (
+                      <p className="text-xs text-zinc-500 dark:text-zinc-400 sm:max-w-[9rem] sm:text-right">
+                        You&apos;re signed in here. This session can&apos;t be
+                        signed out remotely.
+                      </p>
+                    ) : (
+                      <DestructiveActionDialog
+                        triggerLabel="Sign out"
+                        triggerAriaLabel={`Sign out ${session.name}`}
+                        title={`Sign out ${session.name}`}
+                        description={`This signs out ${session.name} (${session.location}). It will need to log in again to regain access.`}
+                        impactItems={[
+                          `${session.name} will be signed out immediately.`,
+                          "Any in-progress actions on that device will be interrupted.",
+                          "You can sign in again on that device at any time.",
+                        ]}
+                        confirmationToken="REVOKE"
+                        confirmationLabel='Type "REVOKE" to continue'
+                        confirmLabel="Sign out session"
+                        onConfirm={() => handleRevokeSession(session.id)}
+                      />
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+
+            <div
+              data-search-label="Sign out all sessions"
+              className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-white/10 dark:bg-white/5"
+            >
+              {otherSessions.length > 0 ? (
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="flex items-start gap-3">
+                    <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-red-500/10 text-red-500">
+                      <LogOut className="size-4" aria-hidden="true" />
+                    </span>
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium text-zinc-900 dark:text-white">
+                        Sign out all other sessions
+                      </p>
+                      <p className="text-xs text-zinc-600 dark:text-zinc-400">
+                        Ends {otherSessions.length} other{" "}
+                        {otherSessions.length === 1 ? "session" : "sessions"} in
+                        one step. This device stays signed in.
+                      </p>
+                    </div>
+                  </div>
+                  <div className="shrink-0">
+                    <DestructiveActionDialog
+                      triggerLabel="Sign out all other sessions"
+                      title="Sign out all other sessions"
+                      description={`This signs out ${otherSessions.length} other ${
+                        otherSessions.length === 1 ? "session" : "sessions"
+                      } and keeps this device signed in.`}
+                      impactItems={[
+                        "Your current session on this device stays signed in.",
+                        "Every other signed-in browser or mobile app will need to log in again.",
+                        "Pending high-risk actions on those devices are interrupted until re-authentication.",
+                      ]}
+                      confirmationToken="LOGOUT"
+                      confirmationLabel='Type "LOGOUT" to continue'
+                      confirmLabel="Sign out other sessions"
+                      onConfirm={handleRevokeAllOtherSessions}
+                    />
                   </div>
                 </div>
-              );
-            })}
-
-            <div data-search-label="Sign out all sessions">
-              <DestructiveActionDialog
-                triggerLabel="Sign out all sessions"
-                title="Sign out every other session"
-                description="This will invalidate every session except the current browser."
-                impactItems={[
-                  "Every signed-in mobile or web session will need to log in again.",
-                  "Pending high-risk actions will be interrupted until re-authentication.",
-                  "This action should only be used if you suspect account access issues.",
-                ]}
-                confirmationToken="LOGOUT"
-                confirmationLabel='Type "LOGOUT" to continue'
-                confirmLabel="Force sign-out"
-                onConfirm={() =>
-                  setStatus({
-                    message:
-                      "Session reset requested. All other devices would be signed out.",
-                    type: "success",
-                  })
-                }
-              />
+              ) : (
+                <p
+                  className="text-sm text-zinc-600 dark:text-zinc-400"
+                  role="status"
+                >
+                  You&apos;re only signed in on this device. There are no other
+                  sessions to sign out.
+                </p>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/design/settings-ia.md
+++ b/design/settings-ia.md
@@ -80,7 +80,10 @@ Credential and session management.
   special char, matching confirm)
 - Two-factor authentication (TOTP): toggle with guided setup panel,
   6-digit code verification
-- Active sessions list with selective revocation
+- Active sessions list with two revoke paths:
+  - Per-session sign-out for each non-current device
+  - Bulk "Sign out all other sessions" that ends every session except the
+    current one (the current device is always excluded)
 - Recovery methods (collapsible disclosure)
 - API key management: create, rotate, revoke with destructive confirmation
 
@@ -89,9 +92,16 @@ Accessibility notes:
   inline error paragraphs.
 - The 2-FA setup panel is a `role="form"` region with a labelled `aria-label`;
   inline errors use `role="alert"`.
-- The sign-out-all-sessions and API key rotate/revoke actions both pass through
-  `DestructiveActionDialog`, which traps focus and requires a typed keyword
-  confirmation before enabling the destructive button.
+- The sessions list is a `<ul>` labelled "Signed-in sessions". The current
+  session is marked with a "This device" badge and exposes no revoke control;
+  each other session's trigger has a unique accessible name
+  (`Sign out <device name>`) so screen-reader users can tell them apart.
+- The per-session sign-out, bulk "Sign out all other sessions", and API key
+  rotate/revoke actions all pass through `DestructiveActionDialog`, which traps
+  focus and requires a typed keyword confirmation before enabling the
+  destructive button. The bulk dialog copy states explicitly that the current
+  device stays signed in. When no other sessions remain, the bulk action is
+  replaced by a `role="status"` empty-state message.
 
 ### Wallets (`wallets`)
 


### PR DESCRIPTION
Closes #743.

## What was Implemented

Adds a distinct **"Sign out all other sessions"** bulk revoke action to the Active sessions card in `security-tab.tsx`, alongside per-session sign-out controls. The current session is always excluded from both actions, and the bulk confirmation dialog states this explicitly.

## Changes

- **Stateful sessions** — converted the static `sessions` array into component state with an `isCurrent` flag and stable ids, so revokes actually update the list and the count badge.
- **Per-session revoke** — each non-current session gets its own guarded "Sign out" control. The current session shows a "This device" badge and **no** revoke control (it can't be signed out remotely).
- **Bulk action** — "Sign out all other sessions" is gated by the existing `DestructiveActionDialog` (rendered through `components/ui/dialog.tsx`, focus-trapped, requires typing `LOGOUT`). It excludes the current session and says so in the copy ("Your current session on this device stays signed in"). When no other sessions remain, it's replaced by a `role="status"` empty-state message.
- **Accessibility (WCAG 2.1 AA)** — added an optional `triggerAriaLabel` to `DestructiveActionDialog` so the repeated "Sign out" buttons get unique accessible names (e.g. "Sign out iPhone 15 Pro"). The sessions list is a labelled `<ul>`. Backward-compatible prop.
- **Bug fix** — removed a pre-existing duplicate `DEMO_SECURITY` import that broke the build for this component.
- **Docs** — documented the two revoke paths and their accessibility behavior in `design/settings-ia.md`.

## Responsive

Session rows and the bulk action stack vertically on small screens (`flex-col`) and lay out horizontally from `sm:` up, matching the Connected apps card pattern. Uses existing design tokens (zinc/red/emerald ring + bg utilities, `rounded-2xl`), light + dark mode.

## Tests

Added an 11-test suite to `security-tab.test.tsx` covering: the current-session badge, distinct per-session controls, the exclusion copy in the bulk dialog, single-session revoke, bulk revoke, the empty state, and the success announcement.

- `security-tab.test.tsx` — 100 passed
- `destructive-action-dialog.test.tsx` — 7 passed
- typecheck + lint clean on the changed files

### Note
Several unrelated test files in `app/settings/preferences/components/` (`wallets-section`, `account-section` — `DEMO_PROFILE is not defined`, `notifications-section.test.tsx` — malformed import, `settings-search.test.ts` — JSX in a `.ts` file) fail on `main` independently of this change and are out of scope here.
