### PR TITLE
feat: add deterministic UTC-based time-window validation for analytic…

### DIFF
--- a/components/analytics/client-analytics-view.tsx
+++ b/components/analytics/client-analytics-view.tsx
@@ -7,6 +7,12 @@ import { Calendar } from "@/components/ui/calendar";
 import Skeleton from "@/components/ui/skeleton";
 import { cn } from "@/utils/commonUtils";
 import type { AnalyticsViewsProps, AnalyticsDataPoint } from "./analytics-view";
+import {
+  createUtcRangePredicate,
+  parseAnalyticsTimeWindow,
+  type AnalyticsDatePreset,
+  type TimeWindowError,
+} from "@/utils/analyticsTimeWindow";
 
 const AnalyticsViews = dynamic(() => import("./analytics-view"), {
   ssr: false,
@@ -29,22 +35,24 @@ const MONTH_NAMES: Record<string, number> = {
   dec: 11, december: 11,
 };
 
-function monthNameToDate(month: string): Date {
+/**
+ * Converts a month name (e.g. "Jan", "September") to a Date representing
+ * the 15th of that month in the current UTC year.
+ *
+ * Uses UTC to avoid DST-related day shifts when the month name is resolved
+ * to a concrete date.
+ */
+function monthNameToUtcDate(month: string): Date {
   const lower = month.toLowerCase();
   const monthIndex = MONTH_NAMES[lower] ?? 0;
-  const now = new Date();
-  const year = now.getFullYear();
-  // Use the 15th as a representative day for the month
-  return new Date(year, monthIndex, 15);
-}
-
-function toDateOnly(d: Date): Date {
-  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const year = new Date().getUTCFullYear();
+  // Use the 15th as a representative day for the month (UTC)
+  return new Date(Date.UTC(year, monthIndex, 15));
 }
 
 // ── date-range presets ─────────────────────────────────────────────────────
 
-export type DateRangePreset = "7d" | "30d" | "90d" | "custom";
+export type DateRangePreset = AnalyticsDatePreset;
 
 export interface DateRangeValue {
   preset: DateRangePreset;
@@ -140,44 +148,43 @@ function DateRangePicker({ value, onChange }: DateRangePickerProps) {
 
 // ── data filtering ─────────────────────────────────────────────────────────
 
-function getPresetStartDate(preset: DateRangePreset): Date {
-  const now = toDateOnly(new Date());
-  switch (preset) {
-    case "7d":
-      return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-    case "30d":
-      return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
-    case "90d":
-      return new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
-    default:
-      return now;
-  }
-}
-
+/**
+ * Filters analytics data points by the given date range.
+ *
+ * Uses the UTC-based {@link parseAnalyticsTimeWindow} pipeline so that:
+ * - DST transitions never shift the requested window.
+ * - Reversed / oversized / same-day ranges are rejected *before* filtering.
+ * - Month-name data points are normalised to UTC dates for deterministic
+ *   comparison.
+ *
+ * @returns An object with the filtered data and any validation error.
+ */
 function filterDataByRange(
   data: AnalyticsDataPoint[],
   range: DateRangeValue,
-): AnalyticsDataPoint[] {
-  const now = toDateOnly(new Date());
+): { filtered: AnalyticsDataPoint[]; error: TimeWindowError | null } {
+  const result = parseAnalyticsTimeWindow({
+    preset: range.preset,
+    from: range.from,
+    to: range.to,
+  });
 
-  let fromDate: Date;
-  let toDate: Date = now;
-
-  if (range.preset === "custom" && range.from && range.to) {
-    fromDate = range.from;
-    toDate = range.to;
-  } else {
-    fromDate = getPresetStartDate(range.preset);
+  if (!result.ok) {
+    // Validation failed — return all data with the error so the caller
+    // can surface the message.  Returning the unfiltered data avoids a
+    // blank screen; the error banner explains why filtering is skipped.
+    return { filtered: data, error: result.error };
   }
 
-  // Normalise bounds to midnight for day-level comparison
-  const fromNorm = toDateOnly(fromDate);
-  const toNorm = toDateOnly(toDate);
+  const { from, to } = result.window;
+  const predicate = createUtcRangePredicate(from, to);
 
-  return data.filter((point) => {
-    const pointDate = monthNameToDate(point.month);
-    return pointDate >= fromNorm && pointDate <= toNorm;
+  const filtered = data.filter((point) => {
+    const pointDate = monthNameToUtcDate(point.month);
+    return predicate(pointDate);
   });
+
+  return { filtered, error: null };
 }
 
 // ── component ──────────────────────────────────────────────────────────────
@@ -223,9 +230,10 @@ export default function ClientAnalyticsView(props: ClientAnalyticsViewProps) {
     [onDateRangeChange],
   );
 
-  // Filter data based on selected date range
-  const filteredData = useMemo(() => {
-    if (!viewProps.data || viewProps.data.length === 0) return viewProps.data;
+  // Validate and filter data based on selected date range
+  const { filtered: filteredData, error: timeWindowError } = useMemo(() => {
+    if (!viewProps.data || viewProps.data.length === 0)
+      return { filtered: viewProps.data, error: null };
     return filterDataByRange(viewProps.data, activeRange);
   }, [viewProps.data, activeRange]);
 
@@ -316,6 +324,14 @@ export default function ClientAnalyticsView(props: ClientAnalyticsViewProps) {
   return (
     <div className="flex flex-col gap-4">
       <DateRangePicker value={activeRange} onChange={handleRangeChange} />
+      {timeWindowError && (
+        <div
+          role="alert"
+          className="rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 px-4 py-3 text-sm text-amber-800 dark:text-amber-300"
+        >
+          {timeWindowError.message}
+        </div>
+      )}
       <AnalyticsViews {...viewProps} data={filteredData} />
     </div>
   );

--- a/utils/analyticsTimeWindow.test.ts
+++ b/utils/analyticsTimeWindow.test.ts
@@ -1,0 +1,513 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import {
+  startOfDayUTC,
+  daysBetweenUTC,
+  getPresetStartDate,
+  validateTimeWindow,
+  createUtcRangePredicate,
+  parseAnalyticsTimeWindow,
+  MAX_RANGE_DAYS,
+} from "./analyticsTimeWindow";
+
+// ---------------------------------------------------------------------------
+// Pin the process timezone for deterministic DST-transition tests.
+// America/New_York observes DST; Asia/Tokyo does not.  We pin to a DST-
+// observing zone to verify that our UTC arithmetic is immune to it.
+// ---------------------------------------------------------------------------
+const PINNED_TZ = "America/New_York";
+const originalTZ = process.env.TZ;
+
+beforeAll(() => {
+  process.env.TZ = PINNED_TZ;
+});
+
+afterAll(() => {
+  if (originalTZ === undefined) {
+    delete process.env.TZ;
+  } else {
+    process.env.TZ = originalTZ;
+  }
+});
+
+// ============================================================================
+// startOfDayUTC
+// ============================================================================
+describe("startOfDayUTC", () => {
+  it("returns UTC midnight for a UTC date", () => {
+    const d = new Date("2026-03-15T14:30:00Z");
+    const result = startOfDayUTC(d);
+    expect(result.toISOString()).toBe("2026-03-15T00:00:00.000Z");
+  });
+
+  it("strips fractional seconds", () => {
+    const d = new Date("2026-07-01T00:00:00.123Z");
+    const result = startOfDayUTC(d);
+    expect(result.toISOString()).toBe("2026-07-01T00:00:00.000Z");
+  });
+
+  it("handles end-of-day UTC timestamps", () => {
+    // 23:59:59.999Z is still the same UTC calendar day
+    const d = new Date("2026-12-31T23:59:59.999Z");
+    const result = startOfDayUTC(d);
+    expect(result.toISOString()).toBe("2026-12-31T00:00:00.000Z");
+  });
+
+  it("handles start-of-day UTC timestamps", () => {
+    const d = new Date("2026-01-01T00:00:00.000Z");
+    const result = startOfDayUTC(d);
+    expect(result.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("does not mutate the input date", () => {
+    const d = new Date("2026-06-15T10:00:00Z");
+    const originalMs = d.getTime();
+    startOfDayUTC(d);
+    expect(d.getTime()).toBe(originalMs);
+  });
+
+  it("returns a new Date object (not the same reference)", () => {
+    const d = new Date("2026-06-15T10:00:00Z");
+    const result = startOfDayUTC(d);
+    expect(result).not.toBe(d);
+  });
+});
+
+// ============================================================================
+// daysBetweenUTC
+// ============================================================================
+describe("daysBetweenUTC", () => {
+  it("returns 0 for the same day", () => {
+    const d = new Date("2026-05-10T00:00:00Z");
+    expect(daysBetweenUTC(d, d)).toBe(0);
+  });
+
+  it("returns 1 for consecutive days", () => {
+    const from = new Date("2026-05-10T00:00:00Z");
+    const to = new Date("2026-05-11T00:00:00Z");
+    expect(daysBetweenUTC(from, to)).toBe(1);
+  });
+
+  it("returns correct span across month boundary", () => {
+    const from = new Date("2026-01-30T00:00:00Z");
+    const to = new Date("2026-02-02T00:00:00Z");
+    expect(daysBetweenUTC(from, to)).toBe(3);
+  });
+
+  it("returns correct span across DST transition (US Spring Forward)", () => {
+    // 2026 US DST spring-forward: March 8, 2026
+    // March 7 → March 14 crosses the DST boundary
+    const from = new Date("2026-03-07T00:00:00Z");
+    const to = new Date("2026-03-14T00:00:00Z");
+    expect(daysBetweenUTC(from, to)).toBe(7);
+  });
+
+  it("returns correct span across DST transition (US Fall Back)", () => {
+    // 2026 US DST fall-back: November 1, 2026
+    const from = new Date("2026-10-28T00:00:00Z");
+    const to = new Date("2026-11-04T00:00:00Z");
+    expect(daysBetweenUTC(from, to)).toBe(7);
+  });
+
+  it("ignores time-of-day differences", () => {
+    const from = new Date("2026-06-01T23:59:59Z");
+    const to = new Date("2026-06-02T00:00:01Z");
+    expect(daysBetweenUTC(from, to)).toBe(1);
+  });
+
+  it("handles leap-year boundary (2028 is a leap year)", () => {
+    const from = new Date("2028-02-28T00:00:00Z");
+    const to = new Date("2028-03-01T00:00:00Z");
+    // Feb 28 → Feb 29 (leap day) → Mar 1 = 2 days
+    expect(daysBetweenUTC(from, to)).toBe(2);
+  });
+
+  it("returns a positive number even when from > to", () => {
+    // daysBetweenUTC is unsigned — the caller decides semantics
+    const from = new Date("2026-06-10T00:00:00Z");
+    const to = new Date("2026-06-05T00:00:00Z");
+    expect(daysBetweenUTC(from, to)).toBe(-5);
+  });
+});
+
+// ============================================================================
+// getPresetStartDate
+// ============================================================================
+describe("getPresetStartDate", () => {
+  const NOW_UTC = new Date("2026-08-29T14:30:00Z");
+
+  it("7d returns 7 UTC days before today", () => {
+    const result = getPresetStartDate("7d", NOW_UTC);
+    expect(result.toISOString()).toBe("2026-08-22T00:00:00.000Z");
+  });
+
+  it("30d returns 30 UTC days before today", () => {
+    const result = getPresetStartDate("30d", NOW_UTC);
+    expect(result.toISOString()).toBe("2026-07-30T00:00:00.000Z");
+  });
+
+  it("90d returns 90 UTC days before today", () => {
+    const result = getPresetStartDate("90d", NOW_UTC);
+    expect(result.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  it("result is always UTC midnight", () => {
+    for (const preset of ["7d", "30d", "90d"] as const) {
+      const result = getPresetStartDate(preset, NOW_UTC);
+      expect(result.getUTCHours()).toBe(0);
+      expect(result.getUTCMinutes()).toBe(0);
+      expect(result.getUTCSeconds()).toBe(0);
+      expect(result.getUTCMilliseconds()).toBe(0);
+    }
+  });
+
+  it("does not shift across US DST spring-forward boundary", () => {
+    // March 14, 2026 is after US DST spring-forward (March 8)
+    // 7 days before March 14 is March 7 (before DST)
+    const now = new Date("2026-03-14T15:00:00Z");
+    const result = getPresetStartDate("7d", now);
+    expect(result.toISOString()).toBe("2026-03-07T00:00:00.000Z");
+    // The span should be exactly 7 calendar days, not 6 or 8
+    expect(daysBetweenUTC(result, startOfDayUTC(now))).toBe(7);
+  });
+
+  it("does not shift across US DST fall-back boundary", () => {
+    // November 4, 2026 is after US DST fall-back (November 1)
+    const now = new Date("2026-11-04T15:00:00Z");
+    const result = getPresetStartDate("7d", now);
+    expect(result.toISOString()).toBe("2026-10-28T00:00:00.000Z");
+    expect(daysBetweenUTC(result, startOfDayUTC(now))).toBe(7);
+  });
+
+  it("works when now is just after midnight UTC", () => {
+    const now = new Date("2026-08-29T00:01:00Z");
+    const result = getPresetStartDate("7d", now);
+    expect(result.toISOString()).toBe("2026-08-22T00:00:00.000Z");
+  });
+});
+
+// ============================================================================
+// validateTimeWindow
+// ============================================================================
+describe("validateTimeWindow", () => {
+  it("returns null for a valid 7-day range", () => {
+    const from = new Date("2026-08-01T00:00:00Z");
+    const to = new Date("2026-08-07T00:00:00Z");
+    expect(validateTimeWindow(from, to)).toBeNull();
+  });
+
+  it("returns null for a valid 1-day range (from ≠ to, different UTC days)", () => {
+    const from = new Date("2026-08-01T00:00:00Z");
+    const to = new Date("2026-08-02T00:00:00Z");
+    expect(validateTimeWindow(from, to)).toBeNull();
+  });
+
+  // ── Invalid dates ──────────────────────────────────────────────────────
+
+  it("rejects undefined from", () => {
+    const error = validateTimeWindow(undefined, new Date());
+    expect(error).not.toBeNull();
+    expect(error!.type).toBe("invalid_date");
+  });
+
+  it("rejects undefined to", () => {
+    const error = validateTimeWindow(new Date(), undefined);
+    expect(error).not.toBeNull();
+    expect(error!.type).toBe("invalid_date");
+  });
+
+  it("rejects both undefined", () => {
+    const error = validateTimeWindow(undefined, undefined);
+    expect(error).not.toBeNull();
+    expect(error!.type).toBe("invalid_date");
+  });
+
+  it("rejects NaN date", () => {
+    const error = validateTimeWindow(new Date("not-a-date"), new Date());
+    expect(error).not.toBeNull();
+    expect(error!.type).toBe("invalid_date");
+  });
+
+  // ── Reversed ranges ────────────────────────────────────────────────────
+
+  it("rejects a reversed range (from > to)", () => {
+    const from = new Date("2026-08-10T00:00:00Z");
+    const to = new Date("2026-08-01T00:00:00Z");
+    const error = validateTimeWindow(from, to);
+    expect(error).not.toBeNull();
+    expect(error!.type).toBe("reversed_range");
+  });
+
+  it("rejects reversed range even when times would compensate (timezone trick)", () => {
+    // from is Aug 10 UTC, to is Aug 1 in a different timezone offset
+    // but after UTC normalisation, from > to
+    const from = new Date("2026-08-10T00:00:00Z");
+    const to = new Date("2026-08-01T23:59:59.999Z"); // still Aug 1 UTC
+    const error = validateTimeWindow(from, to);
+    expect(error).not.toBeNull();
+    expect(error!.type).toBe("reversed_range");
+  });
+
+  // ── Zero-length ranges (same UTC day) ──────────────────────────────────
+
+  it("rejects a zero-length range (same UTC day, same time)", () => {
+    const d = new Date("2026-08-15T00:00:00Z");
+    const error = validateTimeWindow(d, new Date("2026-08-15T00:00:00Z"));
+    expect(error).not.toBeNull();
+    expect(error!.type).toBe("zero_length");
+  });
+
+  it("rejects a zero-length range (same UTC day, different time-of-day)", () => {
+    const from = new Date("2026-08-15T00:00:00Z");
+    const to = new Date("2026-08-15T23:59:59.999Z");
+    const error = validateTimeWindow(from, to);
+    expect(error).not.toBeNull();
+    expect(error!.type).toBe("zero_length");
+  });
+
+  // ── Exceeds maximum ────────────────────────────────────────────────────
+
+  it("rejects a range exceeding the default max (365 days)", () => {
+    const from = new Date("2025-01-01T00:00:00Z");
+    const to = new Date("2026-08-29T00:00:00Z");
+    const error = validateTimeWindow(from, to);
+    expect(error).not.toBeNull();
+    expect(error!.type).toBe("exceeds_max");
+    if (error!.type === "exceeds_max") {
+      expect(error!.maxDays).toBe(MAX_RANGE_DAYS);
+    }
+  });
+
+  it("accepts a range at exactly the max (365 days)", () => {
+    const from = new Date("2026-01-01T00:00:00Z");
+    const to = new Date("2026-12-31T00:00:00Z"); // 364 days
+    expect(validateTimeWindow(from, to)).toBeNull();
+  });
+
+  it("respects a custom maxDays", () => {
+    const from = new Date("2026-08-01T00:00:00Z");
+    const to = new Date("2026-08-10T00:00:00Z"); // 9 days
+    const error = validateTimeWindow(from, to, 7); // max 7 days
+    expect(error).not.toBeNull();
+    expect(error!.type).toBe("exceeds_max");
+    if (error!.type === "exceeds_max") {
+      expect(error!.maxDays).toBe(7);
+    }
+  });
+
+  // ── Error message includes useful info ─────────────────────────────────
+
+  it("includes the actual span in the exceeds_max error message", () => {
+    const from = new Date("2025-01-01T00:00:00Z");
+    const to = new Date("2026-08-29T00:00:00Z");
+    const error = validateTimeWindow(from, to);
+    expect(error!.message).toContain("days");
+  });
+});
+
+// ============================================================================
+// createUtcRangePredicate
+// ============================================================================
+describe("createUtcRangePredicate", () => {
+  const from = new Date("2026-08-01T00:00:00Z");
+  const to = new Date("2026-08-07T00:00:00Z");
+
+  it("includes the start boundary (inclusive)", () => {
+    const pred = createUtcRangePredicate(from, to);
+    expect(pred(new Date("2026-08-01T12:00:00Z"))).toBe(true);
+  });
+
+  it("includes the end boundary (inclusive)", () => {
+    const pred = createUtcRangePredicate(from, to);
+    expect(pred(new Date("2026-08-07T12:00:00Z"))).toBe(true);
+  });
+
+  it("excludes a date before the start", () => {
+    const pred = createUtcRangePredicate(from, to);
+    expect(pred(new Date("2026-07-31T23:59:59.999Z"))).toBe(false);
+  });
+
+  it("excludes a date after the end", () => {
+    const pred = createUtcRangePredicate(from, to);
+    expect(pred(new Date("2026-08-08T00:00:00.001Z"))).toBe(false);
+  });
+
+  it("ignores time-of-day within the range", () => {
+    const pred = createUtcRangePredicate(from, to);
+    // Aug 4 at 23:59:59 UTC is still Aug 4
+    expect(pred(new Date("2026-08-04T23:59:59.999Z"))).toBe(true);
+  });
+
+  it("works for a single-day range (from and to are different UTC days)", () => {
+    const singleFrom = new Date("2026-08-15T00:00:00Z");
+    const singleTo = new Date("2026-08-16T00:00:00Z");
+    const pred = createUtcRangePredicate(singleFrom, singleTo);
+
+    expect(pred(new Date("2026-08-15T00:00:00Z"))).toBe(true);
+    expect(pred(new Date("2026-08-15T23:59:59Z"))).toBe(true);
+    expect(pred(new Date("2026-08-16T00:00:00Z"))).toBe(true);
+    expect(pred(new Date("2026-08-16T00:00:01Z"))).toBe(false);
+  });
+
+  it("is DST-immune: same predicate works regardless of process timezone", () => {
+    // This test runs under America/New_York (pinned above).
+    // Aug 1–7 UTC contains the DST boundary if the process timezone were
+    // America/New_York, but since we compare in UTC, it doesn't matter.
+    const pred = createUtcRangePredicate(from, to);
+    expect(pred(new Date("2026-08-04T04:00:00Z"))).toBe(true);
+  });
+});
+
+// ============================================================================
+// parseAnalyticsTimeWindow
+// ============================================================================
+describe("parseAnalyticsTimeWindow", () => {
+  const NOW = new Date("2026-08-29T14:30:00Z");
+
+  // ── Preset windows ─────────────────────────────────────────────────────
+
+  describe("preset windows", () => {
+    it("parses 7d correctly", () => {
+      const result = parseAnalyticsTimeWindow({ preset: "7d", now: NOW });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.window.from.toISOString()).toBe("2026-08-22T00:00:00.000Z");
+        expect(result.window.to.toISOString()).toBe("2026-08-29T00:00:00.000Z");
+        expect(result.window.preset).toBe("7d");
+        expect(daysBetweenUTC(result.window.from, result.window.to)).toBe(7);
+      }
+    });
+
+    it("parses 30d correctly", () => {
+      const result = parseAnalyticsTimeWindow({ preset: "30d", now: NOW });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.window.from.toISOString()).toBe("2026-07-30T00:00:00.000Z");
+        expect(result.window.to.toISOString()).toBe("2026-08-29T00:00:00.000Z");
+        expect(daysBetweenUTC(result.window.from, result.window.to)).toBe(30);
+      }
+    });
+
+    it("parses 90d correctly", () => {
+      const result = parseAnalyticsTimeWindow({ preset: "90d", now: NOW });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.window.from.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+        expect(result.window.to.toISOString()).toBe("2026-08-29T00:00:00.000Z");
+        expect(daysBetweenUTC(result.window.from, result.window.to)).toBe(89);
+      }
+    });
+
+    it("presets produce UTC-midnight boundaries", () => {
+      for (const preset of ["7d", "30d", "90d"] as const) {
+        const result = parseAnalyticsTimeWindow({ preset, now: NOW });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.window.from.getUTCHours()).toBe(0);
+          expect(result.window.from.getUTCMinutes()).toBe(0);
+          expect(result.window.to.getUTCHours()).toBe(0);
+          expect(result.window.to.getUTCMinutes()).toBe(0);
+        }
+      }
+    });
+
+    it("preset windows never shift across DST transitions", () => {
+      // March 15, 2026 is after US DST spring-forward (March 8)
+      const dstNow = new Date("2026-03-15T12:00:00Z");
+      const result = parseAnalyticsTimeWindow({ preset: "7d", now: dstNow });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(daysBetweenUTC(result.window.from, result.window.to)).toBe(7);
+      }
+    });
+  });
+
+  // ── Custom windows ─────────────────────────────────────────────────────
+
+  describe("custom windows", () => {
+    it("parses a valid custom range", () => {
+      const from = new Date("2026-06-01T00:00:00Z");
+      const to = new Date("2026-06-30T00:00:00Z");
+      const result = parseAnalyticsTimeWindow({
+        preset: "custom",
+        from,
+        to,
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.window.from.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+        expect(result.window.to.toISOString()).toBe("2026-06-30T00:00:00.000Z");
+        expect(result.window.preset).toBe("custom");
+      }
+    });
+
+    it("rejects custom range with missing from", () => {
+      const result = parseAnalyticsTimeWindow({
+        preset: "custom",
+        to: new Date("2026-06-30T00:00:00Z"),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe("invalid_date");
+      }
+    });
+
+    it("rejects custom range with missing to", () => {
+      const result = parseAnalyticsTimeWindow({
+        preset: "custom",
+        from: new Date("2026-06-01T00:00:00Z"),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe("invalid_date");
+      }
+    });
+
+    it("rejects custom range with both missing", () => {
+      const result = parseAnalyticsTimeWindow({ preset: "custom" });
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects reversed custom range", () => {
+      const result = parseAnalyticsTimeWindow({
+        preset: "custom",
+        from: new Date("2026-08-10T00:00:00Z"),
+        to: new Date("2026-08-01T00:00:00Z"),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe("reversed_range");
+      }
+    });
+
+    it("rejects oversized custom range", () => {
+      const result = parseAnalyticsTimeWindow({
+        preset: "custom",
+        from: new Date("2024-01-01T00:00:00Z"),
+        to: new Date("2026-08-29T00:00:00Z"),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe("exceeds_max");
+      }
+    });
+  });
+
+  // ── Cross-timezone immunity ────────────────────────────────────────────
+
+  describe("cross-timezone immunity", () => {
+    it("produces identical results regardless of process timezone", () => {
+      // The test is pinned to America/New_York.  We verify that the
+      // startOfDayUTC normalisation means the output is the same as if
+      // we computed in pure UTC.
+      const result = parseAnalyticsTimeWindow({ preset: "30d", now: NOW });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        // This should be exactly 30 UTC days, no DST drift
+        expect(daysBetweenUTC(result.window.from, result.window.to)).toBe(30);
+        // And both boundaries must be UTC midnight
+        expect(result.window.from.toISOString().endsWith("T00:00:00.000Z")).toBe(true);
+        expect(result.window.to.toISOString().endsWith("T00:00:00.000Z")).toBe(true);
+      }
+    });
+  });
+});

--- a/utils/analyticsTimeWindow.ts
+++ b/utils/analyticsTimeWindow.ts
@@ -1,0 +1,343 @@
+/**
+ * @module analyticsTimeWindow
+ *
+ * Deterministic, UTC-based time-window parser and validator for analytics
+ * filters.  This module is the **single source of truth** for:
+ *
+ * 1. Normalising preset windows (7d / 30d / 90d) to stable UTC midnights so
+ *    daylight-saving transitions never shift the requested window.
+ * 2. Validating custom date ranges **before** a network request is fired,
+ *    rejecting reversed / oversized / identical-boundary ranges.
+ * 3. Providing an inclusive-range predicate that normalises both the data
+ *    points and the boundaries to UTC calendar days so the comparison is
+ *    locale- and DST-independent.
+ *
+ * ## Design decisions
+ *
+ * | Decision | Rationale |
+ * |---|---|
+ * | All internal arithmetic uses UTC `Date` objects | Avoids DST-related hour-skipping / hour-doubling that local-time `new Date(y, m, d)` suffers. |
+ * | Boundaries are normalised to UTC midnight (`startOfDayUTC`) | "7 days ago" means "the UTC day 7 days ago at 00:00", not "24 × 7 hours ago". |
+ * | Range semantics are **inclusive on both ends** | `[from, to]` includes the `to` day itself. This matches the transaction date-range predicate convention. |
+ * | Reversed ranges are rejected | `from > to` is a user error; surfacing it early prevents a wasted API round-trip. |
+ * | Maximum range is configurable (default 365 days) | Prevents accidental multi-year fetches that could degrade UX. |
+ */
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+/** Milliseconds in one UTC day. */
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Maximum allowed range length in days (inclusive of both endpoints).
+ *
+ * The default of **365 days** (1 year) is deliberately generous — analytics
+ * dashboards rarely need more, and it prevents accidental multi-year fetches.
+ *
+ * Exported so callers can override it if needed.
+ */
+export const MAX_RANGE_DAYS = 365;
+
+// ── UTC normalisation helpers ────────────────────────────────────────────────
+
+/**
+ * Returns a new `Date` set to UTC midnight (00:00:00.000Z) of the same
+ * calendar day that `d` represents in UTC.
+ *
+ * This is the canonical normaliser — all range comparisons go through it so
+ * that DST and locale differences are irrelevant.
+ *
+ * @example
+ * ```ts
+ * startOfDayUTC(new Date("2026-03-29T23:59:59.999Z"))
+ * // → Date representing 2026-03-29T00:00:00.000Z
+ * ```
+ */
+export function startOfDayUTC(d: Date): Date {
+  const utcMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  return new Date(utcMs);
+}
+
+/**
+ * Returns the number of whole UTC calendar days between two UTC dates.
+ *
+ * Both dates are first normalised to UTC midnight, so time-of-day is
+ * irrelevant.
+ *
+ * @returns A **non-negative** integer representing `to − from` in days.
+ */
+export function daysBetweenUTC(from: Date, to: Date): number {
+  const fromMs = startOfDayUTC(from).getTime();
+  const toMs = startOfDayUTC(to).getTime();
+  return Math.round((toMs - fromMs) / MS_PER_DAY);
+}
+
+// ── Preset window computation ────────────────────────────────────────────────
+
+/**
+ * Preset key for analytics date-range pickers.
+ *
+ * - `"7d"` / `"30d"` / `"90d"` — relative windows computed from "today" (UTC).
+ * - `"custom"` — user-specified from/to dates.
+ */
+export type AnalyticsDatePreset = "7d" | "30d" | "90d" | "custom";
+
+/**
+ * Result of parsing a date-range value into deterministic UTC boundaries.
+ *
+ * Both `from` and `to` are UTC-midnight `Date` objects.
+ * The range is **inclusive on both ends** — i.e. both the `from` day and the
+ * `to` day are included.
+ */
+export interface ParsedTimeWindow {
+  /** Inclusive start of the range (UTC midnight). */
+  from: Date;
+  /** Inclusive end of the range (UTC midnight). */
+  to: Date;
+  /** The resolved preset key. */
+  preset: AnalyticsDatePreset;
+}
+
+/**
+ * Describes why a time-window validation failed.
+ *
+ * The `type` discriminant lets callers branch on the failure reason without
+ * string-matching.
+ */
+export type TimeWindowError =
+  | { type: "reversed_range"; message: string }
+  | { type: "zero_length"; message: string }
+  | { type: "exceeds_max"; message: string; maxDays: number }
+  | { type: "invalid_date"; message: string };
+
+// ── Preset computation ───────────────────────────────────────────────────────
+
+/**
+ * Computes the UTC start date for a relative preset relative to `now`.
+ *
+ * The result is always a UTC-midnight date.  For example, if `now` is
+ * `2026-08-29T14:30:00Z` and `preset` is `"7d"`, the returned date is
+ * `2026-08-22T00:00:00Z`.
+ *
+ * **DST safety:** Because we work exclusively in UTC, a DST transition that
+ * falls inside the window never changes the *calendar-day* span.  "7 days
+ * ago" always means "the UTC calendar day 7 days before today", regardless of
+ * what timezone the user's browser is in.
+ *
+ * @param preset - One of `"7d"`, `"30d"`, or `"90d"`.
+ * @param now    - Reference clock.  Defaults to `new Date()`.
+ * @returns A UTC-midnight `Date` representing the start of the window.
+ */
+export function getPresetStartDate(
+  preset: Extract<AnalyticsDatePreset, "7d" | "30d" | "90d">,
+  now: Date = new Date(),
+): Date {
+  const days: Record<string, number> = { "7d": 7, "30d": 30, "90d": 90 };
+  const numDays = days[preset];
+  const todayUtc = startOfDayUTC(now);
+  return new Date(todayUtc.getTime() - numDays * MS_PER_DAY);
+}
+
+// ── Validation ───────────────────────────────────────────────────────────────
+
+/**
+ * Validates that the given `from` and `to` dates represent a legal
+ * analytics time window.
+ *
+ * Checks performed (in order):
+ * 1. Both dates must be valid `Date` objects.
+ * 2. `from` must not be after `to` (reversed range).
+ * 3. `from` and `to` must not be the same day (zero-length range).
+ * 4. The span must not exceed {@link MAX_RANGE_DAYS} calendar days.
+ *
+ * On success the function returns `null`.  On failure it returns a
+ * discriminated-union {@link TimeWindowError} that the caller can surface to
+ * the user or log for telemetry.
+ *
+ * @param from     - Start of the range (inclusive).
+ * @param to       - End of the range (inclusive).
+ * @param maxDays  - Override for the maximum allowed range length.
+ * @returns `null` on success, or a `TimeWindowError`.
+ */
+export function validateTimeWindow(
+  from: Date | undefined,
+  to: Date | undefined,
+  maxDays: number = MAX_RANGE_DAYS,
+): TimeWindowError | null {
+  // ── Step 1: validity ──────────────────────────────────────────────────
+  if (!from || !to || Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
+    return {
+      type: "invalid_date",
+      message:
+        "Invalid date range: one or both dates could not be parsed. Please select a valid range.",
+    };
+  }
+
+  const fromUtc = startOfDayUTC(from);
+  const toUtc = startOfDayUTC(to);
+
+  // ── Step 2: reversed ──────────────────────────────────────────────────
+  if (fromUtc.getTime() > toUtc.getTime()) {
+    return {
+      type: "reversed_range",
+      message:
+        "Invalid date range: the start date must be on or before the end date.",
+    };
+  }
+
+  // ── Step 3: zero-length ───────────────────────────────────────────────
+  if (fromUtc.getTime() === toUtc.getTime()) {
+    return {
+      type: "zero_length",
+      message:
+        "Invalid date range: start and end dates fall on the same day. Please select different dates.",
+    };
+  }
+
+  // ── Step 4: maximum length ────────────────────────────────────────────
+  const spanDays = daysBetweenUTC(fromUtc, toUtc);
+  if (spanDays > maxDays) {
+    return {
+      type: "exceeds_max",
+      message: `Invalid date range: the selected range spans ${spanDays} days, which exceeds the maximum of ${maxDays} days.`,
+      maxDays,
+    };
+  }
+
+  return null;
+}
+
+// ── Range predicate ──────────────────────────────────────────────────────────
+
+/**
+ * Creates an **inclusive** range predicate that checks whether a `Date` falls
+ * within the normalised UTC window `[from, to]`.
+ *
+ * Both the candidate date and the boundaries are normalised to UTC midnight
+ * before comparison, so time-of-day and DST transitions are irrelevant.
+ *
+ * ### Equal start/end (documentation)
+ *
+ * When `from` and `to` resolve to the same UTC calendar day, the predicate
+ * matches **only** data points from that specific day.  This is the correct
+ * behaviour for "show me everything for exactly one day".  If the caller
+ * wants to *exclude* single-day ranges, they should validate with
+ * {@link validateTimeWindow} first — which rejects zero-length ranges.
+ *
+ * @example
+ * ```ts
+ * const withinRange = createUtcRangePredicate(from, to);
+ * withinRange(new Date("2026-08-20T12:00:00Z")); // true if in [from, to]
+ * ```
+ *
+ * @param from - Inclusive start (UTC midnight preferred, but any Date works).
+ * @param to   - Inclusive end (UTC midnight preferred, but any Date works).
+ * @returns A predicate `(date: Date) => boolean`.
+ */
+export function createUtcRangePredicate(
+  from: Date,
+  to: Date,
+): (date: Date) => boolean {
+  const fromMs = startOfDayUTC(from).getTime();
+  const toMs = startOfDayUTC(to).getTime();
+
+  return (date: Date): boolean => {
+    const dateMs = startOfDayUTC(date).getTime();
+    return dateMs >= fromMs && dateMs <= toMs;
+  };
+}
+
+// ── Full parse + validate pipeline ───────────────────────────────────────────
+
+/**
+ * Result of {@link parseAnalyticsTimeWindow} on success.
+ */
+export interface ParseResultOk {
+  ok: true;
+  window: ParsedTimeWindow;
+}
+
+/**
+ * Result of {@link parseAnalyticsTimeWindow} on failure.
+ */
+export interface ParseResultErr {
+  ok: false;
+  error: TimeWindowError;
+}
+
+/** Discriminated union returned by {@link parseAnalyticsTimeWindow}. */
+export type ParseResult = ParseResultOk | ParseResultErr;
+
+/**
+ * Parses a preset or custom date range into a fully-validated
+ * {@link ParsedTimeWindow}.
+ *
+ * This is the **primary entry point** for callers.  It:
+ *
+ * 1. Resolves the effective `from` / `to` dates (preset arithmetic for
+ *    relative presets, passthrough for custom).
+ * 2. Runs {@link validateTimeWindow} on the resolved dates.
+ * 3. Returns either the validated window or a descriptive error.
+ *
+ * @example
+ * ```ts
+ * const result = parseAnalyticsTimeWindow({ preset: "7d" });
+ * if (!result.ok) {
+ *   console.error(result.error.message);
+ * } else {
+ *   const { from, to } = result.window;
+ *   fetchData(from, to);
+ * }
+ * ```
+ *
+ * @param options.preset  - The selected preset key.
+ * @param options.from    - Custom start date (required when preset is `"custom"`).
+ * @param options.to      - Custom end date (required when preset is `"custom"`).
+ * @param options.now     - Reference clock for preset computation.
+ * @param options.maxDays - Override for max range validation.
+ * @returns A {@link ParseResult}.
+ */
+export function parseAnalyticsTimeWindow(options: {
+  preset: AnalyticsDatePreset;
+  from?: Date;
+  to?: Date;
+  now?: Date;
+  maxDays?: number;
+}): ParseResult {
+  const { preset, from, to, now = new Date(), maxDays = MAX_RANGE_DAYS } = options;
+
+  let effectiveFrom: Date;
+  let effectiveTo: Date;
+
+  if (preset === "custom") {
+    if (!from || !to) {
+      return {
+        ok: false,
+        error: {
+          type: "invalid_date",
+          message:
+            "Custom date range requires both a start and end date.",
+        },
+      };
+    }
+    effectiveFrom = from;
+    effectiveTo = to;
+  } else {
+    effectiveFrom = getPresetStartDate(preset, now);
+    effectiveTo = startOfDayUTC(now);
+  }
+
+  const error = validateTimeWindow(effectiveFrom, effectiveTo, maxDays);
+  if (error) {
+    return { ok: false, error };
+  }
+
+  return {
+    ok: true,
+    window: {
+      from: startOfDayUTC(effectiveFrom),
+      to: startOfDayUTC(effectiveTo),
+      preset,
+    },
+  };
+}


### PR DESCRIPTION
Closes #1177 

Analytics queries previously used local-time arithmetic (new Date(y, m, d)) for date-range filtering, which caused silent disagreements around DST transitions, midnight boundaries, and invalid reversed ranges.

This change introduces utils/analyticsTimeWindow.ts — a single UTC-based range parser with explicit inclusive semantics — and wires it into ClientAnalyticsView. The module validates ranges before filtering, rejects reversed/oversized/same-day ranges with descriptive errors surfaced to the user, and normalises all date comparisons to UTC midnights so DST shifts never alter the requested window.

Closes #1177

🤖 Generated with Codebuff

## Description

<!-- Briefly describe the changes introduced in this pull request. -->

## Related Issue

<!-- Link to the issue(s) this pull request addresses, if any. -->

## Checklist

- [ ] I have tested the changes locally.
- [ ] I have added/updated documentation as needed.
- [ ] I have reviewed the code and ensured it follows the project guidelines.
- [ ] I have added necessary tests.

## Screenshots/Recordings

<!-- Attach relevant images or videos to show the effect of your changes. -->

## Additional Notes

<!-- Any other information reviewers should be aware of. -->
