### PR TITLE
feat: add a bulk sign-out-all-other-sessions action to security settings (Closes #743)

### DIFF
--- a/app/settings/preferences/components/security-tab.test.tsx
+++ b/app/settings/preferences/components/security-tab.test.tsx
@@ -127,16 +127,81 @@ describe("SecurityTab — initial render", () => {
     expect(screen.getByText("Large transfer approval")).toBeInTheDocument();
   });
 
-  it("renders the sign-out-all-sessions trigger", () => {
+  it("renders the sign-out-all-other-sessions trigger", () => {
     render(<SecurityTab />);
     expect(
-      screen.getByRole("button", { name: /sign out all sessions/i }),
+      screen.getByRole("button", { name: /sign out all other sessions/i }),
     ).toBeInTheDocument();
   });
 
   it("renders the recovery-methods disclosure element", () => {
     render(<SecurityTab />);
     expect(screen.getByText(/show recovery methods/i)).toBeInTheDocument();
+  });
+
+  it("renders a per-session sign-out button for non-current sessions", () => {
+    render(<SecurityTab />);
+    const signOutButton = screen.getByRole("button", { name: /sign out iphone 15 pro/i });
+    expect(signOutButton).toBeInTheDocument();
+  });
+
+  it("does not render a per-session sign-out button for the current session", () => {
+    render(<SecurityTab />);
+    expect(
+      screen.queryByRole("button", { name: /sign out chrome on windows/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the correct session count in the badge", () => {
+    render(<SecurityTab />);
+    expect(screen.getByText("2 devices")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session management — per-session revoke + bulk sign-out
+// ---------------------------------------------------------------------------
+
+describe("SecurityTab — session management", () => {
+  it("removes a single session when its sign-out button is clicked", () => {
+    render(<SecurityTab />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /sign out iphone 15 pro/i }),
+    );
+
+    expect(screen.queryByText("iPhone 15 Pro")).not.toBeInTheDocument();
+    expect(screen.getByText("Chrome on Windows")).toBeInTheDocument();
+    expect(screen.getByText("1 devices")).toBeInTheDocument();
+  });
+
+  it("keeps the current session after a single session is revoked", () => {
+    render(<SecurityTab />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /sign out iphone 15 pro/i }),
+    );
+
+    expect(screen.getByText("Chrome on Windows")).toBeInTheDocument();
+    expect(screen.getByText("Current session")).toBeInTheDocument();
+  });
+
+  it("signs out every other session while keeping the current device", async () => {
+    render(<SecurityTab />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /sign out all other sessions/i }),
+    );
+
+    // The confirmation dialog requires typing "LOGOUT" exactly.
+    const confirmInput = await screen.findByPlaceholderText("LOGOUT");
+    fireEvent.change(confirmInput, { target: { value: "LOGOUT" } });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /sign out all other sessions/i }),
+    );
+
+    expect(screen.queryByText("iPhone 15 Pro")).not.toBeInTheDocument();
+    expect(screen.getByText("Chrome on Windows")).toBeInTheDocument();
+    expect(screen.getByText("1 devices")).toBeInTheDocument();
   });
 });
 

