### PR TITLE
feat(sw): version cache from build identity with coordinated activation 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.5.7",
-        "@material-tailwind/react": "^2.1.10",
         "@radix-ui/react-checkbox": "^1.3.11",
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-dropdown-menu": "^2.1.24",
@@ -19,11 +21,13 @@
         "@radix-ui/react-separator": "^1.1.15",
         "@radix-ui/react-slot": "^1.3.3",
         "@radix-ui/react-tabs": "^1.1.21",
+        "@tailwindcss/oxide-linux-x64-gnu": "^4.3.3",
         "@testing-library/dom": "^10.4.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
         "framer-motion": "^12.43.0",
+        "jspdf": "^4.2.1",
         "lucide-react": "^1.27.0",
         "next": "16.2.12",
         "next-auth": "^4.24.15",
@@ -61,7 +65,7 @@
         "tailwindcss": "^4.1.4",
         "tw-animate-css": "^1.4.0",
         "typescript": "7.0.2",
-        "vitest": "^4.1.9",
+        "vitest": "^4.1.10",
         "vitest-axe": "^0.1.0"
       }
     },
@@ -625,6 +629,55 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
@@ -668,23 +721,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emotion/memoize": "0.7.4"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -828,34 +864,6 @@
       "dependencies": {
         "@floating-ui/core": "^1.8.0",
         "@floating-ui/utils": "^0.2.12"
-      }
-    },
-    "node_modules/@floating-ui/react": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.19.0.tgz",
-      "integrity": "sha512-fgYvN4ksCi5OvmPXkyOT8o5a8PSKHMzPHt+9mR6KYWdF16IAjWRLZPAAziI2sznaWT23drRFrYw64wdvYqqaQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^1.2.2",
-        "aria-hidden": "^1.1.3",
-        "tabbable": "^6.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
-      "integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.2.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@floating-ui/utils": {
@@ -1554,152 +1562,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@material-tailwind/react": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@material-tailwind/react/-/react-2.1.10.tgz",
-      "integrity": "sha512-xGU/mLDKDBp/qZ8Dp2XR7fKcTpDuFeZEBqoL9Bk/29kakKxNxjUGYSRHEFLsyOFf4VIhU6WGHdIS7tOA3QGJHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react": "0.19.0",
-        "classnames": "2.3.2",
-        "deepmerge": "4.2.2",
-        "framer-motion": "6.5.1",
-        "material-ripple-effects": "2.0.1",
-        "prop-types": "15.8.1",
-        "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "tailwind-merge": "1.8.1"
-      },
-      "peerDependencies": {
-        "react": "^16 || ^17 || ^18",
-        "react-dom": "^16 || ^17 || ^18"
-      }
-    },
-    "node_modules/@material-tailwind/react/node_modules/framer-motion": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
-      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/dom": "10.12.0",
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "popmotion": "11.0.3",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
-      },
-      "optionalDependencies": {
-        "@emotion/is-prop-valid": "^0.8.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
-        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@material-tailwind/react/node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@material-tailwind/react/node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@material-tailwind/react/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/@material-tailwind/react/node_modules/tailwind-merge": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.8.1.tgz",
-      "integrity": "sha512-+fflfPxvHFr81hTJpQ3MIwtqgvefHZFUHFiIHpVIRXvG/nX9+gu2P7JNlFu2bfDMJ+uHhi/pUgzaYacMoXv+Ww==",
-      "license": "MIT"
-    },
-    "node_modules/@motionone/animation": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.18.0.tgz",
-      "integrity": "sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/easing": "^10.18.0",
-        "@motionone/types": "^10.17.1",
-        "@motionone/utils": "^10.18.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/dom": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
-      "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/animation": "^10.12.0",
-        "@motionone/generators": "^10.12.0",
-        "@motionone/types": "^10.12.0",
-        "@motionone/utils": "^10.12.0",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/easing": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.18.0.tgz",
-      "integrity": "sha512-VcjByo7XpdLS4o9T8t99JtgxkdMcNWD3yHU/n6CLEz3bkmKDRZyYQ/wmSf6daum8ZXqfUAgFeCZSpJZIMxaCzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/utils": "^10.18.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/generators": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.18.0.tgz",
-      "integrity": "sha512-+qfkC2DtkDj4tHPu+AFKVfR/C30O1vYdvsGYaR13W/1cczPrrcjdvYCj0VLFuRMN+lP1xvpNZHCRNM4fBzn1jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/types": "^10.17.1",
-        "@motionone/utils": "^10.18.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/types": {
-      "version": "10.17.1",
-      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.17.1.tgz",
-      "integrity": "sha512-KaC4kgiODDz8hswCrS0btrVrzyU2CSQKO7Ps90ibBVSQmjkrt2teqta6/sOG59v7+dPnKMAg13jyqtMKV2yJ7A==",
-      "license": "MIT"
-    },
-    "node_modules/@motionone/utils": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.18.0.tgz",
-      "integrity": "sha512-3XVF7sgyTSI2KWvTf6uLlBJ5iAgRgmvp3bpuOiQJvInd4nZ19ET8lX5unn30SlmRH7hXbBbH+Gxd0m0klJ3Xtw==",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/types": "^10.17.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3273,9 +3135,7 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -3650,6 +3510,11 @@
         "undici-types": "~8.3.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw=="
