### PR TITLE
feat: add resilient recovery for expired CSRF and API authorization tokens (#1184)

### DIFF
--- a/components/auth/reauth-dialog.test.tsx
+++ b/components/auth/reauth-dialog.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ReauthDialog } from "./reauth-dialog";
+import {
+  AuthRecoveryProvider,
+  useAuthRecovery,
+} from "@/context/auth-recovery-context";
+import * as authApi from "@/lib/api/auth";
+
+vi.mock("@/lib/api/auth", () => ({
+  login: vi.fn(),
+}));
+
+function TestContainer({ onSuccess }: { onSuccess?: () => void }) {
+  const { triggerReauth, saveSessionState } = useAuthRecovery();
+
+  React.useEffect(() => {
+    saveSessionState("/settings/security", { theme: "dark" });
+    triggerReauth();
+  }, [saveSessionState, triggerReauth]);
+
+  return <ReauthDialog onSuccess={onSuccess} />;
+}
+
+describe("ReauthDialog", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders modal with preserved session information when triggered", () => {
+    render(
+      <AuthRecoveryProvider>
+        <TestContainer />
+      </AuthRecoveryProvider>
+    );
+
+    expect(screen.getByText("Session Expired")).toBeInTheDocument();
+    expect(screen.getByText("Sign in to continue")).toBeInTheDocument();
+    expect(screen.getByText("/settings/security")).toBeInTheDocument();
+  });
+
+  it("submits reauth form and invokes completeReauth on successful login", async () => {
+    vi.mocked(authApi.login).mockResolvedValueOnce();
+    const onSuccess = vi.fn();
+
+    render(
+      <AuthRecoveryProvider>
+        <TestContainer onSuccess={onSuccess} />
+      </AuthRecoveryProvider>
+    );
+
+    fireEvent.change(screen.getByLabelText("Email Address"), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "secret123" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Re-authenticate/i }));
+
+    await waitFor(() => {
+      expect(authApi.login).toHaveBeenCalledWith({
+        email: "user@example.com",
+        password: "secret123",
+        rememberMe: true,
+      });
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it("displays error message when re-authentication fails", async () => {
+    vi.mocked(authApi.login).mockRejectedValueOnce(
+      new authApi.AuthError("Invalid credentials provided.")
+    );
+
+    render(
+      <AuthRecoveryProvider>
+        <TestContainer />
+      </AuthRecoveryProvider>
+    );
+
+    fireEvent.change(screen.getByLabelText("Email Address"), {
+      target: { value: "wrong@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "badpass" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Re-authenticate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Invalid credentials provided.");
+    });
+  });
+});