--- a/app/settings/preferences/components/security-tab.tsx
+++ b/app/settings/preferences/components/security-tab.tsx
@@ -11,6 +11,7 @@ import {
   Download,
   EyeOff,
   KeyRound,
+  LogOut,
   Monitor,
   Plus,
   ShieldCheck,
@@ -41,24 +42,8 @@ import {
 } from "@/utils/authUtils";
 import DestructiveActionDialog from "./destructive-action-dialog";
 import { DEMO_SECURITY, DEMO_CONNECTED_APPS } from "@/lib/demo-data";
-import { DEMO_SECURITY } from "@/lib/demo-data";
 import { generateTotpSecret, verifyTotpCode } from "@/lib/totp";
 import QRCode from "qrcode";
-
-const sessions = [
-  {
-    name: "Chrome on Windows",
-    location: "Lagos, Nigeria",
-    status: "Current session",
-    icon: Monitor,
-  },
-  {
-    name: "iPhone 15 Pro",
-    location: "Mobile app",
-    status: "Last active 2 hours ago",
-    icon: Smartphone,
-  },
-];
 
 const initialApiKeys = [
   {
@@ -336,6 +321,41 @@ export default function SecurityTab({
   const [connectedApps, setConnectedApps] = useState(() => [
     ...DEMO_CONNECTED_APPS,
   ]);
+
+  const [sessions, setSessions] = useState([
+    {
+      id: "session-chrome-windows",
+      name: "Chrome on Windows",
+      location: "Lagos, Nigeria",
+      status: "Current session",
+      icon: Monitor,
+    },
+    {
+      id: "session-iphone",
+      name: "iPhone 15 Pro",
+      location: "Mobile app",
+      status: "Last active 2 hours ago",
+      icon: Smartphone,
+    },
+  ]);
+
+  const handleRevokeSession = (sessionId: string) => {
+    setSessions((current) => current.filter((s) => s.id !== sessionId));
+    setStatus({
+      message: "Session signed out. The device will need to re-authenticate.",
+      type: "success",
+    });
+    setTimeout(() => setStatus({ message: "", type: null }), 5000);
+  };
+
+  const handleRevokeAllOtherSessions = () => {
+    setSessions((current) => current.filter((s) => s.status === "Current session"));
+    setStatus({
+      message: "All other sessions signed out. You remain signed in on this device.",
+      type: "success",
+    });
+    setTimeout(() => setStatus({ message: "", type: null }), 5000);
+  };
 
   const handleRevokeApp = (appId: string) => {
     setConnectedApps((current) => current.filter((app) => app.id !== appId));
@@ -1523,13 +1543,13 @@ export default function SecurityTab({
 
               return (
                 <div
-                  key={session.name}
+                  key={session.id}
                   className="flex items-start gap-3 rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-white/10 dark:bg-white/5"
                 >
                   <span className="mt-0.5 flex h-10 w-10 items-center justify-center rounded-2xl bg-zinc-900 text-white dark:bg-white dark:text-zinc-900">
                     <SessionIcon className="size-4" />
                   </span>
-                  <div className="space-y-1">
+                  <div className="min-w-0 flex-1 space-y-1">
                     <p className="font-medium text-zinc-900 dark:text-white">
                       {session.name}
                     </p>
@@ -1540,30 +1560,38 @@ export default function SecurityTab({
                       {session.status}
                     </p>
                   </div>
+                  {session.status !== "Current session" && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleRevokeSession(session.id)}
+                      aria-label={`Sign out ${session.name}`}
+                      className="shrink-0 gap-1.5"
+                    >
+                      <LogOut className="h-4 w-4" />
+                      <span className="sr-only sm:not-sr-only">Sign out</span>
+                    </Button>
+                  )}
                 </div>
               );
             })}
 
-            <div data-search-label="Sign out all sessions">
+            <div data-search-label="Sign out all other sessions">
               <DestructiveActionDialog
-                triggerLabel="Sign out all sessions"
+                triggerLabel="Sign out all other sessions"
                 title="Sign out every other session"
-                description="This will invalidate every session except the current browser."
+                description="This will invalidate every session except the current browser. You will remain signed in on this device."
                 impactItems={[
-                  "Every signed-in mobile or web session will need to log in again.",
-                  "Pending high-risk actions will be interrupted until re-authentication.",
-                  "This action should only be used if you suspect account access issues.",
+                  "Every signed-in mobile or web session except this browser will need to log in again.",
+                  "The current session on this device is not affected.",
+                  "Pending high-risk actions on other devices will be interrupted until re-authentication.",
+                  "You can sign back in from any device at any time.",
                 ]}
                 confirmationToken="LOGOUT"
                 confirmationLabel='Type "LOGOUT" to continue'
-                confirmLabel="Force sign-out"
-                onConfirm={() =>
-                  setStatus({
-                    message:
-                      "Session reset requested. All other devices would be signed out.",
-                    type: "success",
-                  })
-                }
+                confirmLabel="Sign out all other sessions"
+                onConfirm={handleRevokeAllOtherSessions}
               />
             </div>
           </CardContent>


### PR DESCRIPTION
## Summary

Adds a **sign-out-all-other-sessions** bulk revoke action to the security settings, distinct from the per-session revoke control.

### Changes

- **Per-session revoke**: Each non-current session row now shows a `Sign out` button (with `LogOut` icon) that removes that single session
- **Bulk action**: Renamed from "Sign out all sessions" to "Sign out all other sessions". The confirmation dialog explicitly states the current session is not affected
- **State management**: Sessions are now tracked as state (not a static array), so revoking one or all updates the UI immediately
- **Confirmation copy**: Updated dialog title/description/impact items to clarify that the current device remains signed in
- **Tests**: Added new tests covering per-session sign-out, current-session protection, session count badge, and bulk sign-out flow

### QA

- [x] Per-session sign-out button is shown only for non-current sessions
- [x] Clicking per-session sign-out removes the session and updates the badge count
- [x] Bulk sign-out (requires typing "LOGOUT") removes all non-current sessions
- [x] Current session is preserved after both individual and bulk revoke
- [x] All 97 tests pass (no regressions)