### PR TITLE
Make security headers testable in the production preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,12 @@ playwright Install Playwright browsers npx playwright install --with-deps chromi
 E2E + accessibility npx playwright test Full Playwright suite, including the axe-core a11y scans described in Accessibility testing — a serious/critical violation fails this job
 On failure, the playwright job uploads the HTML report as a build artifact (playwright-report, retained 7 days) so violations and traces can be inspected without re-running locally.
 
+Security headers
+The repo ships a strict security policy (CSP, X-Frame-Options, HSTS, Referrer-Policy, X-Content-Type-Options) defined once in `lib/security-headers.ts` and applied to every route via `next.config.ts`. The same module drives two regression checks:
+
+- `lib/security-headers.test.ts` — Vitest unit coverage asserting the policy rejects unsafe inline scripts and cross-origin framing.
+- `tests/security-headers.spec.ts` — a Playwright preview check that asserts the headers on representative routes and a hashed static asset. Point it at a deployed preview with `BASE_URL=https://<preview> npx playwright test tests/security-headers.spec.ts --project=chromium`, or run it locally against the prod build with `npm run test:security-headers`. See `design/security-headers-check.md`.
+
 Running a single browser locally
 Pass --project=<name> to target one browser:
 

--- a/design/security-headers-check.md
+++ b/design/security-headers-check.md
@@ -1,0 +1,52 @@
+# Security Headers — Production Preview Check
+
+This document explains the acceptance-criteria test added for
+[#1174](https://github.com/Stellopay/stellopay-frontend/issues/1174): make the
+deployed preview prove it serves the intended security policy.
+
+## Outcome
+
+- Required headers (`Content-Security-Policy`, `X-Frame-Options`,
+  `Strict-Transport-Security`, `Referrer-Policy`, `X-Content-Type-Options`)
+  are asserted on representative routes and a hashed static asset.
+- The policy rejects unsafe inline scripts (`'unsafe-inline'`, `'unsafe-eval'`
+  in `script-src`) and cross-origin framing (`frame-ancestors 'none'`).
+- Failures name the missing or weakened header and directive.
+
+## Source of truth
+
+The exact header values live once in `lib/security-headers.ts` and are wired
+into `next.config.ts` via the `headers()` hook. Both the unit tests
+(`lib/security-headers.test.ts`) and the preview check
+(`tests/security-headers.spec.ts`) import that module, so the policy cannot
+drift from what the server actually sends.
+
+## Validation
+
+### 1. Unit coverage
+
+```bash
+npx vitest run lib/security-headers.test.ts --coverage.enabled=false
+```
+
+### 2. Against a local production build
+
+Build and run the production server, then point the preview check at it:
+
+```bash
+npm run build
+npm run start   # next start, default port 3000
+npm run test:security-headers
+```
+
+### 3. Against a configured preview
+
+Point Playwright at the deployment URL:
+
+```bash
+BASE_URL=https://<preview-url> npx playwright test tests/security-headers.spec.ts --project=chromium
+```
+
+The check uses `request.get()` with redirect-following, so authenticated
+routes that 307 to the public session-expired page still get their headers
+verified on the final response.

--- a/lib/security-headers.test.ts
+++ b/lib/security-headers.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONTENT_SECURITY_POLICY,
+  CSP_DIRECTIVES,
+  PERMISSIONS_POLICY,
+  REFERRER_POLICY,
+  SECURITY_HEADERS,
+  STRICT_TRANSPORT_SECURITY,
+  X_CONTENT_TYPE_OPTIONS,
+  X_FRAME_OPTIONS,
+  X_XSS_PROTECTION,
+} from "./security-headers";
+
+describe("security-headers", () => {
+  it("applies the full set of required headers", () => {
+    const keys = SECURITY_HEADERS.map((h) => h.key);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        "Content-Security-Policy",
+        "X-Frame-Options",
+        "Strict-Transport-Security",
+        "Referrer-Policy",
+        "X-Content-Type-Options",
+      ]),
+    );
+  });
+
+  it("rejects unsafe inline scripts and eval in script-src", () => {
+    const scriptSrc = CSP_DIRECTIVES.find((d) => d.startsWith("script-src"));
+    expect(scriptSrc).toBe("script-src 'self'");
+    // Explicitly assert no unsafe-inline / unsafe-eval in the script directive.
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+    expect(scriptSrc).not.toContain("'unsafe-eval'");
+  });
+
+  it("still permits inline styles required by Next/Tailwind in style-src only", () => {
+    const styleSrc = CSP_DIRECTIVES.find((d) => d.startsWith("style-src"));
+    expect(styleSrc).toContain("'self'");
+    // style-src may keep 'unsafe-inline', but script-src must not inherit it.
+    expect(
+      CSP_DIRECTIVES.find((d) => d.startsWith("script-src")),
+    ).not.toContain("'unsafe-inline'");
+  });
+
+  it("rejects all cross-origin framing via frame-ancestors 'none'", () => {
+    expect(CSP_DIRECTIVES).toContain("frame-ancestors 'none'");
+    expect(X_FRAME_OPTIONS).toBe("DENY");
+  });
+
+  it("enforces transport security via HSTS", () => {
+    expect(STRICT_TRANSPORT_SECURITY).toContain("max-age=");
+    expect(STRICT_TRANSPORT_SECURITY).toContain("includeSubDomains");
+  });
+
+  it("restricts referrer leakage to same-origin", () => {
+    expect(REFERRER_POLICY).toBe("strict-origin-when-cross-origin");
+  });
+
+  it("prevents MIME type sniffing", () => {
+    expect(X_CONTENT_TYPE_OPTIONS).toBe("nosniff");
+  });
+});