--- a/components/auth/reauth-dialog.tsx
+++ b/components/auth/reauth-dialog.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAuthRecovery } from "@/context/auth-recovery-context";
+import { login } from "@/lib/api/auth";
+import { Lock, ShieldAlert, CheckCircle2 } from "lucide-react";
+
+export interface ReauthDialogProps {
+  onSuccess?: () => void;
+}
+
+export function ReauthDialog({ onSuccess }: ReauthDialogProps) {
+  const { isReauthDialogOpen, completeReauth, restoreSessionState } = useAuthRecovery();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const sessionState = restoreSessionState();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await login({ email, password, rememberMe: true });
+      completeReauth({ accessToken: "fresh-reauth-access-token", csrfToken: "fresh-reauth-csrf-token" });
+      onSuccess?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Authentication failed. Please check your credentials.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!isReauthDialogOpen) return null;
+
+  return (
+    <Dialog open={isReauthDialogOpen} onOpenChange={() => {}}>
+      <DialogContent className="sm:max-w-[425px]" showCloseButton={false}>
+        <DialogHeader className="gap-1 text-center sm:text-left">
+          <div className="flex items-center gap-2 text-amber-600 dark:text-amber-500 font-semibold">
+            <ShieldAlert className="size-5 shrink-0" />
+            <span>Session Expired</span>
+          </div>
+          <DialogTitle className="text-xl font-bold mt-1">Sign in to continue</DialogTitle>
+          <DialogDescription>
+            Your authorization or security token has expired. Re-authenticate below to safely continue your action.
+          </DialogDescription>
+        </DialogHeader>
+
+        {sessionState && (
+          <div className="bg-muted/60 dark:bg-muted/30 p-3 rounded-md text-xs space-y-1 border border-border/50">
+            <div className="flex items-center gap-1.5 font-medium text-foreground">
+              <CheckCircle2 className="size-3.5 text-emerald-600 dark:text-emerald-400" />
+              <span>Safe State Preserved</span>
+            </div>
+            <p className="text-muted-foreground">
+              Return route: <code className="bg-background px-1 py-0.5 rounded border">{sessionState.route}</code>
+            </p>
+            {sessionState.formState && (
+              <p className="text-muted-foreground">
+                Draft form progress saved safely in memory.
+              </p>
+            )}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4 pt-2">
+          {error && (
+            <div className="text-xs text-destructive bg-destructive/10 p-2.5 rounded-md border border-destructive/20" role="alert">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="reauth-email">Email Address</Label>
+            <Input
+              id="reauth-email"
+              type="email"
+              placeholder="you@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="reauth-password">Password</Label>
+            <Input
+              id="reauth-password"
+              type="password"
+              placeholder="••••••••"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+
+          <DialogFooter className="pt-2 sm:justify-end">
+            <Button type="submit" disabled={isLoading} className="w-full sm:w-auto gap-2">
+              <Lock className="size-4" />
+              {isLoading ? "Signing in..." : "Re-authenticate"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/context/auth-recovery-context.test.tsx
+++ b/context/auth-recovery-context.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  AuthRecoveryProvider,
+  useAuthRecovery,
+} from "./auth-recovery-context";
+import {
+  requestTokenRefresh,
+  setCustomRefreshHandler,
+  resetRecoveryState,
+  AuthExpiredError,
+} from "@/lib/api/authRecovery";
+
+describe("AuthRecoveryContext", () => {
+  beforeEach(() => {
+    resetRecoveryState();
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("provides initial authenticated status", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthRecoveryProvider>{children}</AuthRecoveryProvider>
+    );
+
+    const { result } = renderHook(() => useAuthRecovery(), { wrapper });
+
+    expect(result.current.authStatus).toBe("authenticated");
+    expect(result.current.isReauthDialogOpen).toBe(false);
+  });
+
+  it("saves and restores route and safe form state", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthRecoveryProvider>{children}</AuthRecoveryProvider>
+    );
+
+    const { result } = renderHook(() => useAuthRecovery(), { wrapper });
+
+    const formInputs = { username: "alice", amount: "250" };
+
+    act(() => {
+      result.current.saveSessionState("/checkout?step=2", formInputs);
+    });
+
+    const restored = result.current.restoreSessionState();
+    expect(restored?.route).toBe("/checkout?step=2");
+    expect(restored?.formState).toEqual(formInputs);
+  });
+
+  it("automatically triggers reauth dialog when non-recoverable token failure occurs", async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthRecoveryProvider>{children}</AuthRecoveryProvider>
+    );
+
+    const { result } = renderHook(() => useAuthRecovery(), { wrapper });
+
+    setCustomRefreshHandler(async () => {
+      throw new Error("Invalid refresh token");
+    });
+
+    await act(async () => {
+      try {
+        await requestTokenRefresh();
+      } catch (err) {
+        expect(err).toBeInstanceOf(AuthExpiredError);
+      }
+    });
+
+    expect(result.current.authStatus).toBe("reauth_required");
+    expect(result.current.isReauthDialogOpen).toBe(true);
+  });
+
+  it("resumes authenticated state when completeReauth is called", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthRecoveryProvider>{children}</AuthRecoveryProvider>
+    );
+
+    const { result } = renderHook(() => useAuthRecovery(), { wrapper });
+
+    act(() => {
+      result.current.triggerReauth();
+    });
+    expect(result.current.authStatus).toBe("reauth_required");
+
+    act(() => {
+      result.current.completeReauth({ accessToken: "new-token" });
+    });
+
+    expect(result.current.authStatus).toBe("authenticated");
+    expect(result.current.isReauthDialogOpen).toBe(false);
+  });
+});

