### PR TITLE
fix: resolve 13 syntax errors in faq-card.tsx and RechartsMiniBarChart.tsx

### DIFF
--- a/components/common/faq-card.test.tsx
+++ b/components/common/faq-card.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import FaqCard from "./faq-card";
+import React from "react";
 
 const mockPush = vi.fn();
 
@@ -10,6 +11,30 @@ vi.mock("next/navigation", () => ({
     push: mockPush,
     replace: vi.fn(),
   }),
+}));
+
+// highlight-text renders plain text when query is empty, so no mark tags expected
+vi.mock("@/components/common/highlight-text", () => ({
+  HighlightText: ({
+    text,
+    query,
+  }: {
+    text: string;
+    query: string;
+  }) => {
+    if (!query) return <>{text}</>;
+    return (
+      <>
+        {text.split(new RegExp(`(${query})`, "gi")).map((part, i) =>
+          part.toLowerCase() === query.toLowerCase() ? (
+            <mark key={i}>{part}</mark>
+          ) : (
+            part
+          ),
+        )}
+      </>
+    );
+  },
 }));
 
 const defaultProps = {
@@ -22,6 +47,8 @@ describe("FaqCard", () => {
   beforeEach(() => {
     mockPush.mockClear();
   });
+
+  // ── Basic rendering ──────────────────────────────────────────────────
 
   it("renders title and subtitle", () => {
     render(<FaqCard {...defaultProps} />);
@@ -39,23 +66,22 @@ describe("FaqCard", () => {
     expect(icon).toBeInTheDocument();
   });
 
+  // ── Accessibility / role ─────────────────────────────────────────────
+
   it("uses role='button' and is keyboard-focusable", () => {
     render(<FaqCard {...defaultProps} />);
-    const card = screen.getByRole("button", {
-      name: /Account Management/i,
-    });
+    const card = screen.getByRole("button", { name: /Account Management/i });
     expect(card).toBeInTheDocument();
     expect(card).toHaveAttribute("tabIndex", "0");
   });
 
-  it("has an aria-label that includes title and subtitle", () => {
+  it("has an aria-label equal to the title when articleCount is not provided", () => {
     render(<FaqCard {...defaultProps} />);
     const card = screen.getByRole("button");
-    expect(card).toHaveAttribute(
-      "aria-label",
-      "Account Management: Update your profile, reset your password, and manage your account.",
-    );
+    expect(card).toHaveAttribute("aria-label", "Account Management");
   });
+
+  // ── Navigation ───────────────────────────────────────────────────────
 
   it("navigates on click", () => {
     render(<FaqCard {...defaultProps} />);
@@ -80,6 +106,74 @@ describe("FaqCard", () => {
     fireEvent.click(screen.getByRole("button"));
     expect(mockPush).toHaveBeenCalledWith("/settings/preferences");
   });
+
+  // ── icon prop ────────────────────────────────────────────────────────
+
+  it("renders an icon when icon prop is provided", () => {
+    render(
+      <FaqCard
+        {...defaultProps}
+        icon={<span data-testid="custom-icon">★</span>}
+      />,
+    );
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+
+  it("does not render icon wrapper div when icon prop is omitted", () => {
+    const { container } = render(<FaqCard {...defaultProps} />);
+    // The icon wrapper is a div with aria-hidden=true and a specific size class
+    const iconWrapperDiv = container.querySelector(
+      "div[aria-hidden='true'].w-10.h-10",
+    );
+    expect(iconWrapperDiv).not.toBeInTheDocument();
+  });
+
+  // ── articleCount prop ────────────────────────────────────────────────
+
+  it("renders article count badge when articleCount is provided", () => {
+    render(<FaqCard {...defaultProps} articleCount={6} />);
+    expect(screen.getByText("6 articles")).toBeInTheDocument();
+  });
+
+  it("renders '1 article' (singular) when articleCount is 1", () => {
+    render(<FaqCard {...defaultProps} articleCount={1} />);
+    expect(screen.getByText("1 article")).toBeInTheDocument();
+  });
+
+  it("includes articleCount in aria-label when provided", () => {
+    render(<FaqCard {...defaultProps} articleCount={6} />);
+    const card = screen.getByRole("button");
+    expect(card).toHaveAttribute(
+      "aria-label",
+      "Account Management: 6 articles",
+    );
+  });
+
+  it("does not render article count badge when articleCount is not provided", () => {
+    render(<FaqCard {...defaultProps} />);
+    expect(screen.queryByText(/articles?/)).not.toBeInTheDocument();
+  });
+
+  // ── highlightQuery prop ──────────────────────────────────────────────
+
+  it("highlights matching text in title when highlightQuery is provided", () => {
+    render(<FaqCard {...defaultProps} highlightQuery="Account" />);
+    const mark = screen.getByText("Account");
+    expect(mark.tagName).toBe("MARK");
+  });
+
+  it("highlights matching text in subtitle when highlightQuery is provided", () => {
+    render(<FaqCard {...defaultProps} highlightQuery="profile" />);
+    const mark = screen.getByText("profile");
+    expect(mark.tagName).toBe("MARK");
+  });
+
+  it("renders plain text when no highlightQuery is provided", () => {
+    render(<FaqCard {...defaultProps} />);
+    expect(screen.queryByRole("mark")).not.toBeInTheDocument();
+  });
+
+  // ── Styling ──────────────────────────────────────────────────────────
 
   it("clamps subtitle to 2 lines", () => {
     render(<FaqCard {...defaultProps} />);
@@ -119,18 +213,11 @@ describe("FaqCard", () => {
     expect(inner.className).toMatch(/items-start/);
   });
 
-  it("renders text with theme-aware colors", () => {
-    render(<FaqCard {...defaultProps} />);
-    const title = screen.getByText("Account Management");
-    expect(title.className).toMatch(/text-zinc-900/);
-    expect(title.className).toMatch(/dark:text-white/);
-  });
-
   it("renders long text without layout breakage", () => {
     render(
       <FaqCard
         title="A very long FAQ card title that should still wrap gracefully without breaking the layout"
-        subtitle="This is an extremely long subtitle that goes on and on and on and on and on and on and on and on and on and on and on and on and on and on to test that the card handles overflow gracefully and the icon stays aligned with the title."
+        subtitle="This is an extremely long subtitle that goes on and on and on and on and on and on and on to test that the card handles overflow gracefully and the icon stays aligned with the title."
       />,
     );
     const card = screen.getByRole("button");

--- a/components/common/faq-card.tsx
+++ b/components/common/faq-card.tsx
@@ -3,22 +3,16 @@ import { SquareArrowOutUpRight } from "lucide-react";
 import React from "react";
 import { useRouter } from "next/navigation";
 import { FaqCardProps } from "@/types/ui";
- feat/help-support-search-first
 import { HighlightText } from "@/components/common/highlight-text";
-
 import { cn } from "@/utils/commonUtils";
- main
 
 const FaqCard: React.FC<FaqCardProps> = ({
   title,
   subtitle,
   link,
- feat/help-support-search-first
   highlightQuery,
-
   icon,
   articleCount,
- main
 }) => {
   const router = useRouter();
 
@@ -36,47 +30,39 @@ const FaqCard: React.FC<FaqCardProps> = ({
   return (
     <div
       onClick={handleCardClick}
-      role="link"
+      onKeyDown={handleKeyDown}
+      role="button"
       tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          handleCardClick();
-        }
-      }}
       aria-label={
         articleCount !== undefined
           ? `${title}: ${articleCount} article${articleCount !== 1 ? "s" : ""}`
           : title
       }
-      className="w-full bg-[#121212] border border-[#2E2E2E] rounded-xl p-4 sm:p-5 md:p-6 hover:shadow-2xl hover:scale-105 transition-all duration-300 ease-in-out cursor-pointer"
+      className={cn(
+        "w-full rounded-xl border p-5 transition-all duration-200 cursor-pointer",
+        "bg-white dark:bg-[#121212] border-zinc-200 dark:border-[#2E2E2E]",
+        "hover:shadow-md hover:border-zinc-300 dark:hover:border-zinc-600",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#121212]",
+      )}
     >
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
- feat/help-support-search-first
-        <div className="flex-1">
-          <h3 className="text-base  font-semibold text-white mb-1">
-            <HighlightText text={title} query={highlightQuery || ""} />
-          </h3>
-          <p className="line-clamp-2 text-sm  text-[#707070]">
-            <HighlightText text={subtitle} query={highlightQuery || ""} />
-          </p>
-
+      <div className="flex flex-col sm:flex-row items-start justify-between gap-4">
         <div className="flex items-start gap-3 flex-1 min-w-0">
           {icon && (
             <div
-              className="flex-shrink-0 flex justify-center items-center border border-[#2E2E2E] rounded-lg w-10 h-10"
+              className="flex-shrink-0 flex justify-center items-center border border-zinc-200 dark:border-[#2E2E2E] rounded-lg w-10 h-10"
               aria-hidden="true"
             >
               {icon}
             </div>
           )}
           <div className="flex-1 min-w-0">
-            <h3 className="text-base font-semibold text-white mb-1">
-              {title}
+            <h3 className="text-base font-semibold text-zinc-900 dark:text-white mb-1">
+              <HighlightText text={title} query={highlightQuery || ""} />
             </h3>
-            <p className="line-clamp-2 text-sm text-[#707070]">{subtitle}</p>
+            <p className="line-clamp-2 text-sm text-zinc-500 dark:text-[#707070] mt-1">
+              <HighlightText text={subtitle} query={highlightQuery || ""} />
+            </p>
           </div>
- main
         </div>
 
         <div className="flex items-center gap-2 flex-shrink-0">
@@ -85,8 +71,11 @@ const FaqCard: React.FC<FaqCardProps> = ({
               {articleCount} article{articleCount !== 1 ? "s" : ""}
             </span>
           )}
-          <div className="flex justify-center items-center border border-[#2E2E2E] rounded-lg w-8 h-8 min-w-[2rem] min-h-[2rem]">
-            <SquareArrowOutUpRight size={18} color="#E5E5E5" />
+          <div className="flex justify-center items-center border border-zinc-200 dark:border-[#2E2E2E] rounded-lg w-8 h-8 min-w-[2rem] min-h-[2rem] shrink-0 mt-0.5">
+            <SquareArrowOutUpRight
+              size={18}
+              className="text-zinc-700 dark:text-[#E5E5E5]"
+            />
           </div>
         </div>
       </div>

--- a/components/dashboard/RechartsMiniBarChart.test.tsx
+++ b/components/dashboard/RechartsMiniBarChart.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
- design-system/mini-bar-chart-dark-tokens
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { RechartsMiniBarChart } from "./RechartsMiniBarChart";
 
 vi.mock("recharts", () => {
@@ -46,7 +45,13 @@ vi.mock("recharts", () => {
     />
   );
 
-  const MockXAxis = ({ dataKey, hide }: { dataKey: string; hide?: boolean }) => (
+  const MockXAxis = ({
+    dataKey,
+    hide,
+  }: {
+    dataKey: string;
+    hide?: boolean;
+  }) => (
     <div data-testid="x-axis" data-key={dataKey} data-hide={String(hide)} />
   );
 
@@ -76,14 +81,14 @@ vi.mock("recharts", () => {
   };
 });
 
-describe("RechartsMiniBarChart", () => {
-  const sampleData = [
-    { value: 40 },
-    { value: 70 },
-    { value: 45 },
-  ];
+const sampleData = [{ value: 40 }, { value: 70 }, { value: 45 }];
 
-  // ── Basic rendering ───────────────────────────────────────────────────
+describe("RechartsMiniBarChart", () => {
+  afterEach(() => {
+    document.documentElement.classList.remove("dark");
+  });
+
+  // ── Basic rendering ────────────────────────────────────────────────────
 
   it("renders a chart when data is provided", () => {
     render(<RechartsMiniBarChart data={sampleData} />);
@@ -98,9 +103,7 @@ describe("RechartsMiniBarChart", () => {
     render(<RechartsMiniBarChart data={[]} />);
 
     expect(screen.queryByTestId("bar-chart")).not.toBeInTheDocument();
-    expect(
-      screen.getByText("No data")
-    ).toBeInTheDocument();
+    expect(screen.getByText("No data")).toBeInTheDocument();
   });
 
   it("uses default fill when no cssVar or color is provided", () => {
@@ -110,7 +113,7 @@ describe("RechartsMiniBarChart", () => {
     expect(bar).toHaveAttribute("data-fill", "var(--chart-1)");
   });
 
-  // ── cssVar prop ───────────────────────────────────────────────────────
+  // ── cssVar prop ────────────────────────────────────────────────────────
 
   it("uses the cssVar prop to build var(--<name>) fill", () => {
     render(<RechartsMiniBarChart data={sampleData} cssVar="--chart-2" />);
@@ -125,14 +128,14 @@ describe("RechartsMiniBarChart", () => {
         data={sampleData}
         cssVar="--chart-3"
         color="#ff0000"
-      />
+      />,
     );
 
     const bar = screen.getByTestId("bar");
     expect(bar).toHaveAttribute("data-fill", "var(--chart-3)");
   });
 
-  // ── color prop ────────────────────────────────────────────────────────
+  // ── color prop ─────────────────────────────────────────────────────────
 
   it("uses the color prop as static fill when cssVar is not set", () => {
     render(<RechartsMiniBarChart data={sampleData} color="#4f6fff" />);
@@ -141,7 +144,32 @@ describe("RechartsMiniBarChart", () => {
     expect(bar).toHaveAttribute("data-fill", "#4f6fff");
   });
 
-  // ── height prop ───────────────────────────────────────────────────────
+  it("accepts CSS variable string via color prop", () => {
+    render(
+      <RechartsMiniBarChart data={sampleData} color="var(--chart-blue)" />,
+    );
+
+    const bar = screen.getByTestId("bar");
+    expect(bar).toHaveAttribute("data-fill", "var(--chart-blue)");
+  });
+
+  it("renders with all three semantic chart color tokens via color prop", () => {
+    const colors = [
+      "var(--chart-blue)",
+      "var(--chart-green)",
+      "var(--chart-amber)",
+    ];
+
+    for (const color of colors) {
+      const { unmount } = render(
+        <RechartsMiniBarChart data={sampleData} color={color} />,
+      );
+      expect(screen.getByTestId("bar")).toHaveAttribute("data-fill", color);
+      unmount();
+    }
+  });
+
+  // ── height prop ────────────────────────────────────────────────────────
 
   it("renders with default height of 3rem", () => {
     const { container } = render(<RechartsMiniBarChart data={sampleData} />);
@@ -152,14 +180,14 @@ describe("RechartsMiniBarChart", () => {
 
   it("renders with custom height", () => {
     const { container } = render(
-      <RechartsMiniBarChart data={sampleData} height="6rem" />
+      <RechartsMiniBarChart data={sampleData} height="6rem" />,
     );
 
     const wrapper = container.firstElementChild as HTMLElement;
     expect(wrapper.style.height).toBe("6rem");
   });
 
-  // ── ariaLabel prop ────────────────────────────────────────────────────
+  // ── ariaLabel prop ─────────────────────────────────────────────────────
 
   it("uses default aria label", () => {
     render(<RechartsMiniBarChart data={sampleData} />);
@@ -173,7 +201,7 @@ describe("RechartsMiniBarChart", () => {
       <RechartsMiniBarChart
         data={sampleData}
         ariaLabel="Revenue mini chart"
-      />
+      />,
     );
 
     const wrapper = screen.getByLabelText("Revenue mini chart");
@@ -187,7 +215,7 @@ describe("RechartsMiniBarChart", () => {
     expect(wrapper).toHaveAttribute("role", "img");
   });
 
-  // ── Chart data transformation ─────────────────────────────────────────
+  // ── Chart data transformation ──────────────────────────────────────────
 
   it("transforms data with index-based name for XAxis", () => {
     render(<RechartsMiniBarChart data={sampleData} />);
@@ -209,7 +237,7 @@ describe("RechartsMiniBarChart", () => {
     expect(margin).toEqual({ top: 0, right: 0, left: 0, bottom: 0 });
   });
 
-  // ── Bar props ─────────────────────────────────────────────────────────
+  // ── Bar props ──────────────────────────────────────────────────────────
 
   it("bars use dataKey='value'", () => {
     render(<RechartsMiniBarChart data={sampleData} />);
@@ -226,7 +254,7 @@ describe("RechartsMiniBarChart", () => {
     expect(radius).toEqual([4, 4, 0, 0]);
   });
 
-  // ── XAxis props ───────────────────────────────────────────────────────
+  // ── XAxis props ────────────────────────────────────────────────────────
 
   it("XAxis uses dataKey='name' and is hidden", () => {
     render(<RechartsMiniBarChart data={sampleData} />);
@@ -236,7 +264,7 @@ describe("RechartsMiniBarChart", () => {
     expect(xAxis).toHaveAttribute("data-hide", "true");
   });
 
-  // ── Tooltip props ─────────────────────────────────────────────────────
+  // ── Tooltip props ──────────────────────────────────────────────────────
 
   it("tooltip uses cursor={false}", () => {
     render(<RechartsMiniBarChart data={sampleData} />);
@@ -250,7 +278,7 @@ describe("RechartsMiniBarChart", () => {
 
     const tooltip = screen.getByTestId("tooltip");
     const style = JSON.parse(
-      tooltip.getAttribute("data-contentstyle") || "{}"
+      tooltip.getAttribute("data-contentstyle") || "{}",
     );
 
     expect(style.background).toBe("var(--chart-tooltip-bg)");
@@ -268,7 +296,7 @@ describe("RechartsMiniBarChart", () => {
     expect(tooltip).toHaveAttribute("data-formatter-result", "42%");
   });
 
-  // ── Edge cases ────────────────────────────────────────────────────────
+  // ── Edge cases ─────────────────────────────────────────────────────────
 
   it("handles single data point", () => {
     render(<RechartsMiniBarChart data={[{ value: 100 }]} />);
@@ -289,131 +317,29 @@ describe("RechartsMiniBarChart", () => {
   it("does not render chart content when data is empty", () => {
     render(<RechartsMiniBarChart data={[]} />);
 
-    expect(screen.queryByTestId("responsive-container")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("responsive-container"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByTestId("bar-chart")).not.toBeInTheDocument();
     expect(screen.queryByTestId("bar")).not.toBeInTheDocument();
     expect(screen.queryByTestId("tooltip")).not.toBeInTheDocument();
   });
 
-  it("renders aria-label on empty state", () => {
+  it("renders aria-label on empty state wrapper", () => {
     render(<RechartsMiniBarChart data={[]} />);
 
     const wrapper = screen.getByLabelText("Mini bar chart");
     expect(wrapper).toBeInTheDocument();
   });
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { RechartsMiniBarChart } from "./RechartsMiniBarChart";
-
-const defaultData = [
-  { value: 40 },
-  { value: 70 },
-  { value: 30 },
-  { value: 60 },
-];
-
-describe("RechartsMiniBarChart", () => {
-  afterEach(() => {
-    document.documentElement.classList.remove("dark");
-  });
-
-  it("renders with basic data", () => {
-    const { container } = render(
-      <RechartsMiniBarChart data={defaultData} color="var(--chart-blue)" />,
-    );
-
-    expect(
-      container.querySelector(".recharts-responsive-container"),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("img")).toHaveAttribute(
-      "aria-label",
-      "Mini bar chart",
-    );
-  });
-
-  it("renders with custom aria label and height", () => {
-    render(
-      <RechartsMiniBarChart
-        data={defaultData}
-        color="var(--chart-green)"
-        height="5rem"
-        ariaLabel="Revenue mini chart"
-      />,
-    );
-
-    const chart = screen.getByRole("img");
-    expect(chart).toHaveAttribute("aria-label", "Revenue mini chart");
-    expect(chart).toHaveStyle("height: 5rem");
-  });
-
-  it("renders with empty data without crashing", () => {
-    const { container } = render(
-      <RechartsMiniBarChart data={[]} color="var(--chart-blue)" />,
-    );
-
-    expect(
-      container.querySelector(".recharts-responsive-container"),
-    ).toBeInTheDocument();
-  });
-
-  it("renders with single data point", () => {
-    render(
-      <RechartsMiniBarChart
-        data={[{ value: 100 }]}
-        color="var(--chart-blue)"
-      />,
-    );
-
-    expect(screen.getByRole("img")).toBeInTheDocument();
-  });
-
-  it("renders with aria attributes for accessibility", () => {
-    render(
-      <RechartsMiniBarChart data={defaultData} color="var(--chart-blue)" />,
-    );
-
-    const chart = screen.getByRole("img");
-    expect(chart).toHaveAttribute("aria-label", "Mini bar chart");
-  });
-
-  it("renders with css variable color and produces a responsive container", () => {
-    const { container } = render(
-      <RechartsMiniBarChart
-        data={defaultData}
-        color="var(--chart-amber)"
-      />,
-    );
-
-    expect(
-      container.querySelector(".recharts-responsive-container"),
-    ).toBeInTheDocument();
-  });
-
-  it("renders with all three semantic chart color tokens", () => {
-    const colors = [
-      "var(--chart-blue)",
-      "var(--chart-green)",
-      "var(--chart-amber)",
-    ];
-
-    for (const color of colors) {
-      const { container, unmount } = render(
-        <RechartsMiniBarChart data={defaultData} color={color} />,
-      );
-
-      expect(
-        container.querySelector(".recharts-responsive-container"),
-      ).toBeInTheDocument();
-      unmount();
-    }
-  });
+  // ── Dark mode ──────────────────────────────────────────────────────────
 
   it("renders correctly in dark mode context", () => {
     document.documentElement.classList.add("dark");
 
     render(
       <RechartsMiniBarChart
-        data={defaultData}
+        data={sampleData}
         color="var(--chart-blue)"
         ariaLabel="Dark mode chart"
       />,
@@ -423,7 +349,4 @@ describe("RechartsMiniBarChart", () => {
     expect(chart).toHaveAttribute("aria-label", "Dark mode chart");
     expect(document.documentElement.classList.contains("dark")).toBe(true);
   });
-
-
- main
 });

--- a/components/dashboard/RechartsMiniBarChart.tsx
+++ b/components/dashboard/RechartsMiniBarChart.tsx
@@ -12,7 +12,6 @@ export interface RechartsMiniBarChartProps {
    */
   data: { value: number }[];
   /**
-design-system/mini-bar-chart-dark-tokens
    * CSS custom property name to use for the bar fill color (e.g. `"--chart-1"`).
    * The property is referenced as `var(<cssVar>)` so it reacts to theme changes
    * without a page reload.
@@ -24,18 +23,10 @@ design-system/mini-bar-chart-dark-tokens
   /**
    * Static color value for the bar fill (e.g. `"#3b82f6"` or `"rgb(59,130,246)"`).
    * Ignored when `cssVar` is set. Use `cssVar` for theme‑aware charts.
-
-   * The fill color for the bars — pass a CSS `<color>` value or a `var(…)` reference
-   * to a theme token (e.g. `"var(--chart-blue)"`) so the chart adapts to dark mode.
- main
    */
   color?: string;
   /**
- design-system/mini-bar-chart-dark-tokens
    * Optional height of the chart container (e.g. `"3rem"`). Defaults to `"3rem"`.
-
-   * Optional height of the chart container (e.g. '3rem'). Defaults to '3rem'.
- main
    */
   height?: string;
   /**
@@ -47,7 +38,6 @@ design-system/mini-bar-chart-dark-tokens
 /**
  * A lightweight, responsive mini bar chart using Recharts.
  *
- design-system/mini-bar-chart-dark-tokens
  * Bar fill is driven by a CSS custom property so the chart adapts to theme
  * changes (light/dark) without a page reload. Tooltip background, text, and
  * border also use CSS variables defined in `app/globals.css` for consistent
@@ -62,12 +52,6 @@ design-system/mini-bar-chart-dark-tokens
  * ```tsx
  * <RechartsMiniBarChart data={data} color="#4f6fff" />
  * ```
-
- * Bar and tooltip colours are driven by CSS custom properties defined in
- * `globals.css` (`--chart-blue`, `--chart-green`, `--chart-amber`,
- * `--chart-tooltip-bg`) so they automatically switch between light and dark
- * values when the `.dark` class is toggled on `<html>`.
- main
  */
 export const RechartsMiniBarChart: React.FC<RechartsMiniBarChartProps> = ({
   data,
@@ -76,6 +60,7 @@ export const RechartsMiniBarChart: React.FC<RechartsMiniBarChartProps> = ({
   height = "3rem",
   ariaLabel = "Mini bar chart",
 }) => {
+  // Transform data to include a simple index label for XAxis (hidden).
   const transformedData = data.map((d, i) => ({ ...d, name: i.toString() }));
 
   // Resolve fill value: prefer cssVar, fall back to color, fall back to --chart-1
@@ -119,29 +104,9 @@ export const RechartsMiniBarChart: React.FC<RechartsMiniBarChartProps> = ({
           className="flex items-center justify-center w-full h-full text-xs text-muted-foreground"
           aria-label="No chart data available"
         >
- design-system/mini-bar-chart-dark-tokens
           No data
         </div>
       )}
-
-          <XAxis dataKey="name" hide />
-          <Tooltip
-            cursor={false}
-            contentStyle={{
-              background: "var(--chart-tooltip-bg)",
-              border: "1px solid var(--chart-tooltip-border, #e4e4e7)",
-              borderRadius: "6px",
-              boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-              fontSize: "12px",
-            }}
-            formatter={(value) =>
-              typeof value === "number" ? `${value}%` : `${value ?? ""}`
-            }
-          />
-          <Bar dataKey="value" fill={color} radius={[4, 4, 0, 0]} />
-        </BarChart>
-      </ResponsiveContainer>
- main
     </div>
   );
 };


### PR DESCRIPTION
## Problem

`components/common/faq-card.tsx` and `components/dashboard/RechartsMiniBarChart.tsx` could not be parsed by TypeScript, contributing 8 and 5 errors respectively (13 total) to the repository's error count. Both files had raw branch-name tokens embedded as literal source text — the signature of a forced merge (`-X theirs`) at `9b6e151` that dropped conflict markers silently.

## Errors before / after

| File | Before | After |
|---|---|---|
| `components/common/faq-card.tsx` | 8 errors | 0 |
| `components/dashboard/RechartsMiniBarChart.tsx` | 5 errors | 0 |
| **Repo total** | **107** | **94** |

## Decision: reconstruct from history, not rewrite

Both files had clean revisions within a few commits of HEAD. Reconstructing is strongly preferred over invention.

### faq-card.tsx — three branches reconciled

| Commit | Contribution |
|---|---|
| `5c8eade` | Design-token polish: `cn()`, `role="button"`, `focus-visible` ring, `zinc-*` tokens, extracted `handleKeyDown` |
| `80d3bf4` | `icon` prop with wrapper div, `articleCount` badge, count-aware `aria-label` |
| `9fec670` | `highlightQuery` prop, `HighlightText` on title and subtitle |

All 6 props (`title`, `subtitle`, `link`, `highlightQuery`, `icon`, `articleCount`) were already declared in `FaqCardProps` (`types/ui.ts`) — no type changes needed.

### RechartsMiniBarChart.tsx — restored from `4892ce9`

The design-token commit (`4892ce9 fix: theme RechartsMiniBarChart colors from design tokens`) is the last clean revision. The `cssVar` prop, `var(--chart-tooltip-*)` contentStyle, and empty-state fallback branch are all preserved. The forced merge had interleaved content from `design-system/mini-bar-chart-dark-tokens` and `main` without markers.

Both test files (`faq-card.test.tsx`, `RechartsMiniBarChart.test.tsx`) had the same merge-conflict duplication (two `describe` blocks) and were also cleaned up.

## Component contracts and caller confirmation

**`FaqCard(title, subtitle, link?, highlightQuery?, icon?, articleCount?)`**
- `role="button"`, `tabIndex=0`, navigates on click / Enter / Space
- `aria-label`: `"<title>: <n> articles"` when `articleCount` is set, else `"<title>"`
- Callers in `app/help/support/page.tsx` pass `icon`, `articleCount`, `highlightQuery` ✅

**`RechartsMiniBarChart(data, cssVar?, color?, height?, ariaLabel?)`**
- fill resolves as `var(<cssVar>)` > `color` > `var(--chart-1)`
- Callers in `components/dashboard/account-summary-card.tsx` use `cssVar`, `color`, `ariaLabel`, `height` ✅

## Verification

```
npx tsc --noEmit:  107 errors → 94 (−13)
vitest run:        49/49 tests pass (23 faq-card, 26 RechartsMiniBarChart)
npm run lint:      exit 0
```

No `@ts-ignore`, `@ts-expect-error`, or `tsconfig` exclusion was used.

## Files changed

- `components/common/faq-card.tsx` — reconstructed
- `components/common/faq-card.test.tsx` — deduped and updated for new contract
- `components/dashboard/RechartsMiniBarChart.tsx` — restored from `4892ce9`
- `components/dashboard/RechartsMiniBarChart.test.tsx` — deduped

Closes #1158