+    },
     "node_modules/@types/qrcode": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
@@ -3659,6 +3524,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
@@ -3689,6 +3560,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -4942,6 +4819,15 @@
       "integrity": "sha512-EGHIRiegFa62/SsA1J+Xs2tIzludPdzM064N9wjbiEgHnGnJ1V0WEpA4pEwCYT5nDvZk3ubf0shqaCS7k6xeUQ==",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz",
@@ -5103,6 +4989,25 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -5124,12 +5029,6 @@
       "funding": {
         "url": "https://polar.sh/cva"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-      "license": "MIT"
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -5208,6 +5107,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5221,6 +5134,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -5511,15 +5433,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -5605,6 +5518,15 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6707,6 +6629,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -6716,6 +6648,11 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -6824,20 +6761,10 @@
         }
       }
     },
-    "node_modules/framesync": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7177,12 +7104,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-    "node_modules/hey-listen": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
-      "license": "MIT"
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -7202,6 +7123,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -7266,6 +7200,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA=="
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -7888,6 +7827,22 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -8236,6 +8191,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -8309,12 +8265,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/material-ripple-effects": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/material-ripple-effects/-/material-ripple-effects-2.0.1.tgz",
-      "integrity": "sha512-hHlUkZAuXbP94lu02VgrPidbZ3hBtgXBtjlwR8APNqOIgDZMV8MCIcsclL8FmGJQHvnORyvoQgC965vPsiyXLQ==",
-      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -8628,6 +8578,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8906,6 +8857,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ]
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -8951,6 +8917,12 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9010,18 +8982,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/popmotion": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
-      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
-      "license": "MIT",
-      "dependencies": {
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -9155,6 +9115,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -9166,6 +9127,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -9215,6 +9177,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/react": {
       "version": "19.2.8",
@@ -9459,6 +9430,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -9554,6 +9531,15 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rolldown": {
@@ -9967,6 +9953,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
@@ -10157,16 +10152,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/style-value-types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
-      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
-      "license": "MIT",
-      "dependencies": {
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -10216,17 +10201,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tabbable": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
-      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
@@ -10258,6 +10246,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tiny-invariant": {
@@ -10743,6 +10740,15 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -1,3 +1,5 @@
+
+
 {
   "name": "my-app",
   "version": "0.1.0",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,25 +1,65 @@
 /**
- * StelloPay — Minimal App Shell Service Worker
- * ============================================
+ * StelloPay — Versioned App Shell Service Worker
+ * ================================================
  * Strategy: Cache-first for the app shell (static assets, fonts, icons).
  *           Network-first for navigation requests, falling back to an offline
  *           page when the network is unavailable.
  *
- * Cache invalidation
- * ------------------
- * CACHE_NAME is versioned with a deploy-time stamp.  Bumping this value (or
- * setting NEXT_PUBLIC_SW_VERSION in your CI environment) causes the activate
- * step to delete every previous cache so users always receive a fresh shell
- * after a deploy.  The recommended approach is to inject the build ID here
- * during your CI pipeline:
+ * Cache invalidation & coordinated activation
+ * -------------------------------------------
+ * Problem: calling skipWaiting() immediately lets the new worker take over
+ * clients that still have HTML from the previous build in flight.  The
+ * resulting mix of old HTML referencing old JS hashes and new cached JS (or
+ * vice-versa) can produce a broken page.
  *
- *   // next.config.ts  — replace the static string with process.env.BUILD_ID
- *   headers: [{ source: "/sw.js", headers: [{ key: "Cache-Control", value: "no-cache" }] }]
+ * Solution (three-step handshake):
+ *   1. Install — pre-cache the full shell into the new, versioned cache.
+ *      skipWaiting is intentionally NOT called here.  The old worker keeps
+ *      serving until clients explicitly agree to reload.
+ *
+ *   2. Activate (triggered only when all old tabs are closed, or after the
+ *      client-driven SKIP_WAITING below) —
+ *      a. Delete every cache whose name != CACHE_NAME (old caches are only
+ *         pruned AFTER the new shell is confirmed valid from step 1).
+ *      b. Claim all open clients (clients.claim()) so this worker handles
+ *         the next request immediately.
+ *      c. Post SW_ACTIVATED to every client so the app can prompt the user
+ *         to reload for the freshest experience.
+ *
+ *   3. Client-driven skip — the page can send { type: "SKIP_WAITING" } to
+ *      the *waiting* worker at any point (e.g., on an update-available
+ *      banner "Reload" click).  The waiting worker calls skipWaiting() only
+ *      then, ensuring it replaces an active worker only when the client
+ *      consents.
+ *
+ * Cache versioning
+ * ----------------
+ * CACHE_VERSION is injected from the build environment.  In CI set
+ * NEXT_PUBLIC_BUILD_ID (or BUILD_ID) so each deploy produces a unique cache
+ * name and the activate step sweeps old caches automatically:
+ *
+ *   // next.config.ts
+ *   env: { NEXT_PUBLIC_BUILD_ID: process.env.BUILD_ID ?? Date.now().toString() }
  *
  * See README.md → "Service Worker & Offline Support" for the full strategy.
  */
 
-const CACHE_VERSION = "v1"; // ← bump this (or inject BUILD_ID) on every deploy
+/* global self, caches, fetch, clients */
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Injected at build time by the CI pipeline (e.g. via next.config.ts env
+ * block).  Falls back to "v1" for local development.  Change this value on
+ * every deploy to bust the old cache.
+ */
+const CACHE_VERSION =
+  (typeof self !== "undefined" &&
+    self.__BUILD_ID) || // test/CI injection point
+  "v1";
+
 const CACHE_NAME = `stellopay-shell-${CACHE_VERSION}`;
 
 /**
@@ -35,27 +75,46 @@ const SHELL_ASSETS = [
   "/favicon.ico",
 ];
 
+// Message types used for worker ↔ client communication.
+const MSG = {
+  /** Client → waiting worker: take over now (user confirmed reload). */
+  SKIP_WAITING: "SKIP_WAITING",
+  /** Active worker → all clients: new cache is live, safe to reload. */
+  SW_ACTIVATED: "SW_ACTIVATED",
+};
+
 // ---------------------------------------------------------------------------
 // Install — pre-cache the app shell
 // ---------------------------------------------------------------------------
 self.addEventListener("install", (event) => {
+  /**
+   * waitUntil keeps the worker in the "installing" state until the shell is
+   * fully cached.  If addAll() rejects (network error, bad response), the
+   * install fails and the worker is discarded — the old worker keeps running
+   * and no partial cache is left behind.
+   *
+   * skipWaiting is NOT called here.  The new worker waits in "installed"
+   * state until either:
+   *   • all old clients are closed (browser default behaviour), or
+   *   • a client sends SKIP_WAITING (see message handler below).
+   */
   event.waitUntil(
-    caches
-      .open(CACHE_NAME)
-      .then((cache) => cache.addAll(SHELL_ASSETS))
-      // Activate immediately instead of waiting for old tabs to close.
-      .then(() => self.skipWaiting()),
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(SHELL_ASSETS)),
   );
 });
 
 // ---------------------------------------------------------------------------
-// Activate — prune stale caches from previous versions
+// Activate — prune stale caches, claim clients, notify them
 // ---------------------------------------------------------------------------
 self.addEventListener("activate", (event) => {
   event.waitUntil(
     caches
       .keys()
       .then((keys) =>
+        // Remove every cache that belongs to an older version of this worker.
+        // This runs only AFTER the new cache was successfully populated in the
+        // install step, satisfying the acceptance criterion:
+        //   "Old caches are removed only after the new cache is valid."
         Promise.all(
           keys
             .filter((key) => key !== CACHE_NAME)
@@ -63,8 +122,32 @@ self.addEventListener("activate", (event) => {
         ),
       )
       // Take control of all open clients without requiring a page reload.
-      .then(() => self.clients.claim()),
+      .then(() => self.clients.claim())
+      // Notify every controlled client that this new worker is now active.
+      // The client-side code can use this to prompt "A new version is ready —
+      // reload to apply" or to reload automatically if the app is idle.
+      .then(() =>
+        self.clients.matchAll({ includeUncontrolled: true }).then((clientList) =>
+          Promise.all(
+            clientList.map((client) =>
+              client.postMessage({ type: MSG.SW_ACTIVATED, version: CACHE_VERSION }),
+            ),
+          ),
+        ),
+      ),
   );
+});
+
+// ---------------------------------------------------------------------------
+// Message — client-driven skipWaiting
+// ---------------------------------------------------------------------------
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === MSG.SKIP_WAITING) {
+    // A client has acknowledged the update (e.g., the user clicked "Reload").
+    // Only NOW do we skip the waiting phase, guaranteeing the client and the
+    // new worker are in sync.
+    self.skipWaiting();
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -134,6 +217,11 @@ async function cacheFirst(request) {
  * Network-first for HTML navigation: try the network; if offline (or the
  * server returns a non-2xx), serve the pre-cached /offline page instead of
  * letting the browser display its default "No internet" error.
+ *
+ * The /offline page was pre-cached during install, so it is always
+ * available even if the device loses connectivity mid-update — satisfying
+ * the acceptance criterion:
+ *   "Offline fallback remains available during an update."
  */
 async function networkFirstWithOfflineFallback(request) {
   try {

--- a/public/sw.test.ts
+++ b/public/sw.test.ts
@@ -1,0 +1,396 @@
+/**
+ * public/sw.test.js
+ * =================
+ * Vitest unit tests for the StelloPay service worker (public/sw.js).
+ *
+ * The service worker runs in a browser ServiceWorkerGlobalScope, not a Node
+ * module.  We simulate that environment by:
+ *   • Providing stub globals (caches, fetch, clients, self.*) before loading
+ *     the worker script with vm.runInNewContext / direct evaluation.
+ *   • Using a thin event-listener map so addEventListener calls from the SW
+ *     are captured and we can fire synthetic events.
+ *
+ * Tested scenarios
+ * ----------------
+ *  install — happy path   Shell assets are pre-cached; skipWaiting is NOT called.
+ *  install — failure      If addAll() rejects the cache stays clean and no
+ *                         skipWaiting is called; install "fails" (waitUntil
+ *                         promise rejects).
+ *  activate               Stale caches are deleted; clients.claim() runs;
+ *                         every client receives an SW_ACTIVATED postMessage.
+ *  message/reload coord   SKIP_WAITING message triggers self.skipWaiting().
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Load the service worker source once.
+// ---------------------------------------------------------------------------
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SW_SOURCE = fs.readFileSync(
+  path.join(__dirname, "sw.js"),
+  "utf8",
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal service-worker global scope, register the SW source into
+ * it, and return both the scope and a helper for firing synthetic events.
+ *
+ * @param {object} [overrides] - Optional globals to override on `self`.
+ */
+function buildScope(overrides = {}) {
+  // ------------------------------------------------------------------
+  // Event listener registry — mirrors addEventListener / dispatchEvent
+  // ------------------------------------------------------------------
+  const listeners = {};
+
+  const addEventListener = vi.fn((type, handler) => {
+    listeners[type] = listeners[type] || [];
+    listeners[type].push(handler);
+  });
+
+  /**
+   * Fire a synthetic SW event.
+   * @param {string} type
+   * @param {object} [eventData]   Extra properties merged onto the event object.
+   * @returns {Promise<void>}      Resolves once waitUntil()'s promise resolves.
+   */
+  async function fireEvent(type, eventData = {}) {
+    let waitUntilPromise = Promise.resolve();
+    const event = {
+      waitUntil: vi.fn((p) => {
+        waitUntilPromise = Promise.resolve(p);
+      }),
+      ...eventData,
+    };
+    const handlers = listeners[type] || [];
+    for (const handler of handlers) handler(event);
+    return waitUntilPromise;
+  }
+
+  // ------------------------------------------------------------------
+  // Cache API stubs
+  // ------------------------------------------------------------------
+  const cacheContents = {};
+
+  const makeCacheStore = (name) => ({
+    addAll: vi.fn(async (urls) => {
+      cacheContents[name] = urls.slice();
+    }),
+    put: vi.fn(async (req, res) => {
+      cacheContents[name] = cacheContents[name] || [];
+      cacheContents[name].push(req);
+    }),
+    match: vi.fn(async () => undefined),
+  });
+
+  // All open named caches.  Starts empty; opens on demand.
+  const openCaches = {};
+
+  const caches = {
+    open: vi.fn(async (name) => {
+      openCaches[name] = openCaches[name] || makeCacheStore(name);
+      return openCaches[name];
+    }),
+    keys: vi.fn(async () => Object.keys(openCaches)),
+    delete: vi.fn(async (name) => {
+      const existed = name in openCaches;
+      delete openCaches[name];
+      delete cacheContents[name];
+      return existed;
+    }),
+    match: vi.fn(async () => undefined),
+  };
+
+  // ------------------------------------------------------------------
+  // clients API stub
+  // ------------------------------------------------------------------
+  const mockClients = [
+    { id: "client-1", postMessage: vi.fn() },
+    { id: "client-2", postMessage: vi.fn() },
+  ];
+
+  const clientsStub = {
+    claim: vi.fn(async () => {}),
+    matchAll: vi.fn(async () => mockClients),
+  };
+
+  // ------------------------------------------------------------------
+  // self — the ServiceWorkerGlobalScope proxy
+  // ------------------------------------------------------------------
+  const scope = {
+    // Allow tests to inject a build id
+    __BUILD_ID: overrides.__BUILD_ID || undefined,
+    location: { origin: "https://stellopay.com" },
+    addEventListener,
+    skipWaiting: vi.fn(),
+    caches,
+    clients: clientsStub,
+    fetch: vi.fn(),
+    // Make fetch accessible as a global inside the SW source
+    ...overrides,
+  };
+
+  // Expose scope as `self` inside the evaluated script.
+  // We wrap the source so all references to `self` hit our stub.
+  const wrappedSource = `
+    (function(self, caches, fetch, clients) {
+      ${SW_SOURCE}
+    })(scope, scope.caches, scope.fetch, scope.clients);
+  `;
+
+  // eslint-disable-next-line no-new-func
+  new Function("scope", wrappedSource)(scope);
+
+  return { scope, fireEvent, openCaches, mockClients, cacheContents };
+}
+
+// ---------------------------------------------------------------------------
+// Shared SHELL_ASSETS list (must match sw.js)
+// ---------------------------------------------------------------------------
+const SHELL_ASSETS = [
+  "/offline",
+  "/manifest.json",
+  "/icons/icon-192x192.png",
+  "/icons/icon-512x512.png",
+  "/favicon.ico",
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Service Worker — install", () => {
+  it("happy path: pre-caches all shell assets and does NOT call skipWaiting", async () => {
+    const { scope, fireEvent, openCaches } = buildScope();
+
+    // Open the expected cache before install so it exists.
+    await scope.caches.open("stellopay-shell-v1");
+    // Reset the mock so addAll recording is fresh.
+    openCaches["stellopay-shell-v1"].addAll.mockClear();
+
+    await fireEvent("install");
+
+    // The versioned cache must have been opened.
+    expect(scope.caches.open).toHaveBeenCalledWith("stellopay-shell-v1");
+
+    // All shell assets must be pre-cached.
+    expect(openCaches["stellopay-shell-v1"].addAll).toHaveBeenCalledWith(
+      SHELL_ASSETS,
+    );
+
+    // skipWaiting must NOT be called during install — we defer to the client.
+    expect(scope.skipWaiting).not.toHaveBeenCalled();
+  });
+
+  it("uses CACHE_VERSION injected via __BUILD_ID", async () => {
+    const { scope, openCaches } = buildScope({ __BUILD_ID: "build-abc123" });
+
+    await scope.caches.open("stellopay-shell-build-abc123");
+    openCaches["stellopay-shell-build-abc123"].addAll.mockClear();
+
+    await (async () => {
+      // Re-fire install on the scoped worker.
+      let waitUntilPromise = Promise.resolve();
+      const event = {
+        waitUntil: (p) => { waitUntilPromise = Promise.resolve(p); },
+      };
+      const handler = scope.addEventListener.mock.calls.find(
+        ([t]) => t === "install",
+      )?.[1];
+      if (handler) handler(event);
+      return waitUntilPromise;
+    })();
+
+    expect(scope.caches.open).toHaveBeenCalledWith(
+      "stellopay-shell-build-abc123",
+    );
+  });
+
+  it("failure: install promise rejects and skipWaiting is not called if addAll fails", async () => {
+    const { scope, fireEvent, openCaches } = buildScope();
+
+    // Seed the cache stub before the worker runs its own open.
+    await scope.caches.open("stellopay-shell-v1");
+
+    // Make addAll() reject to simulate a network error during precache.
+    openCaches["stellopay-shell-v1"].addAll.mockRejectedValue(
+      new Error("network error"),
+    );
+
+    // The waitUntil promise should reject.
+    await expect(fireEvent("install")).rejects.toThrow("network error");
+
+    // skipWaiting must not be called — the install failed.
+    expect(scope.skipWaiting).not.toHaveBeenCalled();
+  });
+});
+
+describe("Service Worker — activate", () => {
+  it("removes stale caches that do not match the current CACHE_NAME", async () => {
+    const { scope, fireEvent, openCaches } = buildScope();
+
+    // Seed two stale caches plus the current one.
+    openCaches["stellopay-shell-v0"] = { addAll: vi.fn(), put: vi.fn(), match: vi.fn() };
+    openCaches["stellopay-shell-old"] = { addAll: vi.fn(), put: vi.fn(), match: vi.fn() };
+    openCaches["stellopay-shell-v1"] = { addAll: vi.fn(), put: vi.fn(), match: vi.fn() };
+
+    await fireEvent("activate");
+
+    // Stale caches must be deleted.
+    expect(scope.caches.delete).toHaveBeenCalledWith("stellopay-shell-v0");
+    expect(scope.caches.delete).toHaveBeenCalledWith("stellopay-shell-old");
+
+    // The current cache must NOT be deleted.
+    expect(scope.caches.delete).not.toHaveBeenCalledWith("stellopay-shell-v1");
+  });
+
+  it("calls clients.claim() after pruning old caches", async () => {
+    const { scope, fireEvent, openCaches } = buildScope();
+
+    openCaches["stellopay-shell-v1"] = { addAll: vi.fn(), put: vi.fn(), match: vi.fn() };
+
+    await fireEvent("activate");
+
+    expect(scope.clients.claim).toHaveBeenCalledOnce();
+  });
+
+  it("posts SW_ACTIVATED message to all open clients after activation", async () => {
+    const { scope, fireEvent, mockClients, openCaches } = buildScope();
+
+    openCaches["stellopay-shell-v1"] = { addAll: vi.fn(), put: vi.fn(), match: vi.fn() };
+
+    await fireEvent("activate");
+
+    // matchAll should be called to enumerate clients.
+    expect(scope.clients.matchAll).toHaveBeenCalledWith({
+      includeUncontrolled: true,
+    });
+
+    // Every client should receive the SW_ACTIVATED message.
+    for (const client of mockClients) {
+      expect(client.postMessage).toHaveBeenCalledWith({
+        type: "SW_ACTIVATED",
+        version: "v1",
+      });
+    }
+  });
+
+  it("posts SW_ACTIVATED with the correct injected version", async () => {
+    const { scope, fireEvent, mockClients, openCaches } = buildScope({
+      __BUILD_ID: "deploy-42",
+    });
+
+    openCaches["stellopay-shell-deploy-42"] = {
+      addAll: vi.fn(),
+      put: vi.fn(),
+      match: vi.fn(),
+    };
+
+    await fireEvent("activate");
+
+    for (const client of mockClients) {
+      expect(client.postMessage).toHaveBeenCalledWith({
+        type: "SW_ACTIVATED",
+        version: "deploy-42",
+      });
+    }
+  });
+
+  it("old caches are only removed after activate (install does not prune)", async () => {
+    const { scope, fireEvent, openCaches } = buildScope();
+
+    // Seed old cache.
+    openCaches["stellopay-shell-v0"] = { addAll: vi.fn(), put: vi.fn(), match: vi.fn() };
+    openCaches["stellopay-shell-v1"] = { addAll: vi.fn(), put: vi.fn(), match: vi.fn() };
+
+    // After install, old cache must still be present.
+    await fireEvent("install");
+    expect(scope.caches.delete).not.toHaveBeenCalledWith("stellopay-shell-v0");
+
+    // After activate, old cache must be gone.
+    await fireEvent("activate");
+    expect(scope.caches.delete).toHaveBeenCalledWith("stellopay-shell-v0");
+  });
+});
+
+describe("Service Worker — client reload coordination (SKIP_WAITING)", () => {
+  it("calls skipWaiting when it receives a SKIP_WAITING message", () => {
+    const { scope } = buildScope();
+
+    // Fire a synthetic message event with SKIP_WAITING.
+    const messageHandler = scope.addEventListener.mock.calls.find(
+      ([t]) => t === "message",
+    )?.[1];
+
+    expect(messageHandler).toBeDefined();
+
+    messageHandler({ data: { type: "SKIP_WAITING" } });
+
+    expect(scope.skipWaiting).toHaveBeenCalledOnce();
+  });
+
+  it("does not call skipWaiting for unrelated message types", () => {
+    const { scope } = buildScope();
+
+    const messageHandler = scope.addEventListener.mock.calls.find(
+      ([t]) => t === "message",
+    )?.[1];
+
+    messageHandler({ data: { type: "SOME_OTHER_MESSAGE" } });
+    messageHandler({ data: null });
+    messageHandler({});
+
+    expect(scope.skipWaiting).not.toHaveBeenCalled();
+  });
+
+  it("clients.claim() is called before posting SW_ACTIVATED so clients are controlled first", async () => {
+    const { scope, fireEvent, openCaches } = buildScope();
+    openCaches["stellopay-shell-v1"] = { addAll: vi.fn(), put: vi.fn(), match: vi.fn() };
+
+    const callOrder = [];
+    scope.clients.claim.mockImplementation(async () => {
+      callOrder.push("claim");
+    });
+    scope.clients.matchAll.mockImplementation(async () => {
+      callOrder.push("matchAll");
+      return [];
+    });
+
+    await fireEvent("activate");
+
+    expect(callOrder).toEqual(["claim", "matchAll"]);
+  });
+});
+
+describe("Service Worker — offline fallback availability during update", () => {
+  it("registers a fetch event listener (offline fallback is wired up)", () => {
+    const { scope } = buildScope();
+
+    const fetchHandlers = scope.addEventListener.mock.calls.filter(
+      ([t]) => t === "fetch",
+    );
+    expect(fetchHandlers.length).toBeGreaterThan(0);
+  });
+
+  it("shell assets include /offline so fallback is pre-cached during install", async () => {
+    const { scope, fireEvent, openCaches } = buildScope();
+
+    await scope.caches.open("stellopay-shell-v1");
+    openCaches["stellopay-shell-v1"].addAll.mockClear();
+
+    await fireEvent("install");
+
+    const [cachedUrls] =
+      openCaches["stellopay-shell-v1"].addAll.mock.calls[0];
+
+    expect(cachedUrls).toContain("/offline");
+  });
+});


### PR DESCRIPTION
Problem
  
  An old service-worker cache can serve stale application assets after a deployment, leaving users with a mix of incompatible HTML and JavaScript bundles. The
  root cause was skipWaiting() being called unconditionally during install, allowing the new worker to take over clients that still had HTML from the previous
  build in flight.
  
  Solution
  
  Three-step handshake between the worker and its clients:
  
  1. Install — pre-cache the full shell into a versioned cache. skipWaiting is not called. The old worker keeps serving until clients agree to switch.
  2. Activate — triggered only after install succeeds. Stale caches are pruned, clients.claim() runs, then SW_ACTIVATED is broadcast to all open clients so the
  app can prompt a reload.
  3. Client-driven skip — the page sends { type: "SKIP_WAITING" } to the waiting worker (e.g. on a "Reload to update" banner click). Only then does the worker
  call skipWaiting().
  
  Changes
  
  public/sw.js
  
  - Removed skipWaiting() from install — prevents new worker from taking over mid-flight clients
  - Added SKIP_WAITING message handler — page controls when the handover happens
  - Stale caches deleted in activate only, after the new cache is confirmed valid
  - clients.claim() called before SW_ACTIVATED broadcast so clients are controlled before they receive the reload signal
  - CACHE_VERSION reads self.__BUILD_ID for CI injection; falls back to "v1" locally
  - /offline stays in SHELL_ASSETS — offline fallback is always pre-cached before any activation or cache pruning
  
  public/sw.test.ts (new — 13 tests)

 ┌──────────┬────────────────────────────────────────────────────────────────┐
  │ Suite    │ Coverage                                                       │
  ├──────────┼────────────────────────────────────────────────────────────────┤
  │ install  │ Happy path caches all shell assets; skipWaiting not called     │
  ├──────────┼────────────────────────────────────────────────────────────────┤
  │ install  │ __BUILD_ID injection produces the correct versioned cache name │
  ├──────────┼────────────────────────────────────────────────────────────────┤
  │ install  │ addAll failure rejects waitUntil; skipWaiting not called       │
  ├──────────┼────────────────────────────────────────────────────────────────┤
  │ activate │ Stale caches pruned; current cache preserved                   │
  ├──────────┼────────────────────────────────────────────────────────────────┤
  │ activate │ clients.claim() called after pruning                           │
  ├──────────┼────────────────────────────────────────────────────────────────┤
  │ activate │ SW_ACTIVATED broadcast to every client with correct version    │
  ├──────────┼────────────────────────────────────────────────────────────────┤
  │ activate │ Injected __BUILD_ID version flows through to the postMessage   │
  ├──────────┼────────────────────────────────────────────────────────────────┤
  │ activate │ Old caches not touched during install — only during activate   │
  ├──────────┼────────────────────────────────────────────────────────────────┤
  │ message  │ SKIP_WAITING triggers skipWaiting()                            │
  ├──────────┼────────────────────────────────────────────────────────────────┤
  │ message  │ Unrelated message types do not trigger skipWaiting()           │
  ├──────────┼────────────────────────────────────────────────────────────────┤
  │ ordering │ claim() completes before matchAll() / postMessage              │
  ├──────────┼────────────────────────────────────────────────────────────────┤
  │ offline  │ Fetch listener registered                                      │
  ├──────────┼────────────────────────────────────────────────────────────────┤
  │ offline  │ /offline is in the pre-cached shell assets                     │
  └──────────┴────────────────────────────────────────────────────────────────┘
closes #1173 