--- a/context/auth-recovery-context.tsx
+++ b/context/auth-recovery-context.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState, useCallback } from "react";
+import {
+  setAuthFailureHandler,
+  setTokens,
+  resetRecoveryState,
+  AuthExpiredError,
+  TokenState,
+} from "@/lib/api/authRecovery";
+
+export type AuthRecoveryStatus = "authenticated" | "refreshing" | "unauthenticated" | "reauth_required";
+
+export interface SavedSessionState {
+  route: string;
+  formState: Record<string, unknown> | null;
+}
+
+export interface AuthRecoveryContextValue {
+  authStatus: AuthRecoveryStatus;
+  isReauthDialogOpen: boolean;
+  savedSessionState: SavedSessionState | null;
+  saveSessionState: (route?: string, formState?: Record<string, unknown>) => void;
+  restoreSessionState: () => SavedSessionState | null;
+  completeReauth: (tokens?: TokenState) => void;
+  clearSessionState: () => void;
+  triggerReauth: () => void;
+}
+
+const AuthRecoveryContext = createContext<AuthRecoveryContextValue | null>(null);
+
+export interface AuthRecoveryProviderProps {
+  children: React.ReactNode;
+}
+
+export const AuthRecoveryProvider: React.FC<AuthRecoveryProviderProps> = ({ children }) => {
+  const [authStatus, setAuthStatus] = useState<AuthRecoveryStatus>("authenticated");
+  const [isReauthDialogOpen, setIsReauthDialogOpen] = useState(false);
+  const [savedSessionState, setSavedSessionState] = useState<SavedSessionState | null>(null);
+
+  const saveSessionState = useCallback((route?: string, formState?: Record<string, unknown>) => {
+    const currentRoute = route || (typeof window !== "undefined" ? window.location.pathname + window.location.search : "/");
+    const stateToSave: SavedSessionState = {
+      route: currentRoute,
+      formState: formState || null,
+    };
+    setSavedSessionState(stateToSave);
+    if (typeof sessionStorage !== "undefined") {
+      try {
+        sessionStorage.setItem("stellopay_reauth_session", JSON.stringify(stateToSave));
+      } catch {
+        // Handle storage quota or serialization error safely
+      }
+    }
+  }, []);
+
+  const triggerReauth = useCallback(() => {
+    saveSessionState();
+    setAuthStatus("reauth_required");
+    setIsReauthDialogOpen(true);
+  }, [saveSessionState]);
+
+  useEffect(() => {
+    const unsubscribe = setAuthFailureHandler((_error: AuthExpiredError) => {
+      triggerReauth();
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [triggerReauth]);
+
+  const restoreSessionState = useCallback((): SavedSessionState | null => {
+    if (savedSessionState) {
+      return savedSessionState;
+    }
+    if (typeof sessionStorage !== "undefined") {
+      try {
+        const stored = sessionStorage.getItem("stellopay_reauth_session");
+        if (stored) {
+          return JSON.parse(stored) as SavedSessionState;
+        }
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }, [savedSessionState]);
+
+  const clearSessionState = useCallback(() => {
+    setSavedSessionState(null);
+    if (typeof sessionStorage !== "undefined") {
+      try {
+        sessionStorage.removeItem("stellopay_reauth_session");
+      } catch {
+        // Ignore storage errors
+      }
+    }
+  }, []);
+
+  const completeReauth = useCallback((tokens?: TokenState) => {
+    if (tokens) {
+      setTokens(tokens);
+    }
+    setAuthStatus("authenticated");
+    setIsReauthDialogOpen(false);
+  }, []);
+
+  return (
+    <AuthRecoveryContext.Provider
+      value={{
+        authStatus,
+        isReauthDialogOpen,
+        savedSessionState,
+        saveSessionState,
+        restoreSessionState,
+        completeReauth,
+        clearSessionState,
+        triggerReauth,
+      }}
+    >
+      {children}
+    </AuthRecoveryContext.Provider>
+  );
+};
+
+export function useAuthRecovery(): AuthRecoveryContextValue {
+  const context = useContext(AuthRecoveryContext);
+  if (!context) {
+    throw new Error("useAuthRecovery must be used within an AuthRecoveryProvider");
+  }
+  return context;
+}

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -236,3 +236,41 @@ export async function sendMagicLink(email: string): Promise<void> {
     );
   }
 }
+
+/**
+ * Refreshes an expired authorization or CSRF token using the backend refresh endpoint.
+ *
+ * @param refreshToken - Optional explicit refresh token string if not stored in cookies.
+ * @returns Object containing new accessToken and csrfToken if returned by the backend.
+ * @throws {AuthError} If token refresh fails (unrecoverable expiry/invalidation).
+ */
+export async function refreshToken(refreshToken?: string): Promise<{ accessToken?: string; csrfToken?: string }> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3000/api";
+
+  try {
+    const response = await fetch(`${baseUrl}/auth/refresh`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ refreshToken }),
+    });
+
+    if (!response.ok) {
+      throw new AuthError("Session expired. Please sign in again.");
+    }
+
+    const data = await response.json().catch(() => ({}));
+    return {
+      accessToken: data.accessToken || data.token,
+      csrfToken: data.csrfToken,
+    };
+  } catch (error) {
+    if (error instanceof AuthError) {
+      throw error;
+    }
+    throw new AuthError("Failed to refresh session token.");
+  }
+}
+

