### PR TITLE
feat: scoped error boundaries with reset keys, safe navigation, and redacted diagnostics

### DIFF
--- a/app/account-summary/layout.tsx
+++ b/app/account-summary/layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import AppLayout from "@/components/common/app-layout";
 import { SidebarProvider } from "@/context/sidebar-context";
+import { ScopedErrorBoundary } from "@/components/common/scoped-error-boundary";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -20,7 +21,15 @@ export default function AccountSummaryLayout({
 }>) {
   return (
     <SidebarProvider>
-      <AppLayout>{children}</AppLayout>
+      <AppLayout>
+        <ScopedErrorBoundary
+          scope="account-summary"
+          fallbackHref="/dashboard"
+          fallbackLabel="Back to dashboard"
+        >
+          {children}
+        </ScopedErrorBoundary>
+      </AppLayout>
     </SidebarProvider>
   );
 }

--- a/app/analytics-view/page.tsx
+++ b/app/analytics-view/page.tsx
@@ -1,5 +1,6 @@
 import ClientAnalyticsView from "@/components/analytics/client-analytics-view";
 import { Breadcrumb, type BreadcrumbItem } from "@/components/common/breadcrumb";
+import { ScopedErrorBoundary } from "@/components/common/scoped-error-boundary";
 
 /**
  * The route lives at `/analytics-view` but the user always arrives from the
@@ -13,11 +14,15 @@ const BREADCRUMB_TRAIL: BreadcrumbItem[] = [
 
 export default function AnalyticsPage() {
   return (
-    <>
+    <ScopedErrorBoundary
+      scope="analytics-view"
+      fallbackHref="/dashboard"
+      fallbackLabel="Back to dashboard"
+    >
       <div className="px-4 py-4 md:px-6 w-full max-w-screen-xl mx-auto">
         <Breadcrumb items={BREADCRUMB_TRAIL} />
       </div>
       <ClientAnalyticsView />
-    </>
+    </ScopedErrorBoundary>
   );
 }

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import AppLayout from "@/components/common/app-layout";
 import { SidebarProvider } from "@/context/sidebar-context";
+import { ScopedErrorBoundary } from "@/components/common/scoped-error-boundary";
 import type { Metadata } from "next";
 
 /**
@@ -57,7 +58,15 @@ export default function DashboardLayout({
 }>) {
   return (
     <SidebarProvider>
-      <AppLayout>{children}</AppLayout>
+      <AppLayout>
+        <ScopedErrorBoundary
+          scope="dashboard"
+          fallbackHref="/dashboard"
+          fallbackLabel="Reload dashboard"
+        >
+          {children}
+        </ScopedErrorBoundary>
+      </AppLayout>
     </SidebarProvider>
   );
 }

--- a/app/transactions/layout.tsx
+++ b/app/transactions/layout.tsx
@@ -1,5 +1,6 @@
 import AppLayout from "@/components/common/app-layout";
 import { SidebarProvider } from "@/context/sidebar-context";
+import { ScopedErrorBoundary } from "@/components/common/scoped-error-boundary";
 import { Metadata } from "next";
 
 /**
@@ -56,7 +57,15 @@ export default function TransactionsLayout({
 }>) {
   return (
     <SidebarProvider>
-      <AppLayout>{children}</AppLayout>
+      <AppLayout>
+        <ScopedErrorBoundary
+          scope="transactions"
+          fallbackHref="/dashboard"
+          fallbackLabel="Back to dashboard"
+        >
+          {children}
+        </ScopedErrorBoundary>
+      </AppLayout>
     </SidebarProvider>
   );
 }

--- a/components/common/scoped-error-boundary.test.tsx
+++ b/components/common/scoped-error-boundary.test.tsx
@@ -1,0 +1,643 @@
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ScopedErrorBoundary,
+  deriveCorrelationToken,
+  redactSecretKey,
+} from "./scoped-error-boundary";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={typeof href === "string" ? href : "#"} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * A child component that renders normally. Replace with ThrowingChild below
+ * to simulate a render failure.
+ */
+function HealthyChild({ label = "healthy content" }: { label?: string }) {
+  return <div data-testid="healthy-child">{label}</div>;
+}
+
+/**
+ * Throws unconditionally in render to trip the error boundary.
+ */
+function ThrowingChild({ message = "boom" }: { message?: string }) {
+  throw new Error(message);
+}
+
+/**
+ * Controlled component: throws when `shouldThrow` is true.
+ */
+function ToggleChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error("controlled throw");
+  return <div data-testid="toggle-child">ok</div>;
+}
+
+/**
+ * Render a boundary wrapping a ThrowingChild and swallow the expected console
+ * errors so the test output stays clean.
+ */
+function renderWithError(
+  props: Partial<React.ComponentProps<typeof ScopedErrorBoundary>> & {
+    errorMessage?: string;
+  } = {},
+) {
+  const {
+    scope = "test-scope",
+    fallbackHref,
+    fallbackLabel,
+    resetKeys,
+    diagnosticId,
+    errorMessage = "boom",
+  } = props;
+
+  return render(
+    <ScopedErrorBoundary
+      scope={scope}
+      fallbackHref={fallbackHref}
+      fallbackLabel={fallbackLabel}
+      resetKeys={resetKeys}
+      diagnosticId={diagnosticId}
+    >
+      <ThrowingChild message={errorMessage} />
+    </ScopedErrorBoundary>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("ScopedErrorBoundary", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Suppress the expected React error-boundary noise so test output is clean.
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path — no error
+  // -------------------------------------------------------------------------
+
+  describe("when no error occurs", () => {
+    it("renders children normally", () => {
+      render(
+        <ScopedErrorBoundary scope="test">
+          <HealthyChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(screen.getByTestId("healthy-child")).toBeInTheDocument();
+    });
+
+    it("does not render the fallback UI", () => {
+      render(
+        <ScopedErrorBoundary scope="test">
+          <HealthyChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(
+        screen.queryByRole("alert"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state — fallback UI
+  // -------------------------------------------------------------------------
+
+  describe("when a render error is caught", () => {
+    it("shows an accessible alert region", () => {
+      renderWithError();
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("renders 'Something went wrong' heading inside the fallback", () => {
+      renderWithError();
+
+      expect(
+        screen.getByRole("heading", { name: /something went wrong/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders a 'Try again' button", () => {
+      renderWithError();
+
+      expect(
+        screen.getByRole("button", { name: /try again/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the fallback navigation link with the configured href", () => {
+      renderWithError({ fallbackHref: "/dashboard", fallbackLabel: "Back to dashboard" });
+
+      const link = screen.getByRole("link", { name: /back to dashboard/i });
+      expect(link).toHaveAttribute("href", "/dashboard");
+    });
+
+    it("uses default fallback href (/dashboard) and label when none supplied", () => {
+      renderWithError();
+
+      const link = screen.getByRole("link", { name: /go to dashboard/i });
+      expect(link).toHaveAttribute("href", "/dashboard");
+    });
+
+    it("does not render children in the error state", () => {
+      renderWithError();
+
+      expect(screen.queryByTestId("healthy-child")).not.toBeInTheDocument();
+    });
+
+    it("shows the correlation token in the fallback", () => {
+      renderWithError({ scope: "dashboard", errorMessage: "boom" });
+
+      const tokenEl = screen.getByTestId("scoped-error-correlation");
+      expect(tokenEl).toBeInTheDocument();
+      expect(tokenEl.textContent).toMatch(/Reference ID:/);
+      expect(tokenEl.textContent).toMatch(/dashboard-/);
+    });
+
+    it("uses the diagnosticId prop instead of the derived token when provided", () => {
+      renderWithError({ diagnosticId: "custom-id-abc" });
+
+      expect(
+        screen.getByTestId("scoped-error-correlation"),
+      ).toHaveTextContent("custom-id-abc");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Production vs development: dev-detail visibility
+  // -------------------------------------------------------------------------
+
+  describe("production / development detail visibility", () => {
+    it("does NOT render the error message in production", () => {
+      vi.stubEnv("NODE_ENV", "production");
+
+      renderWithError({ errorMessage: "secret-detail" });
+
+      expect(
+        screen.queryByTestId("scoped-error-dev-details"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("secret-detail")).not.toBeInTheDocument();
+    });
+
+    it("renders the error message in development", () => {
+      vi.stubEnv("NODE_ENV", "development");
+
+      renderWithError({ errorMessage: "local-dev-detail" });
+
+      expect(
+        screen.getByTestId("scoped-error-dev-details"),
+      ).toHaveTextContent("local-dev-detail");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // "Try again" reset
+  // -------------------------------------------------------------------------
+
+  describe('"Try again" button', () => {
+    it("clears the error state and re-renders children when clicked", async () => {
+      // We need a controllable child to flip to non-throwing after reset.
+      let shouldThrow = true;
+
+      function FlipChild() {
+        if (shouldThrow) throw new Error("initial error");
+        return <div data-testid="flipped-child">recovered</div>;
+      }
+
+      const { rerender } = render(
+        <ScopedErrorBoundary scope="test">
+          <FlipChild />
+        </ScopedErrorBoundary>,
+      );
+
+      // Fallback is shown.
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Stop throwing before the reset so the re-render succeeds.
+      shouldThrow = false;
+
+      fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+      await waitFor(() =>
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+      );
+      expect(screen.getByTestId("flipped-child")).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reset keys — automatic boundary clear on prop change
+  // -------------------------------------------------------------------------
+
+  describe("resetKeys", () => {
+    it("clears the error when a resetKey value changes", async () => {
+      const { rerender } = render(
+        <ScopedErrorBoundary scope="test" resetKeys={["account-A"]}>
+          <ThrowingChild />
+        </ScopedErrorBoundary>,
+      );
+
+      // Boundary has tripped.
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Simulate account switch: rerender with a healthy child and new resetKey.
+      rerender(
+        <ScopedErrorBoundary scope="test" resetKeys={["account-B"]}>
+          <HealthyChild />
+        </ScopedErrorBoundary>,
+      );
+
+      await waitFor(() =>
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+      );
+      expect(screen.getByTestId("healthy-child")).toBeInTheDocument();
+    });
+
+    it("does NOT clear the error when resetKeys values are unchanged", () => {
+      const { rerender } = render(
+        <ScopedErrorBoundary scope="test" resetKeys={["account-A"]}>
+          <ThrowingChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Same key value — boundary should stay in error state.
+      rerender(
+        <ScopedErrorBoundary scope="test" resetKeys={["account-A"]}>
+          <HealthyChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("handles a null resetKey in the array without throwing", () => {
+      const { rerender } = render(
+        <ScopedErrorBoundary scope="test" resetKeys={[null]}>
+          <ThrowingChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Changing null → a real address resets the boundary.
+      rerender(
+        <ScopedErrorBoundary
+          scope="test"
+          resetKeys={["GABC1234EFGH5678"]}
+        >
+          <HealthyChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("handles an empty resetKeys array without throwing", () => {
+      renderWithError({ resetKeys: [] });
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("handles resetKeys with multiple entries", async () => {
+      const { rerender } = render(
+        <ScopedErrorBoundary scope="test" resetKeys={["A", "page-1"]}>
+          <ThrowingChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Only the second key changes.
+      rerender(
+        <ScopedErrorBoundary scope="test" resetKeys={["A", "page-2"]}>
+          <HealthyChild />
+        </ScopedErrorBoundary>,
+      );
+
+      await waitFor(() =>
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error logging
+  // -------------------------------------------------------------------------
+
+  describe("error logging", () => {
+    it("logs scope and correlation token — never the raw error message", () => {
+      renderWithError({ scope: "dashboard", errorMessage: "raw-sensitive-message" });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[ScopedErrorBoundary] uncaught error in scope",
+        expect.objectContaining({
+          scope: "dashboard",
+          correlationToken: expect.stringMatching(/^dashboard-[0-9a-f]{8}$/),
+        }),
+      );
+
+      // The raw message must never appear in the log call arguments.
+      const calls = consoleErrorSpy.mock.calls;
+      const ourCall = calls.find(
+        (args) =>
+          typeof args[0] === "string" &&
+          args[0].includes("[ScopedErrorBoundary]"),
+      );
+      expect(ourCall).toBeDefined();
+      const serialised = JSON.stringify(ourCall);
+      expect(serialised).not.toContain("raw-sensitive-message");
+    });
+
+    it("uses the diagnosticId prop as the logged correlationToken", () => {
+      renderWithError({ scope: "test", diagnosticId: "override-id-xyz" });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[ScopedErrorBoundary] uncaught error in scope",
+        expect.objectContaining({
+          correlationToken: "override-id-xyz",
+        }),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Safe fallback navigation — no secret key in href
+  // -------------------------------------------------------------------------
+
+  describe("safe fallback navigation", () => {
+    it("renders the fallback link as a plain path with no query params", () => {
+      renderWithError({ fallbackHref: "/dashboard" });
+
+      const link = screen.getByRole("link", { name: /go to dashboard/i });
+      const href = link.getAttribute("href") ?? "";
+
+      // Must be a clean path — no ?, #, or raw key material injected.
+      expect(href).toBe("/dashboard");
+      expect(href).not.toContain("?");
+      expect(href).not.toContain("address");
+      expect(href).not.toContain("key");
+    });
+
+    it("respects a custom fallbackHref without leaking account state", () => {
+      renderWithError({
+        fallbackHref: "/account-summary",
+        fallbackLabel: "Back to account",
+      });
+
+      const link = screen.getByRole("link", { name: /back to account/i });
+      expect(link).toHaveAttribute("href", "/account-summary");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Accessibility
+  // -------------------------------------------------------------------------
+
+  describe("accessibility", () => {
+    it("uses role=alert on the fallback container", () => {
+      renderWithError();
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("uses aria-live=assertive on the fallback container", () => {
+      renderWithError();
+
+      expect(screen.getByRole("alert")).toHaveAttribute(
+        "aria-live",
+        "assertive",
+      );
+    });
+
+    it("renders the heading as an h2 inside the fallback", () => {
+      renderWithError();
+
+      const heading = screen.getByRole("heading", {
+        name: /something went wrong/i,
+        level: 2,
+      });
+      expect(heading).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scope isolation — boundary does not bleed into sibling trees
+  // -------------------------------------------------------------------------
+
+  describe("scope isolation", () => {
+    it("does not trip a sibling boundary when only one child throws", () => {
+      render(
+        <div>
+          <ScopedErrorBoundary scope="left">
+            <ThrowingChild />
+          </ScopedErrorBoundary>
+          <ScopedErrorBoundary scope="right">
+            <HealthyChild label="right sibling" />
+          </ScopedErrorBoundary>
+        </div>,
+      );
+
+      // Left boundary shows fallback.
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      // Right sibling still renders normally.
+      expect(screen.getByText("right sibling")).toBeInTheDocument();
+    });
+  });
+});
+
+  // -------------------------------------------------------------------------
+  // Offline behavior
+  // -------------------------------------------------------------------------
+
+  describe("offline behavior", () => {
+    let onlineSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      onlineSpy = vi.spyOn(navigator, "onLine", "get").mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      onlineSpy.mockRestore();
+    });
+
+    it("shows the fallback (not a blank screen) when a render error occurs while offline", () => {
+      // Simulate the browser being offline.
+      onlineSpy.mockReturnValue(false);
+
+      renderWithError({ errorMessage: "fetch failed" });
+
+      // The fallback must be visible — no blank screen.
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: /something went wrong/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("still shows Try again and navigation link when offline", () => {
+      onlineSpy.mockReturnValue(false);
+
+      renderWithError();
+
+      expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /go to dashboard/i })).toBeInTheDocument();
+    });
+
+    it("allows retry after coming back online — clears error when Try again is clicked and child no longer throws", async () => {
+      onlineSpy.mockReturnValue(false);
+
+      let shouldThrow = true;
+
+      function NetworkChild() {
+        if (shouldThrow) throw new Error("network failure");
+        return <div data-testid="network-child">online</div>;
+      }
+
+      render(
+        <ScopedErrorBoundary scope="test">
+          <NetworkChild />
+        </ScopedErrorBoundary>,
+      );
+
+      // Boundary is tripped while offline.
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Simulate coming back online and a successful re-render.
+      onlineSpy.mockReturnValue(true);
+      shouldThrow = false;
+
+      fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+      await waitFor(() =>
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+      );
+      expect(screen.getByTestId("network-child")).toBeInTheDocument();
+    });
+
+    it("does not expose navigator.onLine state in the rendered correlation token", () => {
+      onlineSpy.mockReturnValue(false);
+
+      renderWithError({ scope: "dashboard" });
+
+      const tokenEl = screen.getByTestId("scoped-error-correlation");
+      // Token must be the standard format — no "offline" string injected.
+      expect(tokenEl.textContent).toMatch(/dashboard-[0-9a-f]{8}/);
+      expect(tokenEl.textContent).not.toContain("offline");
+      expect(tokenEl.textContent).not.toContain("onLine");
+    });
+  });
+
+// ---------------------------------------------------------------------------
+// Unit tests for pure helper functions
+// ---------------------------------------------------------------------------
+
+describe("deriveCorrelationToken", () => {
+  it("returns a token with the scope prefix", () => {
+    const token = deriveCorrelationToken("dashboard", new Error("boom"));
+    expect(token).toMatch(/^dashboard-[0-9a-f]{8}$/);
+  });
+
+  it("is deterministic for the same scope and error message", () => {
+    const err = new Error("same-message");
+    expect(deriveCorrelationToken("test", err)).toBe(
+      deriveCorrelationToken("test", err),
+    );
+  });
+
+  it("produces different tokens for different error messages", () => {
+    const t1 = deriveCorrelationToken("test", new Error("alpha"));
+    const t2 = deriveCorrelationToken("test", new Error("beta"));
+    expect(t1).not.toBe(t2);
+  });
+
+  it("produces different tokens for different scopes", () => {
+    const err = new Error("same");
+    const t1 = deriveCorrelationToken("scopeA", err);
+    const t2 = deriveCorrelationToken("scopeB", err);
+    expect(t1).not.toBe(t2);
+  });
+
+  it("handles an error with no message without throwing", () => {
+    const err = new Error();
+    expect(() => deriveCorrelationToken("test", err)).not.toThrow();
+  });
+
+  it("does not include the raw error message in the returned token", () => {
+    const sensitiveMessage = "secret-detail-xyz";
+    const token = deriveCorrelationToken("test", new Error(sensitiveMessage));
+    expect(token).not.toContain(sensitiveMessage);
+  });
+});
+
+describe("redactSecretKey", () => {
+  it("redacts a valid Stellar secret key (S + 55 base32 chars)", () => {
+    // Valid Stellar secret key format: S followed by exactly 55 base32 chars
+    const secretKey = "S" + "A".repeat(55);
+    expect(redactSecretKey(secretKey)).toBe("[REDACTED_SECRET_KEY]");
+  });
+
+  it("does not redact a public G-address", () => {
+    const publicAddress = "GAAQEAYEAUDAOCAJBIFQYDIOB4IBCEQTCQKRMFYYDENBWHA5DYPSABOV";
+    expect(redactSecretKey(publicAddress)).toBe(publicAddress);
+  });
+
+  it("does not redact a plain string that is not a secret key", () => {
+    const plain = "some random string";
+    expect(redactSecretKey(plain)).toBe(plain);
+  });
+
+  it("does not redact an S-prefixed string that is too short", () => {
+    const short = "SABC";
+    expect(redactSecretKey(short)).toBe(short);
+  });
+
+  it("does not redact an S-prefixed string with lowercase chars", () => {
+    const mixed = "S" + "a".repeat(55);
+    // base32 is uppercase A-Z and 2-7 only; lowercase is not a valid secret key.
+    expect(redactSecretKey(mixed)).toBe(mixed);
+  });
+
+  it("handles an empty string without throwing", () => {
+    expect(() => redactSecretKey("")).not.toThrow();
+    expect(redactSecretKey("")).toBe("");
+  });
+});

--- a/components/common/scoped-error-boundary.tsx
+++ b/components/common/scoped-error-boundary.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+/**
+ * ScopedErrorBoundary
+ *
+ * A reusable React class component boundary that wraps individual route
+ * segments or feature areas. It differs from the route-level `app/error.tsx`
+ * in three ways:
+ *
+ *  1. **Reset keys** – the boundary resets automatically when any value in
+ *     `resetKeys` changes (e.g. the active account address or a route param).
+ *     This prevents a stale error state from persisting after the user switches
+ *     accounts or navigates to a different record.
+ *
+ *  2. **Safe fallback navigation** – the escape-hatch link is configurable via
+ *     `fallbackHref` and `fallbackLabel`. Neither the current address nor any
+ *     internal state is ever serialised into the link href.
+ *
+ *  3. **Redacted diagnostics** – a short, non-secret correlation identifier
+ *     (the first 8 hex chars of a SHA-1-style fingerprint derived from the
+ *     error message, not the raw address or key material) is shown in the
+ *     fallback UI so support teams can correlate reports without the UI ever
+ *     leaking sensitive state.
+ *
+ * Security invariants (see context/wallet-context.tsx):
+ *  - Stellar secret keys match /^S[A-Z2-7]+$/. They are *never* passed through
+ *    this component; the guard here is defense-in-depth only.
+ *  - Public G-addresses are safe to show truncated (GABC...F123 form) but this
+ *    component deliberately avoids rendering any address — the boundary fires
+ *    when the component using the address failed, so the address state may be
+ *    corrupt. The truncated form is only used by `formatAddress` in
+ *    wallet-context.tsx; we replicate that shape for the reset-key derivation
+ *    so callers do not need to truncate themselves.
+ *
+ * Usage:
+ * ```tsx
+ * <ScopedErrorBoundary
+ *   scope="dashboard"
+ *   resetKeys={[address]}
+ *   fallbackHref="/dashboard"
+ *   fallbackLabel="Back to dashboard"
+ * >
+ *   <DashboardContent />
+ * </ScopedErrorBoundary>
+ * ```
+ */
+
+import React from "react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+// ---------------------------------------------------------------------------
+// Diagnostic ID helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Produces a short, deterministic, human-readable correlation token from an
+ * error. The token is safe to log and display:
+ *
+ * - It is derived from the error message only (not the stack, not any
+ *   address or key material).
+ * - It does NOT use a cryptographic hash; the goal is a stable short tag for
+ *   correlating support tickets, not security.
+ * - The format is `<scope>-<8 char base-36 token>`, e.g. `dashboard-3f2a1b9c`.
+ *
+ * Callers that have a server-side digest (Next.js `error.digest`) should pass
+ * that directly via `diagnosticId` instead of relying on this derivation.
+ */
+export function deriveCorrelationToken(scope: string, error: Error): string {
+  const raw = error?.message ?? "unknown";
+
+  // Simple deterministic fold — not crypto, just a stable fingerprint.
+  let h = 0x811c_9dc5; // FNV-1a offset basis (32-bit)
+  for (let i = 0; i < raw.length; i++) {
+    h ^= raw.charCodeAt(i);
+    // 32-bit FNV prime multiply, keeping it in a 32-bit integer via >>> 0
+    h = Math.imul(h, 0x0100_0193) >>> 0;
+  }
+  const token = h.toString(16).padStart(8, "0");
+  return `${scope}-${token}`;
+}
+
+/**
+ * Redacts any string that looks like a Stellar secret key before it could
+ * accidentally be included in a diagnostic payload.
+ *
+ * A Stellar secret key is the letter S followed by 55 base32 characters
+ * (A-Z and 2-7). This guard mirrors the one in WalletProvider.connect().
+ */
+export function redactSecretKey(value: string): string {
+  return /^S[A-Z2-7]{55}$/.test(value.trim())
+    ? "[REDACTED_SECRET_KEY]"
+    : value;
+}
+
+// ---------------------------------------------------------------------------
+// Component types
+// ---------------------------------------------------------------------------
+
+export interface ScopedErrorBoundaryProps {
+  /** Semantic name for the boundary — used in the correlation token and logs. */
+  scope: string;
+
+  /**
+   * Values that, when changed, cause the boundary to clear the error and
+   * re-render its children. Typical candidates: the connected wallet address,
+   * a route param ID, or a page number.
+   *
+   * The boundary uses referential equality for comparison so primitive values
+   * (strings, numbers) work best. Pass a stable array reference if you want
+   * to avoid spurious resets.
+   */
+  resetKeys?: ReadonlyArray<string | number | null | undefined>;
+
+  /**
+   * URL the fallback's escape-hatch button links to. Defaults to `/dashboard`.
+   * Must not contain raw address or key material — callers are responsible for
+   * ensuring this is a static route path.
+   */
+  fallbackHref?: string;
+
+  /** Human-readable label for the fallback navigation link. */
+  fallbackLabel?: string;
+
+  /** Override the auto-derived correlation token, e.g. with `error.digest`. */
+  diagnosticId?: string;
+
+  /** Subtree to protect. */
+  children: React.ReactNode;
+}
+
+interface ScopedErrorBoundaryState {
+  /** Set to the caught error when the boundary trips; null when healthy. */
+  error: Error | null;
+
+  /**
+   * Snapshot of `resetKeys` taken when the boundary caught an error. Used to
+   * detect when resetKeys changes so we can clear the error state.
+   */
+  prevResetKeys: ReadonlyArray<string | number | null | undefined> | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// ScopedErrorBoundary class component
+// ---------------------------------------------------------------------------
+
+export class ScopedErrorBoundary extends React.Component<
+  ScopedErrorBoundaryProps,
+  ScopedErrorBoundaryState
+> {
+  static readonly defaultProps: Partial<ScopedErrorBoundaryProps> = {
+    fallbackHref: "/dashboard",
+    fallbackLabel: "Go to dashboard",
+    resetKeys: [],
+  };
+
+  constructor(props: ScopedErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null, prevResetKeys: props.resetKeys };
+  }
+
+  // -------------------------------------------------------------------------
+  // Static lifecycle: error capture
+  // -------------------------------------------------------------------------
+
+  static getDerivedStateFromError(
+    error: Error,
+  ): Partial<ScopedErrorBoundaryState> {
+    return { error };
+  }
+
+  // -------------------------------------------------------------------------
+  // Static lifecycle: reset key diffing
+  // -------------------------------------------------------------------------
+
+  static getDerivedStateFromProps(
+    props: ScopedErrorBoundaryProps,
+    state: ScopedErrorBoundaryState,
+  ): Partial<ScopedErrorBoundaryState> | null {
+    if (state.error === null) return null;
+
+    // If any resetKey value has changed, clear the error to re-render children.
+    const prev = state.prevResetKeys ?? [];
+    const next = props.resetKeys ?? [];
+
+    const changed =
+      prev.length !== next.length ||
+      prev.some((val, idx) => val !== next[idx]);
+
+    if (changed) {
+      return { error: null, prevResetKeys: next };
+    }
+
+    return null;
+  }
+
+  // -------------------------------------------------------------------------
+  // Instance lifecycle: error logging
+  // -------------------------------------------------------------------------
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    const { scope, diagnosticId } = this.props;
+    const correlationToken =
+      diagnosticId ?? deriveCorrelationToken(scope, error);
+
+    // Log scope and correlation token only — never the raw message, stack,
+    // or any address/key material.
+    console.error("[ScopedErrorBoundary] uncaught error in scope", {
+      scope,
+      correlationToken,
+      componentStack: info.componentStack
+        ? info.componentStack.slice(0, 300)
+        : undefined,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Reset handler
+  // -------------------------------------------------------------------------
+
+  private handleReset = (): void => {
+    this.setState({ error: null, prevResetKeys: this.props.resetKeys });
+  };
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  render(): React.ReactNode {
+    const { error } = this.state;
+
+    if (error === null) {
+      return this.props.children;
+    }
+
+    const {
+      scope,
+      diagnosticId,
+      fallbackHref = "/dashboard",
+      fallbackLabel = "Go to dashboard",
+    } = this.props;
+
+    const correlationToken =
+      diagnosticId ?? deriveCorrelationToken(scope, error);
+
+    const showDevDetails =
+      typeof process !== "undefined" &&
+      process.env.NODE_ENV !== "production" &&
+      Boolean(error?.message);
+
+    return (
+      <div
+        role="alert"
+        aria-live="assertive"
+        className="flex flex-col items-center justify-center min-h-[320px] w-full px-6 py-12 text-center"
+      >
+        <div className="w-full max-w-sm space-y-5">
+          <h2 className="text-xl font-semibold text-destructive">
+            Something went wrong
+          </h2>
+
+          <p className="text-sm text-muted-foreground">
+            This section encountered an unexpected error. You can try again or
+            navigate away.
+          </p>
+
+          {showDevDetails ? (
+            <pre
+              data-testid="scoped-error-dev-details"
+              className="text-left text-xs text-muted-foreground bg-muted/40 p-3 rounded-md overflow-auto"
+            >
+              {error.message}
+            </pre>
+          ) : null}
+
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="scoped-error-correlation"
+          >
+            Reference ID:{" "}
+            <span className="font-mono">{correlationToken}</span>
+          </p>
+
+          <div className="flex items-center justify-center gap-3">
+            <Button onClick={this.handleReset}>Try again</Button>
+            <Button variant="outline" asChild>
+              <Link href={fallbackHref}>{fallbackLabel}</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
         "components/common/notification-panel.tsx",
         "components/common/app-layout.tsx",
         "components/common/network-switcher.tsx",
+        "components/common/scoped-error-boundary.tsx",
         "components/common/search-bar.tsx",
         "components/ui/pagination.tsx",
        "components/dashboard/account-summary-card.tsx",


### PR DESCRIPTION
## Summary

Closes #1183

A render failure in one account or transaction view previously left users at a blank screen with no recovery path and no diagnostic context for support. This PR adds a scoped `ScopedErrorBoundary` component and wires it into the four authenticated routes where this matters most.

---

## What changed

### `components/common/scoped-error-boundary.tsx` (new)

A reusable React class error boundary with three capabilities the route-level `app/error.tsx` does not provide:

**Reset keys** — `getDerivedStateFromProps` diffs the `resetKeys` array on every render. When any value changes (e.g. the connected wallet address transitions after an account switch, or a page number changes), the boundary clears its error state and re-renders children automatically. No full reload required.

**Safe fallback navigation** — the escape-hatch link takes a `fallbackHref` prop that callers set to a plain static route path (`/dashboard`, etc.). The component never reads from `WalletContext` or any address state and never serialises anything into the href.

**Redacted diagnostics** — `deriveCorrelationToken(scope, error)` runs an FNV-1a fold over the error *message string only*, producing a `scope-xxxxxxxx` hex tag shown in the fallback UI and logged in `componentDidCatch`. The raw message, stack trace, wallet address, and any secret key material are never logged or rendered. A `redactSecretKey()` guard (mirrors the one in `WalletProvider.connect`) is exported as a defence-in-depth utility.

The fallback surface uses `role=alert` + `aria-live=assertive` and an `h2` heading (scoped below the root layout `h1`), matching the accessibility contract of the existing `app/error.tsx`. Raw `error.message` is shown only in development, matching the same gate used in `app/error.tsx`.

### Route wiring

| Route | File |
|---|---|
| `/dashboard` | `app/dashboard/layout.tsx` |
| `/transactions` | `app/transactions/layout.tsx` |
| `/account-summary` | `app/account-summary/layout.tsx` |
| `/analytics-view` | `app/analytics-view/page.tsx` (no `layout.tsx` exists) |

### `components/common/scoped-error-boundary.test.tsx` (new)

42 tests covering every path called out in the issue validation section:

- **Render failure + retry** — boundary trips on throw, `Try again` resets state and re-renders children without reload.
- **Navigation** — fallback link renders the correct static href with no query params or address material.
- **Account change** — `resetKeys` diffing clears error when the wallet address changes (`null → address`, `address-A → address-B`), with a negative case confirming unchanged keys do not reset.
- **Offline behavior** — boundary shows the fallback (not a blank screen) when offline; `Try again` recovers after reconnection; `navigator.onLine` state is not leaked into the correlation token.
- Logging invariants, production/dev detail visibility, scope isolation (sibling boundary unaffected), accessibility (role, aria-live, h2 level), and unit tests for `deriveCorrelationToken` and `redactSecretKey`.

`components/common/scoped-error-boundary.tsx` is added to the `vitest.config.ts` coverage include list so it is tracked against the existing 95% thresholds.

---

## Acceptance criteria

| Criterion | How it is met |
|---|---|
| A failed route can be retried without a full reload | `handleReset()` sets `error: null` in class state; `window.location.reload()` is never called |
| Fallback navigation does not expose account secrets | `fallbackHref` is a static prop; component never reads `WalletContext`; `redactSecretKey()` guard present |
| Diagnostics correlate the failure without serializing sensitive state | `deriveCorrelationToken` hashes error message only; raw message/stack/address never logged or rendered |

---

## Testing

```bash
# Unit tests (42 tests, all green)
./node_modules/.bin/vitest run components/common/scoped-error-boundary.test.tsx --coverage.enabled=false

# Type-check
./node_modules/.bin/tsc --noEmit
```