### PR TITLE
fix: add account-scoped cleanup for realtime subscriptions (#1179)

### DIFF
--- a/context/wallet-context.test.tsx
+++ b/context/wallet-context.test.tsx
@@ -1,6 +1,12 @@
-import { act, render, renderHook, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import React from "react";
+import React, { useEffect } from "react";
 
 import {
   DEFAULT_NETWORK,
@@ -9,6 +15,7 @@ import {
   formatAddress,
   useWallet,
 } from "@/context/wallet-context";
+import { createAccountScope, realtimeRegistry } from "@/lib/realtime-registry";
 import { WALLET_NETWORK_STORAGE_KEY } from "@/types/wallet";
 import {
   INVALID_SECRET_SEED,
@@ -524,6 +531,132 @@ describe("WalletProvider – network-change event handling", () => {
       });
       unmount();
     }).not.toThrow();
+  });
+});
+
+// ─── Realtime subscription teardown (issue #1179) ────────────────────────────
+//
+// The WalletProvider owns the account scope, so it is responsible for tearing
+// down every realtime channel of the previous account before the new account
+// context takes over. These tests drive a probe component that opens a channel
+// through the shared registry and verify the provider closes it on account
+// switch, logout, and unmount.
+
+describe("WalletProvider – realtime subscription teardown", () => {
+  const SECOND_VALID_WALLET_ADDRESS = "G" + "B".repeat(55);
+
+  /**
+   * Probe that opens a realtime channel for the current wallet scope, the
+   * same way a view using useAccountScopedSubscription would.
+   */
+  function RealtimeProbe() {
+    const { address, network } = useWallet();
+    const scope = createAccountScope(network.id, address);
+
+    useEffect(() => {
+      if (!scope) return;
+      return realtimeRegistry.subscribe(scope, "probe-channel", () => {
+        // no-op listener; presence on the registry is what we assert
+      });
+    }, [scope]);
+
+    return null;
+  }
+
+  function Harness() {
+    const wallet = useWallet();
+    return (
+      <div>
+        <button
+          type="button"
+          data-testid="connect-a"
+          onClick={() => wallet.connect(VALID_WALLET_ADDRESS)}
+        >
+          connect A
+        </button>
+        <button
+          type="button"
+          data-testid="connect-b"
+          onClick={() => wallet.connect(SECOND_VALID_WALLET_ADDRESS)}
+        >
+          connect B
+        </button>
+        <button
+          type="button"
+          data-testid="disconnect"
+          onClick={() => wallet.disconnect()}
+        >
+          disconnect
+        </button>
+        <RealtimeProbe />
+      </div>
+    );
+  }
+
+  function renderHarness() {
+    return render(
+      <WalletProvider>
+        <Harness />
+      </WalletProvider>,
+    );
+  }
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    realtimeRegistry.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    realtimeRegistry.clear();
+  });
+
+  it("opens a channel scoped to the connected account", () => {
+    renderHarness();
+    fireEvent.click(screen.getByTestId("connect-a"));
+
+    expect(realtimeRegistry.getActiveChannelCount("probe-channel")).toBe(1);
+    expect(realtimeRegistry.getChannelScope("probe-channel")).toBe(
+      `stellar:${VALID_WALLET_ADDRESS}`,
+    );
+  });
+
+  it("tears down the previous account's channels before the new account subscribes", () => {
+    renderHarness();
+    fireEvent.click(screen.getByTestId("connect-a"));
+    expect(realtimeRegistry.getChannelScope("probe-channel")).toBe(
+      `stellar:${VALID_WALLET_ADDRESS}`,
+    );
+
+    // Rapid account switch: B replaces A in the same commit.
+    fireEvent.click(screen.getByTestId("connect-b"));
+
+    expect(realtimeRegistry.getActiveChannelCount("probe-channel")).toBe(1);
+    expect(realtimeRegistry.getChannelScope("probe-channel")).toBe(
+      `stellar:${SECOND_VALID_WALLET_ADDRESS}`,
+    );
+  });
+
+  it("removes all listeners on logout (disconnect)", () => {
+    renderHarness();
+    fireEvent.click(screen.getByTestId("connect-a"));
+    expect(realtimeRegistry.getActiveChannelCount("probe-channel")).toBe(1);
+
+    fireEvent.click(screen.getByTestId("disconnect"));
+
+    expect(realtimeRegistry.getActiveChannelCount("probe-channel")).toBe(0);
+    expect(realtimeRegistry.getListenerCount("probe-channel")).toBe(0);
+  });
+
+  it("removes all listeners on provider unmount", () => {
+    const { unmount } = renderHarness();
+    fireEvent.click(screen.getByTestId("connect-a"));
+    expect(realtimeRegistry.getActiveChannelCount("probe-channel")).toBe(1);
+
+    unmount();
+
+    expect(realtimeRegistry.getActiveChannelCount("probe-channel")).toBe(0);
+    expect(realtimeRegistry.getListenerCount("probe-channel")).toBe(0);
   });
 });
 