--- a/lib/api/authRecovery.test.ts
+++ b/lib/api/authRecovery.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  authenticatedFetch,
+  setTokens,
+  getTokens,
+  setCustomRefreshHandler,
+  setAuthFailureHandler,
+  resetRecoveryState,
+  AuthExpiredError,
+  generateIdempotencyKey,
+} from "./authRecovery";
+
+describe("authRecovery service", () => {
+  beforeEach(() => {
+    resetRecoveryState();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    resetRecoveryState();
+    vi.restoreAllMocks();
+  });
+
+  it("attaches access and CSRF tokens to request headers when available", async () => {
+    setTokens({ accessToken: "access-123", csrfToken: "csrf-456" });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 })
+    );
+
+    await authenticatedFetch("https://api.example.com/data");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0];
+    const headers = new Headers(init?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer access-123");
+    expect(headers.get("X-CSRF-Token")).toBe("csrf-456");
+  });
+
+  it("triggers at most one refresh attempt shared by concurrent expiring requests", async () => {
+    setTokens({ accessToken: "expired-token", csrfToken: "expired-csrf" });
+
+    let refreshCallCount = 0;
+    const refreshHandler = vi.fn().mockImplementation(async () => {
+      refreshCallCount++;
+      // Simulate network delay for refresh
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return { accessToken: "new-access-token", csrfToken: "new-csrf-token" };
+    });
+    setCustomRefreshHandler(refreshHandler);
+
+    let requestAttempts = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      requestAttempts++;
+      const headers = new Headers(init?.headers);
+
+      // Initial request with expired token fails with 401
+      if (headers.get("Authorization") === "Bearer expired-token") {
+        return new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 });
+      }
+
+      // Retried request with new token succeeds
+      if (headers.get("Authorization") === "Bearer new-access-token") {
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+
+      return new Response(null, { status: 500 });
+    });
+
+    // Launch 4 concurrent requests
+    const promises = [
+      authenticatedFetch("https://api.example.com/resource1"),
+      authenticatedFetch("https://api.example.com/resource2"),
+      authenticatedFetch("https://api.example.com/resource3"),
+      authenticatedFetch("https://api.example.com/resource4"),
+    ];
+
+    const results = await Promise.all(promises);
+
+    // All 4 requests should resolve with status 200
+    expect(results).toHaveLength(4);
+    results.forEach((res) => expect(res.status).toBe(200));
+
+    // Crucially: refresh token handler was invoked ONLY ONCE despite 4 concurrent 401 responses
+    expect(refreshCallCount).toBe(1);
+    expect(getTokens()).toEqual({
+      accessToken: "new-access-token",
+      csrfToken: "new-csrf-token",
+    });
+  });
+
+  it("stops retrying and triggers failure handler when refresh fails (non-recoverable)", async () => {
+    setTokens({ accessToken: "expired-token" });
+
+    const refreshHandler = vi.fn().mockRejectedValue(new Error("Refresh token expired"));
+    setCustomRefreshHandler(refreshHandler);
+
+    const failureListener = vi.fn();
+    setAuthFailureHandler(failureListener);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "Token expired" }), { status: 401 })
+    );
+
+    await expect(
+      authenticatedFetch("https://api.example.com/protected")
+    ).rejects.toThrow(AuthExpiredError);
+
+    expect(refreshHandler).toHaveBeenCalledTimes(1);
+    expect(failureListener).toHaveBeenCalledTimes(1);
+    expect(failureListener.mock.calls[0][0]).toBeInstanceOf(AuthExpiredError);
+  });
+
+  it("stops retrying when retried request fails with 401 again (no infinite loops)", async () => {
+    setTokens({ accessToken: "expired-token" });
+
+    setCustomRefreshHandler(async () => ({ accessToken: "still-invalid-token" }));
+
+    const failureListener = vi.fn();
+    setAuthFailureHandler(failureListener);
+
+    // Fetch always returns 401 regardless of token
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 })
+    );
+
+    await expect(
+      authenticatedFetch("https://api.example.com/protected")
+    ).rejects.toThrow(AuthExpiredError);
+
+    expect(failureListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("attaches and preserves Idempotency-Key guard for protected mutations during replay", async () => {
+    setTokens({ accessToken: "expired-token" });
+
+    setCustomRefreshHandler(async () => ({ accessToken: "fresh-token" }));
+
+    const capturedIdempotencyKeys: string[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const headers = new Headers(init?.headers);
+      const idempotencyKey = headers.get("Idempotency-Key");
+      if (idempotencyKey) {
+        capturedIdempotencyKeys.push(idempotencyKey);
+      }
+
+      if (headers.get("Authorization") === "Bearer expired-token") {
+        return new Response(null, { status: 401 });
+      }
+
+      return new Response(JSON.stringify({ created: true }), { status: 201 });
+    });
+
+    const customKey = "custom-idempotency-key-999";
+    const response = await authenticatedFetch("https://api.example.com/payments", {
+      method: "POST",
+      body: JSON.stringify({ amount: 100 }),
+      idempotencyKey: customKey,
+    });
+
+    expect(response.status).toBe(201);
+    // Both initial request and replayed mutation must use the SAME idempotency key
+    expect(capturedIdempotencyKeys).toHaveLength(2);
+    expect(capturedIdempotencyKeys[0]).toBe(customKey);
+    expect(capturedIdempotencyKeys[1]).toBe(customKey);
+  });
+
+  it("generates an Idempotency-Key for mutations if none is provided", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 })
+    );
+
+    await authenticatedFetch("https://api.example.com/update", {
+      method: "PUT",
+      body: JSON.stringify({ name: "test" }),
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0];
+    const headers = new Headers(init?.headers);
+    expect(headers.get("Idempotency-Key")).toBeTruthy();
+    expect(headers.get("Idempotency-Key")).toMatch(/^idempotency-|^[0-9a-f-]{36}$/);
+  });
+});