--- a/lib/security-headers.ts
+++ b/lib/security-headers.ts
@@ -1,0 +1,72 @@
+/**
+ * @file lib/security-headers.ts
+ *
+ * Single source of truth for the app's HTTP security headers.
+ *
+ * These values are consumed by:
+ *  - next.config.ts  (applied to every route via the Next.js `headers()` hook)
+ *  - tests/security-headers.spec.ts  (Playwright preview checks)
+ *
+ * Centralizing the policy here means the test asserts against the exact
+ * directives the server actually sends — a header can't drift without the
+ * check failing. A failing assertion names the header and directive that
+ * regressed, so the policy can be corrected rather than silently weakened.
+ *
+ * Requirement coverage (issue #1174):
+ *  - CSP            → Content-Security-Policy
+ *  - frame          → X-Frame-Options + CSP frame-ancestors
+ *  - transport      → Strict-Transport-Security (HSTS)
+ *  - referrer       → Referrer-Policy
+ *  - content-type   → X-Content-Type-Options
+ */
+
+/** Collectively enforced CSP directives that reject unsafe inline/cross-origin behavior. */
+export const CSP_DIRECTIVES: string[] = [
+  // No inline or eval'd scripts: resources must come from the same origin.
+  "default-src 'self'",
+  "script-src 'self'",
+  // Styles allow inline so Tailwind/Next injected <style> nodes work.
+  "style-src 'self' 'unsafe-inline'",
+  // Images may be data/blob for icons & avatars; nothing external besides self.
+  "img-src 'self' data: blob:",
+  "font-src 'self'",
+  // Same-origin API + specific Stellar network hosts only.
+  "connect-src 'self' https://stellar.org https://horizon.stellar.org https://soroban.stellar.org",
+  // Reject all framing of this site (clickjacking defence).
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "upgrade-insecure-requests",
+];
+
+/** Full serialized Content-Security-Policy header value. */
+export const CONTENT_SECURITY_POLICY = CSP_DIRECTIVES.join("; ");
+
+export const X_FRAME_OPTIONS = "DENY";
+
+/** 2-year HSTS; includeSubDomains + preload for transport security. */
+export const STRICT_TRANSPORT_SECURITY =
+  "max-age=63072000; includeSubDomains; preload";
+
+export const REFERRER_POLICY = "strict-origin-when-cross-origin";
+
+export const X_CONTENT_TYPE_OPTIONS = "nosniff";
+
+export const X_XSS_PROTECTION = "1; mode=block";
+
+export const PERMISSIONS_POLICY =
+  "camera=(), microphone=(), geolocation=(), interest-cohort=()";
+
+/**
+ * The exact { key, value } objects applied by Next.js `headers()`.
+ * Exported so the Playwright preview check and config can never disagree.
+ */
+export const SECURITY_HEADERS = [
+  { key: "Content-Security-Policy", value: CONTENT_SECURITY_POLICY },
+  { key: "X-Frame-Options", value: X_FRAME_OPTIONS },
+  { key: "Strict-Transport-Security", value: STRICT_TRANSPORT_SECURITY },
+  { key: "Referrer-Policy", value: REFERRER_POLICY },
+  { key: "X-Content-Type-Options", value: X_CONTENT_TYPE_OPTIONS },
+  { key: "X-XSS-Protection", value: X_XSS_PROTECTION },
+  { key: "Permissions-Policy", value: PERMISSIONS_POLICY },
+] as const;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import bundleAnalyzer from "@next/bundle-analyzer";
+import { SECURITY_HEADERS } from "./lib/security-headers";
 
 const nextConfig: NextConfig = {
   // ESLint now runs during `next build` so lint errors surface in CI.
@@ -9,6 +10,15 @@ const nextConfig: NextConfig = {
     // supported by the framework build worker.
     useTypeScriptCli: true,
   },
+
+  // Apply the security policy to every route so the deployed preview and
+  // production serve identical protection.
+  headers: async () => [
+    {
+      source: "/(.*)",
+      headers: [...SECURITY_HEADERS] as { key: string; value: string }[],
+    },
+  ],
 };
 
 const withBundleAnalyzer = bundleAnalyzer({

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:e2e": "playwright test --project=chromium",
     "test:a11y": "playwright test tests/a11y.spec.ts",
     "type-check": "tsc --noEmit",
-    "test:e2e:settings": "playwright test tests/settings.spec.ts"
+    "test:e2e:settings": "playwright test tests/settings.spec.ts",
+    "test:security-headers": "playwright test tests/security-headers.spec.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/tests/security-headers.spec.ts
+++ b/tests/security-headers.spec.ts
@@ -1,0 +1,141 @@
+// End-to-end security-header check (issue #1174).
+//
+// This spec asserts that the deployed preview (or the local production build)
+// actually serves the intended security policy. It runs against whatever
+// server the Playwright webServer/browserBaseURL points at — in CI that is
+// the production preview; locally you can point it at `npm run build` +
+// `npm run start`.
+//
+// The policy it verifies is defined once in lib/security-headers.ts and wired
+// into next.config.ts, so a header cannot drift without this test failing.
+//
+// Representative routes:  HTML document (public + authenticated shell) and a
+// hashed static asset (declares the content-type / inline protections that
+// apply to served files).
+//
+// A failing assertion names the exact header + directive that regressed.
+
+import { expect, test, type APIResponse } from "@playwright/test";
+import {
+  CONTENT_SECURITY_POLICY,
+  REFERRER_POLICY,
+  STRICT_TRANSPORT_SECURITY,
+  X_CONTENT_TYPE_OPTIONS,
+  X_FRAME_OPTIONS,
+} from "../lib/security-headers";
+
+/** Routes exercised by the check: a public page and the app shell. */
+const REPRESENTATIVE_ROUTES = ["/", "/dashboard"];
+
+/**
+ * Required headers asserted on every representative route and on a hashed
+ * static asset. Value is a predicate (true = header matches expected policy).
+ */
+const REQUIRED_HEADERS: Record<string, (value: string | null) => boolean> = {
+  "Content-Security-Policy": (v) => v === CONTENT_SECURITY_POLICY,
+  "X-Frame-Options": (v) => v === X_FRAME_OPTIONS,
+  "Strict-Transport-Security": (v) => v === STRICT_TRANSPORT_SECURITY,
+  "Referrer-Policy": (v) => v === REFERRER_POLICY,
+  "X-Content-Type-Options": (v) => v === X_CONTENT_TYPE_OPTIONS,
+};
+
+/** Directives that must NOT appear in the served script-src (rejects unsafe inline/eval). */
+const FORBIDDEN_SCRIPT_DIRECTIVES = ["'unsafe-inline'", "'unsafe-eval'"];
+
+/** Extract the value of a single CSP directive (e.g. script-src …; -> 'self'). */
+function cspDirective(csp: string, name: string): string | null {
+  const match = csp.match(new RegExp(`(?:^|;)\\s*${name}\\s+([^;]+)`));
+  return match ? match[1].trim() : null;
+}
+
+/** Assert that `response` satisfies the full required-header policy. */
+function assertPolicyOnResponse(name: string, response: APIResponse): void {
+  for (const [header, matches] of Object.entries(REQUIRED_HEADERS)) {
+    const value = response.headers()[header.toLowerCase()] ?? null;
+    expect(
+      matches(value),
+      `[${name}] missing or weakened header "${header}". ` +
+        `Expected "${header}" to match the policy; got ${JSON.stringify(value || null)}`,
+    ).toBe(true);
+  }
+
+  // The policy must reject unsafe inline / eval'd scripts and cross-origin framing.
+  const csp = response.headers()["content-security-policy"] ?? "";
+  const scriptSrc = cspDirective(csp, "script-src");
+  expect(
+    scriptSrc,
+    `[${name}] CSP must define a script-src directive`,
+  ).toBeTruthy();
+  for (const directive of FORBIDDEN_SCRIPT_DIRECTIVES) {
+    expect(
+      scriptSrc!.includes(directive),
+      `[${name}] script-src must reject ${directive} (unsafe inline/eval)`,
+    ).toBe(false);
+  }
+  expect(
+    csp.includes("frame-ancestors 'none'"),
+    `[${name}] CSP must deny framing via frame-ancestors 'none'`,
+  ).toBe(true);
+}
+
+test.describe("Security headers on representative routes", () => {
+  for (const route of REPRESENTATIVE_ROUTES) {
+    test(`responds with the required security policy on ${route}`, async ({
+      request,
+      baseURL,
+    }) => {
+      const res = await request.get(`${baseURL}${route}`);
+      expect(res.status(), `${route} should return 200`).toBe(200);
+      assertPolicyOnResponse(route, res);
+    });
+  }
+});
+
+test.describe("Security headers on static assets", () => {
+  test("responds with content-type and framing protection on a hashed asset", async ({
+    request,
+    baseURL,
+  }) => {
+    // Fetch the landing page first to discover a real content-hashed asset.
+    const page = await request.get(`${baseURL}/`);
+    expect(page.status()).toBe(200);
+
+    const html = await page.text();
+    const match =
+      html.match(/src="(\/_next\/static\/[^"]+\.js)"/) ??
+      html.match(/href="(\/_next\/static\/[^"]+\.css)"/);
+    expect(
+      match,
+      "landing page should reference a _next/static asset",
+    ).toBeTruthy();
+
+    const assetUrl = `${baseURL}${match![1]}`;
+    const asset = await request.get(assetUrl);
+    expect(asset.status()).toBe(200);
+
+    assertPolicyOnResponse("static asset", asset);
+  });
+});
+
+test.describe("Security policy rejects unsafe behavior", () => {
+  test("script-src rejects unsafe-inline and unsafe-eval on every representative route", async ({
+    request,
+    baseURL,
+  }) => {
+    for (const route of REPRESENTATIVE_ROUTES) {
+      const res = await request.get(`${baseURL}${route}`);
+      const csp = res.headers()["content-security-policy"] ?? "";
+      const scriptSrc = cspDirective(csp, "script-src");
+      expect(
+        scriptSrc,
+        `[${route}] CSP must define a script-src directive`,
+      ).toBeTruthy();
+      for (const directive of FORBIDDEN_SCRIPT_DIRECTIVES) {
+        expect(
+          scriptSrc!.includes(directive),
+          `[${route}] script-src must reject ${directive}`,
+        ).toBe(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Makes the security policy testable against the deployed production preview so a header can't silently weaken or drift during a release.

The required headers now live once in `lib/security-headers.ts` and are applied to every route via `next.config.ts`, guaranteeing preview and production serve identical protection. Two regression checks consume that same module so the test asserts against the exact policy the server sends.

## Scope (issue #1174)
- CSP (`Content-Security-Policy`)
- Frame (`X-Frame-Options` + CSP `frame-ancestors 'none'`)
- Transport (`Strict-Transport-Security`)
- Referrer (`Referrer-Policy`)
- Content-type (`X-Content-Type-Options`)

## Acceptance criteria
- **Required headers are asserted on representative routes and assets.** `tests/security-headers.spec.ts` checks `/`, `/dashboard`, and a content-hashed `/_next/static` asset.
- **The policy rejects unsafe inline or cross-origin behavior as intended.** The check enforces `script-src 'self'` (no `'unsafe-inline'` / `'unsafe-eval'`) and `frame-ancestors 'none'` on every route.
- **Failures identify the missing or weakened directive.** Each assertion names the header and the expected value on failure.

## Validation
- Unit coverage: `npx vitest run lib/security-headers.test.ts --coverage.enabled=false` (7 tests pass).
- Against a local production server: `npm run build && npm run start`, then `npm run test:security-headers`.
- Against a configured preview: `BASE_URL=https://<preview> npx playwright test tests/security-headers.spec.ts --project=chromium`.

## Files changed
- `lib/security-headers.ts` — single source of truth for the header policy
- `next.config.ts` — wires `SECURITY_HEADERS` into the `headers()` hook
- `lib/security-headers.test.ts` — unit tests for the policy
- `tests/security-headers.spec.ts` — Playwright preview check
- `package.json` — `test:security-headers` script
- `design/security-headers-check.md` — validation runbook
- `README.md` — documents the check under CI Pipeline

Fixes: Stellopay/stellopay-frontend#1174

Closes #1174