--- a/context/wallet-context.tsx
+++ b/context/wallet-context.tsx
@@ -23,6 +23,7 @@ import type {
   WalletProviderProps,
 } from "@/types/wallet";
 import { isWalletAddress, isWalletConnectionResult } from "@/types/wallet";
+import { createAccountScope, realtimeRegistry } from "@/lib/realtime-registry";
 
 // Networks exposed to the UI. Stellar is the only network the product is
 // actually built on, so it is the sole supported entry. The placeholder EVM
@@ -88,6 +89,25 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({
     initialNetwork ?? DEFAULT_NETWORK,
   );
   const [isUnsupportedNetwork, setIsUnsupportedNetwork] = useState(false);
+
+  // Account scope of the currently active wallet context. All realtime
+  // subscriptions opened by views are owned by this scope, so the provider
+  // can tear them down when the account (or network) is replaced.
+  const scope = createAccountScope(network.id, address);
+
+  // Tear down realtime channels owned by the *previous* account scope before
+  // the new account context takes over. React runs this cleanup (which closes
+  // over the old scope) whenever the scope changes — account switch, logout,
+  // network switch — and on provider unmount. Combined with the registry's
+  // ownership guard, this guarantees no previous-account event can ever reach
+  // a listener opened for the current account (issue #1179).
+  useEffect(() => {
+    return () => {
+      if (scope) {
+        realtimeRegistry.unsubscribeScope(scope);
+      }
+    };
+  }, [scope]);
 
   // Hydrate the network on the client. Running this in an effect (rather than
   // in useState's initializer) keeps server and first client render in sync,

--- a/hooks/useAccountScopedSubscription.test.tsx
+++ b/hooks/useAccountScopedSubscription.test.tsx
@@ -1,0 +1,163 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+import { useAccountScopedSubscription } from "./useAccountScopedSubscription";
+import { realtimeRegistry } from "@/lib/realtime-registry";
+import { useWallet } from "@/context/wallet-context";
+
+vi.mock("@/context/wallet-context", () => ({
+  useWallet: vi.fn(),
+}));
+
+const NETWORK_ID = "stellar";
+const ADDRESS_A = "GAAQEAYEAUDAOCAJBIFQYDIOB4IBCEQTCQKRMFYYDENBWHA5DYPSABOV";
+const ADDRESS_B = "G" + "B".repeat(55);
+const CHANNEL = "transactions";
+
+function mockWallet(address: string | null) {
+  (useWallet as Mock).mockReturnValue({
+    address,
+    network: { id: NETWORK_ID },
+  });
+}
+
+describe("useAccountScopedSubscription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    realtimeRegistry.clear();
+  });
+
+  it("does not subscribe while logged out", () => {
+    mockWallet(null);
+    renderHook(() => useAccountScopedSubscription(CHANNEL, () => undefined));
+    expect(realtimeRegistry.getActiveChannelCount(CHANNEL)).toBe(0);
+  });
+
+  it("subscribes to the channel for the current account scope", () => {
+    mockWallet(ADDRESS_A);
+    renderHook(() => useAccountScopedSubscription(CHANNEL, vi.fn()));
+
+    expect(realtimeRegistry.getActiveChannelCount(CHANNEL)).toBe(1);
+    expect(realtimeRegistry.getChannelScope(CHANNEL)).toBe(
+      `${NETWORK_ID}:${ADDRESS_A}`,
+    );
+  });
+
+  it("delivers emitted payloads to the listener of the current account", () => {
+    mockWallet(ADDRESS_A);
+    const listener = vi.fn();
+    renderHook(() => useAccountScopedSubscription(CHANNEL, listener));
+
+    act(() => {
+      realtimeRegistry.emit(CHANNEL, { id: "tx-1" });
+    });
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith({ id: "tx-1" });
+  });
+
+  it("re-renders with a new listener identity keep a single subscription per view", () => {
+    mockWallet(ADDRESS_A);
+    const firstListener = vi.fn();
+    const secondListener = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ listener }) => useAccountScopedSubscription(CHANNEL, listener),
+      { initialProps: { listener: firstListener } },
+    );
+
+    rerender({ listener: secondListener });
+
+    // Listener identity change must not open a second channel.
+    expect(realtimeRegistry.getActiveChannelCount(CHANNEL)).toBe(1);
+
+    act(() => {
+      realtimeRegistry.emit(CHANNEL, "event");
+    });
+
+    // The latest listener receives events; the stale one is detached.
+    expect(secondListener).toHaveBeenCalledExactlyOnceWith("event");
+    expect(firstListener).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes from the previous account and subscribes under the new scope on account switch", () => {
+    mockWallet(ADDRESS_A);
+    const accountAListener = vi.fn();
+    const accountBListener = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ listener }) => useAccountScopedSubscription(CHANNEL, listener),
+      { initialProps: { listener: accountAListener } },
+    );
+
+    mockWallet(ADDRESS_B);
+    rerender({ listener: accountBListener });
+
+    // Exactly one subscription remains, now owned by the new account.
+    expect(realtimeRegistry.getActiveChannelCount(CHANNEL)).toBe(1);
+    expect(realtimeRegistry.getChannelScope(CHANNEL)).toBe(
+      `${NETWORK_ID}:${ADDRESS_B}`,
+    );
+    expect(realtimeRegistry.getListenerCount(CHANNEL)).toBe(1);
+
+    // Events on the channel reach only the current account's listener — the
+    // previous account's listener is fully detached after the switch.
+    act(() => {
+      realtimeRegistry.emit(CHANNEL, "event");
+    });
+    expect(accountBListener).toHaveBeenCalledExactlyOnceWith("event");
+    expect(accountAListener).not.toHaveBeenCalled();
+  });
+
+  it("removes the listener on logout (scope becomes null)", () => {
+    mockWallet(ADDRESS_A);
+    const listener = vi.fn();
+
+    const { rerender } = renderHook(() =>
+      useAccountScopedSubscription(CHANNEL, listener),
+    );
+
+    mockWallet(null);
+    rerender();
+
+    expect(realtimeRegistry.getActiveChannelCount(CHANNEL)).toBe(0);
+
+    act(() => {
+      realtimeRegistry.emit(CHANNEL, "after-logout");
+    });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("removes the listener on unmount", () => {
+    mockWallet(ADDRESS_A);
+    const listener = vi.fn();
+
+    const { unmount } = renderHook(() =>
+      useAccountScopedSubscription(CHANNEL, listener),
+    );
+
+    expect(realtimeRegistry.getActiveChannelCount(CHANNEL)).toBe(1);
+
+    unmount();
+
+    expect(realtimeRegistry.getActiveChannelCount(CHANNEL)).toBe(0);
+    expect(realtimeRegistry.getListenerCount(CHANNEL)).toBe(0);
+
+    act(() => {
+      realtimeRegistry.emit(CHANNEL, "after-unmount");
+    });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("reconnect after unmount opens exactly one subscription per view", () => {
+    mockWallet(ADDRESS_A);
+    const { unmount } = renderHook(() =>
+      useAccountScopedSubscription(CHANNEL, vi.fn()),
+    );
+    unmount();
+    expect(realtimeRegistry.getActiveChannelCount(CHANNEL)).toBe(0);
+
+    // Reconnect — the same view subscribes again without stacking duplicates.
+    renderHook(() => useAccountScopedSubscription(CHANNEL, vi.fn()));
+    expect(realtimeRegistry.getActiveChannelCount(CHANNEL)).toBe(1);
+  });
+});

--- a/hooks/useAccountScopedSubscription.ts
+++ b/hooks/useAccountScopedSubscription.ts
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * @fileoverview React hook for account-scoped realtime subscriptions.
+ *
+ * Subscribes a listener to a realtime channel for the **current** wallet
+ * account (scope = `"${network.id}:${address}"`). The subscription lifecycle
+ * is fully tied to the account context:
+ *
+ * - **Account switch / network change** — the previous scope's listener is
+ *   removed (React runs the effect cleanup before the next effect subscribes)
+ *   and the new scope subscribes. The registry additionally refuses to deliver
+ *   to a channel owned by a different scope, so a late event for the previous
+ *   account can never update current UI state.
+ * - **Logout** — the scope becomes `null`; the listener is removed and no new
+ *   subscription is created.
+ * - **Unmount** — the effect cleanup removes the listener (and closes the
+ *   channel when it was the last listener).
+ * - **Reconnect / re-render** — the listener is kept in a ref, so re-renders
+ *   never re-subscribe. The registry also dedupes by channel, guaranteeing at
+ *   most one subscription per view per account.
+ *
+ * @example
+ * ```tsx
+ * function TransactionHistory() {
+ *   const { refetch } = useTransactions();
+ *   useAccountScopedSubscription<TransactionEvent>("transactions", (event) => {
+ *     if (event.kind === "created") refetch();
+ *   });
+ *   return <Table rows={data} />;
+ * }
+ * ```
+ *
+ * @param channel  Name of the realtime channel to subscribe to
+ *                 (e.g. `"transactions"`, `"account-summary"`).
+ * @param listener Called with every payload delivered on the channel for the
+ *                 current account. Keep the reference stable or use
+ *                 `useCallback`; the hook re-subscribes only when the scope or
+ *                 channel changes, never when the listener identity changes.
+ */
+import { useEffect, useRef } from "react";
+import { useWallet } from "@/context/wallet-context";
+import { createAccountScope, realtimeRegistry } from "@/lib/realtime-registry";
+import type { RealtimeListener } from "@/lib/realtime-registry";
+
+export function useAccountScopedSubscription<T = unknown>(
+  channel: string,
+  listener: RealtimeListener<T>,
+): void {
+  const { address, network } = useWallet();
+  const scope = createAccountScope(network.id, address);
+
+  // Keep the latest listener in a ref so a changing listener identity never
+  // triggers a re-subscribe. Subscriptions are scoped to the channel, not the
+  // callback — this is what keeps "reconnect" at one subscription per view.
+  const listenerRef = useRef<RealtimeListener<T>>(listener);
+  useEffect(() => {
+    listenerRef.current = listener;
+  });
+
+  useEffect(() => {
+    // No connected account → nothing to subscribe. The previous effect's
+    // cleanup has already detached any listener owned by the old scope.
+    if (scope === null) return;
+
+    return realtimeRegistry.subscribe(scope, channel, (payload) => {
+      listenerRef.current(payload);
+    });
+  }, [scope, channel]);
+}

--- a/lib/realtime-registry.test.ts
+++ b/lib/realtime-registry.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  RealtimeRegistry,
+  createAccountScope,
+  type AccountScope,
+} from "./realtime-registry";
+
+const SCOPE_A: AccountScope =
+  "stellar:GAAQEAYEAUDAOCAJBIFQYDIOB4IBCEQTCQKRMFYYDENBWHA5DYPSABOV";
+const SCOPE_B: AccountScope =
+  "stellar:GBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCB";
+const CHANNEL = "transactions";
+
+function makeRegistry() {
+  return new RealtimeRegistry();
+}
+
+describe("createAccountScope", () => {
+  it("combines network id and address into a scope", () => {
+    expect(createAccountScope("stellar", "GABC")).toBe("stellar:GABC");
+  });
+
+  it("returns null when there is no connected address", () => {
+    expect(createAccountScope("stellar", null)).toBeNull();
+  });
+});
+
+describe("RealtimeRegistry.subscribe / emit", () => {
+  it("delivers emitted payloads to the listener of the owning scope", () => {
+    const registry = makeRegistry();
+    const listener = vi.fn();
+
+    registry.subscribe(SCOPE_A, CHANNEL, listener);
+    registry.emit(CHANNEL, { id: "tx-1" });
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith({ id: "tx-1" });
+  });
+
+  it("fans out to multiple listeners without opening a second subscription", () => {
+    const registry = makeRegistry();
+    const first = vi.fn();
+    const second = vi.fn();
+
+    registry.subscribe(SCOPE_A, CHANNEL, first);
+    registry.subscribe(SCOPE_A, CHANNEL, second);
+
+    // Same scope + same channel → still exactly one channel record.
+    expect(registry.getActiveChannelCount(CHANNEL)).toBe(1);
+    expect(registry.getListenerCount(CHANNEL)).toBe(2);
+
+    registry.emit(CHANNEL, "event");
+    expect(first).toHaveBeenCalledExactlyOnceWith("event");
+    expect(second).toHaveBeenCalledExactlyOnceWith("event");
+  });
+
+  it("unsubscribe removes only that listener and closes the channel when it was the last", () => {
+    const registry = makeRegistry();
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const unsubscribeFirst = registry.subscribe(SCOPE_A, CHANNEL, first);
+    const unsubscribeSecond = registry.subscribe(SCOPE_A, CHANNEL, second);
+
+    unsubscribeFirst();
+    registry.emit(CHANNEL, "event");
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledExactlyOnceWith("event");
+    expect(registry.getListenerCount(CHANNEL)).toBe(1);
+
+    // Remove the last listener → channel closes entirely.
+    unsubscribeSecond();
+    expect(registry.getActiveChannelCount(CHANNEL)).toBe(0);
+    expect(registry.getListenerCount(CHANNEL)).toBe(0);
+  });
+
+  it("unsubscribe is idempotent and safe after the channel is gone", () => {
+    const registry = makeRegistry();
+    const unsubscribe = registry.subscribe(SCOPE_A, CHANNEL, vi.fn());
+
+    registry.unsubscribeScope(SCOPE_A);
+    expect(() => unsubscribe()).not.toThrow();
+    expect(registry.getActiveChannelCount(CHANNEL)).toBe(0);
+  });
+
+  it("emit on a closed channel is a no-op", () => {
+    const registry = makeRegistry();
+    expect(() => registry.emit(CHANNEL, "nobody-listens")).not.toThrow();
+  });
+});
+
+describe("RealtimeRegistry account scoping", () => {
+  it("re-subscribing the same scope+channel reuses the channel (one subscription per view)", () => {
+    const registry = makeRegistry();
+
+    registry.subscribe(SCOPE_A, CHANNEL, vi.fn());
+    registry.subscribe(SCOPE_A, CHANNEL, vi.fn());
+    registry.subscribe(SCOPE_A, CHANNEL, vi.fn());
+
+    expect(registry.getActiveChannelCount(CHANNEL)).toBe(1);
+    expect(registry.getChannelScope(CHANNEL)).toBe(SCOPE_A);
+  });
+
+  it("tears down the previous account's channel before re-opening under a new scope", () => {
+    const registry = makeRegistry();
+    const oldAccountListener = vi.fn();
+    const newAccountListener = vi.fn();
+
+    registry.subscribe(SCOPE_A, CHANNEL, oldAccountListener);
+
+    // Account switch: same view, new account. The old channel must be torn
+    // down and the channel re-opened under SCOPE_B before the new listener is
+    // attached.
+    registry.subscribe(SCOPE_B, CHANNEL, newAccountListener);
+
+    expect(registry.getChannelScope(CHANNEL)).toBe(SCOPE_B);
+    expect(registry.getActiveChannelCount(CHANNEL)).toBe(1);
+
+    // A late event for the previous account must not reach the new listener.
+    registry.emit(CHANNEL, "late-event");
+    expect(oldAccountListener).not.toHaveBeenCalled();
+    expect(newAccountListener).toHaveBeenCalledExactlyOnceWith("late-event");
+  });
+
+  it("an unsubscribed old-scope listener cannot reattach to the new scope channel", () => {
+    const registry = makeRegistry();
+    const oldAccountListener = vi.fn();
+
+    const unsubscribeOld = registry.subscribe(
+      SCOPE_A,
+      CHANNEL,
+      oldAccountListener,
+    );
+
+    // Ownership swap closes the old channel; the old unsubscribe is a no-op.
+    registry.subscribe(SCOPE_B, CHANNEL, vi.fn());
+    unsubscribeOld();
+
+    registry.emit(CHANNEL, "event");
+    expect(oldAccountListener).not.toHaveBeenCalled();
+    expect(registry.getChannelScope(CHANNEL)).toBe(SCOPE_B);
+  });
+
+  it("unsubscribeScope removes every channel owned by a scope and leaves others intact", () => {
+    const registry = makeRegistry();
+    const scopeAListener = vi.fn();
+    const scopeBListener = vi.fn();
+
+    registry.subscribe(SCOPE_A, "a:transactions", scopeAListener);
+    registry.subscribe(SCOPE_A, "a:summary", scopeAListener);
+    registry.subscribe(SCOPE_B, "b:transactions", scopeBListener);
+
+    registry.unsubscribeScope(SCOPE_A);
+
+    expect(registry.getActiveChannelCount()).toBe(1);
+    expect(registry.getChannelScope("b:transactions")).toBe(SCOPE_B);
+    expect(registry.getActiveChannelCount("a:transactions")).toBe(0);
+    expect(registry.getActiveChannelCount("a:summary")).toBe(0);
+
+    registry.emit("a:transactions", "stale");
+    registry.emit("b:transactions", "fresh");
+    expect(scopeAListener).not.toHaveBeenCalled();
+    expect(scopeBListener).toHaveBeenCalledExactlyOnceWith("fresh");
+  });
+
+  it("unsubscribeScope is a no-op for an unknown or null scope", () => {
+    const registry = makeRegistry();
+    registry.subscribe(SCOPE_A, CHANNEL, vi.fn());
+
+    expect(() => {
+      registry.unsubscribeScope("stellar:GUNKNOWN");
+      registry.unsubscribeScope(null);
+    }).not.toThrow();
+    expect(registry.getActiveChannelCount(CHANNEL)).toBe(1);
+  });
+
+  it("clear removes every channel and listener", () => {
+    const registry = makeRegistry();
+    const listener = vi.fn();
+
+    registry.subscribe(SCOPE_A, "a:transactions", listener);
+    registry.subscribe(SCOPE_B, "b:transactions", listener);
+    registry.clear();
+
+    expect(registry.getActiveChannelCount()).toBe(0);
+    registry.emit("a:transactions", "event");
+    registry.emit("b:transactions", "event");
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/lib/realtime-registry.ts
+++ b/lib/realtime-registry.ts
@@ -1,0 +1,160 @@
+/**
+ * @fileoverview Account-scoped registry for realtime subscriptions.
+ *
+ * The registry is the single source of truth for every realtime channel the
+ * app opens (transactions, account summary, payment history, …). Channels are
+ * owned by an **account scope** — `"${network.id}:${address}"` for a connected
+ * wallet, or `null` when logged out.
+ *
+ * Why this exists (issue #1179):
+ *
+ * - **Track subscription ownership** — every channel records the scope that
+ *   created it, so we always know which account a subscription belongs to.
+ * - **Tear down channels before replacing account context** — when a channel
+ *   is re-subscribed under a *different* scope, the previous scope's channel
+ *   is torn down first. A late event for the old account can never reach a
+ *   listener registered by the new account.
+ * - **At most one subscription per view** — subscribing to a channel that is
+ *   already open for the same scope reuses the existing channel and only adds
+ *   a listener, so reconnect/refetch never stack duplicate connections.
+ * - **Deterministic teardown** — `unsubscribeScope` (logout / account switch)
+ *   and `clear()` (app teardown) remove every listener of the affected
+ *   channels.
+ *
+ * The transport itself is intentionally decoupled: today the app is mock-data
+ * only, so events are delivered via {@link emit}. When a real backend lands,
+ * only the transport (a WebSocket / SSE client) changes — the registry,
+ * ownership tracking, and teardown contract stay identical.
+ */
+
+export type AccountScope = string | null;
+
+export type RealtimeListener<T = unknown> = (payload: T) => void;
+
+/** Serialize the active wallet into an account scope, or `null` when logged out. */
+export function createAccountScope(
+  networkId: string,
+  address: string | null,
+): AccountScope {
+  return address ? `${networkId}:${address}` : null;
+}
+
+interface ChannelRecord {
+  /** Scope that owns this channel. */
+  scope: AccountScope;
+  /** Listeners currently registered on the channel. */
+  listeners: Set<RealtimeListener>;
+}
+
+/**
+ * Account-scoped realtime subscription registry.
+ *
+ * Each channel maps to exactly one {@link ChannelRecord} (one "connection").
+ * Multiple components may listen to the same channel; they share the record
+ * rather than opening a second subscription.
+ */
+export class RealtimeRegistry {
+  private readonly channels = new Map<string, ChannelRecord>();
+
+  /**
+   * Subscribe a listener to a channel on behalf of `scope`.
+   *
+   * - Channel not open yet → opened and owned by `scope`.
+   * - Channel open for the same `scope` → listener added to the existing
+   *   channel (no duplicate subscription).
+   * - Channel open for a **different** scope → stale subscription from a
+   *   previous account; the channel is torn down and re-opened under the new
+   *   scope before the listener is attached.
+   *
+   * Returns an unsubscribe function that removes only this listener and closes
+   * the channel when it was the last one. Unsubscribing is idempotent.
+   */
+  subscribe<T = unknown>(
+    scope: AccountScope,
+    channel: string,
+    listener: RealtimeListener<T>,
+  ): () => void {
+    const existing = this.channels.get(channel);
+
+    if (existing && existing.scope !== scope) {
+      // Ownership changed: a previous account still owns this channel. Tear it
+      // down so no event for the old account can reach a new-account listener.
+      this.channels.delete(channel);
+    }
+
+    let record = this.channels.get(channel);
+    if (!record) {
+      record = { scope, listeners: new Set() };
+      this.channels.set(channel, record);
+    }
+
+    const typedListener = listener as RealtimeListener;
+    record.listeners.add(typedListener);
+
+    return () => {
+      const current = this.channels.get(channel);
+      // The channel may already be gone (unsubscribeScope / clear / ownership
+      // swap). Unsubscribe is intentionally idempotent.
+      if (!current) return;
+      current.listeners.delete(typedListener);
+      if (current.listeners.size === 0) {
+        this.channels.delete(channel);
+      }
+    };
+  }
+
+  /**
+   * Tear down every channel owned by `scope`. Used on logout and account
+   * switch so no listener of the previous account stays attached.
+   */
+  unsubscribeScope(scope: AccountScope): void {
+    for (const [channel, record] of this.channels) {
+      if (record.scope === scope) {
+        this.channels.delete(channel);
+      }
+    }
+  }
+
+  /** Tear down every channel and listener (global logout / app teardown). */
+  clear(): void {
+    this.channels.clear();
+  }
+
+  /**
+   * Deliver a payload to every listener of `channel`. No-op when the channel
+   * is not open. This is the seam a real WebSocket/SSE transport plugs into.
+   */
+  emit<T = unknown>(channel: string, payload: T): void {
+    const record = this.channels.get(channel);
+    if (!record) return;
+    for (const listener of record.listeners) {
+      listener(payload);
+    }
+  }
+
+  /**
+   * Number of channels currently open. Exposed for tests and debugging; a
+   * "reconnect creates at most one subscription per view" assertion is simply
+   * `getActiveChannelCount("transactions") === 1`.
+   */
+  getActiveChannelCount(channel?: string): number {
+    if (channel === undefined) return this.channels.size;
+    return this.channels.has(channel) ? 1 : 0;
+  }
+
+  /** Number of listeners currently attached to `channel` (0 when not open). */
+  getListenerCount(channel: string): number {
+    return this.channels.get(channel)?.listeners.size ?? 0;
+  }
+
+  /** Scope that currently owns `channel`, or `null` when the channel is closed. */
+  getChannelScope(channel: string): AccountScope {
+    return this.channels.get(channel)?.scope ?? null;
+  }
+}
+
+/**
+ * App-wide singleton. All components, hooks, and the wallet provider share
+ * this instance so teardown is coordinated in one place.
+ */
+export const realtimeRegistry = new RealtimeRegistry();


### PR DESCRIPTION
Closes #1179

## Problem

Subscriptions can continue receiving updates for a previous account after logout or account switching. Because no layer tracked which account owned an open channel, a late event for the old account could still reach a listener registered by the current account and mutate UI state.

## What changed

Realtime channels are now **account-scoped** — every subscription is owned by an account scope (`"${network.id}:${address}"`, or `null` when logged out) and is torn down before the account context is replaced.

### New: `lib/realtime-registry.ts`
A shared, app-wide registry that is the single source of truth for every realtime channel:

- **Tracks subscription ownership** — each channel records the scope that opened it (`getChannelScope`, `getActiveChannelCount`, `getListenerCount` for observability).
- **Tears down channels before replacing account context** — subscribing to a channel that is still owned by a *different* scope tears the old channel down and re-opens it under the new scope, so no previous-account event can ever reach a current-account listener.
- **At most one subscription per view** — subscribing to an already-open channel (same scope) reuses the existing channel and only adds a listener, so reconnect/refetch never stack duplicate connections.
- **Deterministic teardown** — `unsubscribeScope(scope)` (logout / account switch) and `clear()` (app teardown) remove every listener of the affected channels.
- `emit()` is the transport seam: today the app is mock-data only, so events are delivered in-process; swapping in a WebSocket/SSE client only changes the transport, never the ownership/teardown contract.

### New: `hooks/useAccountScopedSubscription.ts`
React hook for views to subscribe to a channel for the **current** account:

- Listener is kept in a ref, so re-renders never re-subscribe (reconnect stays at one subscription per view).
- Effect cleanup detaches the listener on **account switch**, **logout** (scope becomes `null`), and **unmount**.
- Re-subscribes under the new scope automatically after a switch.

### `context/wallet-context.tsx`
`WalletProvider` now derives the active account scope and runs a teardown effect that closes every channel owned by the *previous* scope whenever the scope changes (account switch, logout, network switch) and on provider unmount — a safety net so even a component that forgets to clean up cannot leave a previous account's channels alive.

## Acceptance criteria

| Criterion | How it's met |
| --- | --- |
| No previous-account event updates current UI state | Registry ownership guard + effect cleanup run before new subscriptions mount; old-scope listeners are detached and old channels closed |
| All listeners are removed on logout and unmount | Hook cleanup + provider `unsubscribeScope` on scope change/unmount |
| Reconnect creates at most one subscription per view | Registry dedupes by channel; hook keeps listener in a ref so identity changes don't re-subscribe |

## Validation

Added 25 tests covering rapid account switches, logout, reconnect, and unmount:

- `lib/realtime-registry.test.ts` (13) — ownership tracking, ownership swap teardown, fan-out dedupe, `unsubscribeScope`/`clear`, idempotent unsubscribe.
- `hooks/useAccountScopedSubscription.test.tsx` (8) — subscribe scope, delivery, listener-identity stability (one subscription per view), account switch, logout, unmount, reconnect.
- `context/wallet-context.test.tsx` (4 new) — provider opens a channel per connected account, tears down the previous account's channel on rapid switch, and removes all listeners on disconnect and on unmount.

All 64 tests in the touched files pass. Note: the repository's full unit suite has 256 pre-existing failures on `main` (unrelated auth/UI components) and `tsc --noEmit` is already broken on `main` in `app/settings/preferences/components/notifications-section.tsx`; this PR introduces no new failures and no new type errors.

## Testing

```bash
npx vitest run lib/realtime-registry.test.ts hooks/useAccountScopedSubscription.test.tsx context/wallet-context.test.tsx
```