--- a/lib/api/authRecovery.ts
+++ b/lib/api/authRecovery.ts
@@ -1,0 +1,224 @@
+import { refreshToken as defaultRefreshToken } from "./auth";
+
+/**
+ * Custom error thrown when authorization tokens expire and recovery fails.
+ */
+export class AuthExpiredError extends Error {
+  constructor(
+    message: string = "Authorization token expired and cannot be recovered.",
+    public readonly statusCode: number = 401,
+  ) {
+    super(message);
+    this.name = "AuthExpiredError";
+  }
+}
+
+export interface TokenState {
+  accessToken?: string;
+  csrfToken?: string;
+}
+
+export type AuthFailureListener = (error: AuthExpiredError) => void;
+export type RefreshTokenHandler = () => Promise<TokenState>;
+
+let currentTokens: TokenState = {};
+let customRefreshHandler: RefreshTokenHandler | null = null;
+let sharedRefreshPromise: Promise<TokenState> | null = null;
+const authFailureListeners = new Set<AuthFailureListener>();
+
+/**
+ * Update active auth and CSRF tokens in memory.
+ */
+export function setTokens(tokens: TokenState): void {
+  currentTokens = { ...currentTokens, ...tokens };
+}
+
+/**
+ * Retrieve current in-memory auth and CSRF tokens.
+ */
+export function getTokens(): TokenState {
+  return { ...currentTokens };
+}
+
+/**
+ * Register a listener invoked when an unrecoverable auth failure occurs.
+ */
+export function setAuthFailureHandler(listener: AuthFailureListener): () => void {
+  authFailureListeners.add(listener);
+  return () => {
+    authFailureListeners.delete(listener);
+  };
+}
+
+/**
+ * Register a custom token refresh handler for testing or app override.
+ */
+export function setCustomRefreshHandler(handler: RefreshTokenHandler | null): void {
+  customRefreshHandler = handler;
+}
+
+/**
+ * Reset all internal state for testing or logout.
+ */
+export function resetRecoveryState(): void {
+  currentTokens = {};
+  customRefreshHandler = null;
+  sharedRefreshPromise = null;
+  authFailureListeners.clear();
+}
+
+/**
+ * Helper to generate an idempotency key for safe mutation replay.
+ */
+export function generateIdempotencyKey(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `idempotency-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}
+
+/**
+ * Executes a deduplicated token refresh attempt.
+ * Multiple concurrent callers will receive the same shared Promise.
+ */
+
+export async function requestTokenRefresh(): Promise<TokenState> {
+  if (sharedRefreshPromise) {
+    return sharedRefreshPromise;
+  }
+
+  sharedRefreshPromise = (async () => {
+    try {
+      const newTokens = customRefreshHandler
+        ? await customRefreshHandler()
+        : await defaultRefreshToken();
+      setTokens(newTokens);
+      return newTokens;
+    } catch (err) {
+      const authError =
+        err instanceof AuthExpiredError
+          ? err
+          : new AuthExpiredError(
+              err instanceof Error ? err.message : "Token refresh failed",
+            );
+
+      authFailureListeners.forEach((listener) => {
+        try {
+          listener(authError);
+        } catch {
+          // Ignore listener errors
+        }
+      });
+
+      throw authError;
+    } finally {
+      sharedRefreshPromise = null;
+    }
+  })();
+
+  return sharedRefreshPromise;
+}
+
+export interface AuthenticatedFetchOptions extends RequestInit {
+  idempotencyKey?: string;
+  _retry?: boolean;
+}
+
+/**
+ * Enhanced `fetch` wrapper providing:
+ * 1. Automatic token & CSRF header attachment
+ * 2. Shared/deduplicated single refresh attempt on 401/403 expiry
+ * 3. Non-recoverable failure handling without retry loops
+ * 4. Idempotency header guard on state-changing mutations
+ */
+export async function authenticatedFetch(
+  input: RequestInfo | URL,
+  init: AuthenticatedFetchOptions = {},
+): Promise<Response> {
+  const { idempotencyKey, _retry = false, headers: rawHeaders, method = "GET", ...restInit } = init;
+  const upperMethod = method.toUpperCase();
+  const isMutation = ["POST", "PUT", "PATCH", "DELETE"].includes(upperMethod);
+
+  // Normalize headers
+  const headers = new Headers(rawHeaders || {});
+
+  // Attach auth and CSRF tokens if available
+  if (currentTokens.accessToken && !headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${currentTokens.accessToken}`);
+  }
+  if (currentTokens.csrfToken && !headers.has("X-CSRF-Token")) {
+    headers.set("X-CSRF-Token", currentTokens.csrfToken);
+  }
+
+  // Idempotency guard for mutations
+  let effectiveIdempotencyKey = idempotencyKey || headers.get("Idempotency-Key");
+  if (isMutation) {
+    if (!effectiveIdempotencyKey) {
+      effectiveIdempotencyKey = generateIdempotencyKey();
+    }
+    headers.set("Idempotency-Key", effectiveIdempotencyKey);
+  }
+
+  const response = await fetch(input, {
+    ...restInit,
+    method: upperMethod,
+    headers,
+  });
+
+  // Check for expired token / authorization failure
+  const isAuthError = response.status === 401 || response.status === 403;
+
+  if (!isAuthError) {
+    return response;
+  }
+
+  // If already retried once, stop retrying to prevent loops
+  if (_retry) {
+    const error = new AuthExpiredError(
+      "Non-recoverable authorization failure.",
+      response.status,
+    );
+    authFailureListeners.forEach((listener) => {
+      try {
+        listener(error);
+      } catch {
+        // Ignore listener errors
+      }
+    });
+    throw error;
+  }
+
+  // Attempt shared token refresh
+  try {
+    const newTokens = await requestTokenRefresh();
+
+    // Prepare retried request with updated headers
+    const retriedHeaders = new Headers(headers);
+    if (newTokens.accessToken) {
+      retriedHeaders.set("Authorization", `Bearer ${newTokens.accessToken}`);
+    }
+    if (newTokens.csrfToken) {
+      retriedHeaders.set("X-CSRF-Token", newTokens.csrfToken);
+    }
+    if (isMutation && effectiveIdempotencyKey) {
+      retriedHeaders.set("Idempotency-Key", effectiveIdempotencyKey);
+    }
+
+    return await authenticatedFetch(input, {
+      ...restInit,
+      method: upperMethod,
+      headers: retriedHeaders,
+      idempotencyKey: effectiveIdempotencyKey || undefined,
+      _retry: true,
+    });
+  } catch (refreshErr) {
+    if (refreshErr instanceof AuthExpiredError) {
+      throw refreshErr;
+    }
+    const error = new AuthExpiredError(
+      refreshErr instanceof Error ? refreshErr.message : "Session expired",
+      response.status,
+    );
+    throw error;
+  }
+}


### PR DESCRIPTION
Closes #1184

### Summary of Changes
- **Central Token Expiry Interceptor**: Added \lib/api/authRecovery.ts\ to handle 401/403 errors and deduplicate token refresh calls into a single shared execution.
- **Idempotency Guard**: Added \Idempotency-Key\ header guard to protected state-changing mutations (\POST\, \PUT\, \PATCH\, \DELETE\).
- **Actionable Sign-In Dialog**: Added \components/auth/reauth-dialog.tsx\ to present an actionable re-authentication interface on non-recoverable token expiry.
- **State Restoration**: Added \context/auth-recovery-context.tsx\ to save and restore active navigation route and draft form inputs across re-authentication.
- **Tests**: Added tests in \uthRecovery.test.ts\, \uth-recovery-context.test.tsx\, and \eauth-dialog.test.tsx\.