### PR TITLE
feat: stale-cache indicators and invalidation for dashboard account data

### DIFF
--- a/hooks/useAccountSummary.ts
+++ b/hooks/useAccountSummary.ts
@@ -8,12 +8,25 @@ interface UseAccountSummaryResult {
   data: AccountSummary | null;
   isLoading: boolean;
   error: string | null;
+  isStale: boolean;
   refetch: () => void;
 }
 
-// Module-level cache scoped to the session.
-// Keyed by `${network.id}:${address}` to ensure proper scoping across accounts.
-const accountSummaryCache = new Map<string, AccountSummary>();
+// Module-level cache scoped to the session, keyed by `${network.id}:${address}`
+// to ensure proper scoping across accounts. Each entry records when it was
+// fetched so callers can detect stale data after a long offline period.
+const STALE_AFTER_MS = 60_000; // 1 minute
+
+interface CacheEntry {
+  value: AccountSummary;
+  fetchedAt: number;
+}
+
+const accountSummaryCache = new Map<string, CacheEntry>();
+
+function readCache(key: string | null): CacheEntry | null {
+  return key ? accountSummaryCache.get(key) ?? null : null;
+}
 
 export function clearAccountSummaryCache() {
   accountSummaryCache.clear();
@@ -71,11 +84,16 @@ export function useAccountSummary(): UseAccountSummaryResult {
   const cacheKey = address ? `${network.id}:${address}` : null;
 
   const [data, setData] = useState<AccountSummary | null>(() => {
-    return cacheKey ? accountSummaryCache.get(cacheKey) || null : null;
+    return readCache(cacheKey)?.value ?? null;
+  });
+
+  const [isStale, setIsStale] = useState<boolean>(() => {
+    const entry = readCache(cacheKey);
+    return !!entry && Date.now() - entry.fetchedAt > STALE_AFTER_MS;
   });
 
   const [isLoading, setIsLoading] = useState(() => {
-    return cacheKey ? !accountSummaryCache.has(cacheKey) : false;
+    return cacheKey ? !readCache(cacheKey) : false;
   });
 
   const [error, setError] = useState<string | null>(null);
@@ -86,10 +104,16 @@ export function useAccountSummary(): UseAccountSummaryResult {
   const previousCacheKey = useRef(cacheKey);
   if (previousCacheKey.current !== cacheKey) {
     previousCacheKey.current = cacheKey;
-    const cached = cacheKey ? accountSummaryCache.get(cacheKey) || null : null;
-    setData(cached);
+    const cached = readCache(cacheKey);
+    setData(cached?.value ?? null);
+    setIsStale(!!cached && Date.now() - cached.fetchedAt > STALE_AFTER_MS);
     setIsLoading(!cached && !!cacheKey);
     setError(null);
+    // Serving stale data for this account/network on a (re)mount should not look
+    // current: refresh it once, but keep the stale value visible until it lands.
+    if (cached && Date.now() - cached.fetchedAt > STALE_AFTER_MS) {
+      setRequestTick((tick) => tick + 1);
+    }
   }
 
   const refetch = useCallback(() => {
@@ -109,7 +133,7 @@ export function useAccountSummary(): UseAccountSummaryResult {
     const requestId = latestRequestId.current + 1;
     latestRequestId.current = requestId;
 
-    if (!accountSummaryCache.has(cacheKey)) {
+    if (!readCache(cacheKey)) {
       setIsLoading(true);
     }
     setError(null);
@@ -117,8 +141,9 @@ export function useAccountSummary(): UseAccountSummaryResult {
     getAccountSummary()
       .then((result) => {
         if (!cancelled && requestId === latestRequestId.current) {
-          accountSummaryCache.set(cacheKey, result);
+          accountSummaryCache.set(cacheKey, { value: result, fetchedAt: Date.now() });
           setData(result);
+          setIsStale(false);
           setIsLoading(false);
         }
       })
@@ -138,5 +163,13 @@ export function useAccountSummary(): UseAccountSummaryResult {
     };
   }, [cacheKey, requestTick]);
 
-  return { data, isLoading, error, refetch };
+  // Reconnect triggers exactly one controlled refresh so a long offline period
+  // does not leave the dashboard showing a silently stale balance.
+  useEffect(() => {
+    const handleOnline = () => setRequestTick((tick) => tick + 1);
+    window.addEventListener("online", handleOnline);
+    return () => window.removeEventListener("online", handleOnline);
+  }, []);
+
+  return { data, isLoading, error, isStale, refetch };
 }


### PR DESCRIPTION
Closes #1167

## Summary
Adds stale-cache detection and invalidation to dashboard account data so cached balances never appear current after an account switch or a long offline period.

## Changes
- `hooks/useAccountSummary.ts`
  - Cache entries now store `{ value, fetchedAt }` (the account summary plus the time it was fetched).
  - Exposes `isStale` on the hook result (true when cached data is older than 60s).
  - The cache remains keyed by `network.id:address`, so data from another account is never displayed.
  - On account/network change: stale cached data is served (not hidden) but flagged stale and refreshed exactly once.
  - On network **reconnect** (`window` `online`), triggers exactly one controlled refresh.

## Validation
- Please run `useAccountSummary.test.ts` and the dashboard tests in CI; I could not run them here (no deps/network).
- The same stale/invalidate pattern should be applied to `hooks/useTransactions.ts` for transaction summaries (follow-up) if desired.