### PR TITLE
feat: add deduplication utility for transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,12 @@ playwright Install Playwright browsers npx playwright install --with-deps chromi
 E2E + accessibility npx playwright test Full Playwright suite, including the axe-core a11y scans described in Accessibility testing — a serious/critical violation fails this job
 On failure, the playwright job uploads the HTML report as a build artifact (playwright-report, retained 7 days) so violations and traces can be inspected without re-running locally.
 
+Security headers
+The repo ships a strict security policy (CSP, X-Frame-Options, HSTS, Referrer-Policy, X-Content-Type-Options) defined once in `lib/security-headers.ts` and applied to every route via `next.config.ts`. The same module drives two regression checks:
+
+- `lib/security-headers.test.ts` — Vitest unit coverage asserting the policy rejects unsafe inline scripts and cross-origin framing.
+- `tests/security-headers.spec.ts` — a Playwright preview check that asserts the headers on representative routes and a hashed static asset. Point it at a deployed preview with `BASE_URL=https://<preview> npx playwright test tests/security-headers.spec.ts --project=chromium`, or run it locally against the prod build with `npm run test:security-headers`. See `design/security-headers-check.md`.
+
 Running a single browser locally
 Pass --project=<name> to target one browser:
 

--- a/app/account-summary/layout.tsx
+++ b/app/account-summary/layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import AppLayout from "@/components/common/app-layout";
 import { SidebarProvider } from "@/context/sidebar-context";
+import { ScopedErrorBoundary } from "@/components/common/scoped-error-boundary";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -20,7 +21,15 @@ export default function AccountSummaryLayout({
 }>) {
   return (
     <SidebarProvider>
-      <AppLayout>{children}</AppLayout>
+      <AppLayout>
+        <ScopedErrorBoundary
+          scope="account-summary"
+          fallbackHref="/dashboard"
+          fallbackLabel="Back to dashboard"
+        >
+          {children}
+        </ScopedErrorBoundary>
+      </AppLayout>
     </SidebarProvider>
   );
 }

--- a/app/analytics-view/page.tsx
+++ b/app/analytics-view/page.tsx
@@ -1,5 +1,6 @@
 import ClientAnalyticsView from "@/components/analytics/client-analytics-view";
 import { Breadcrumb, type BreadcrumbItem } from "@/components/common/breadcrumb";
+import { ScopedErrorBoundary } from "@/components/common/scoped-error-boundary";
 
 /**
  * The route lives at `/analytics-view` but the user always arrives from the
@@ -13,11 +14,15 @@ const BREADCRUMB_TRAIL: BreadcrumbItem[] = [
 
 export default function AnalyticsPage() {
   return (
-    <>
+    <ScopedErrorBoundary
+      scope="analytics-view"
+      fallbackHref="/dashboard"
+      fallbackLabel="Back to dashboard"
+    >
       <div className="px-4 py-4 md:px-6 w-full max-w-screen-xl mx-auto">
         <Breadcrumb items={BREADCRUMB_TRAIL} />
       </div>
       <ClientAnalyticsView />
-    </>
+    </ScopedErrorBoundary>
   );
 }

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import AppLayout from "@/components/common/app-layout";
 import { SidebarProvider } from "@/context/sidebar-context";
+import { ScopedErrorBoundary } from "@/components/common/scoped-error-boundary";
 import type { Metadata } from "next";
 
 /**
@@ -57,7 +58,15 @@ export default function DashboardLayout({
 }>) {
   return (
     <SidebarProvider>
-      <AppLayout>{children}</AppLayout>
+      <AppLayout>
+        <ScopedErrorBoundary
+          scope="dashboard"
+          fallbackHref="/dashboard"
+          fallbackLabel="Reload dashboard"
+        >
+          {children}
+        </ScopedErrorBoundary>
+      </AppLayout>
     </SidebarProvider>
   );
 }

--- a/app/settings/preferences/components/destructive-action-dialog.test.tsx
+++ b/app/settings/preferences/components/destructive-action-dialog.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import DestructiveActionDialog from "./destructive-action-dialog";
@@ -23,6 +29,25 @@ function renderOpenDialog(onConfirm = vi.fn()) {
 
   fireEvent.click(screen.getByRole("button", { name: "Deactivate account" }));
   return { onConfirm };
+}
+
+/** Opens the dialog and types the exact token so the confirm button is enabled. */
+function openDialogAndType(onConfirm = vi.fn()) {
+  renderOpenDialog(onConfirm);
+  fireEvent.change(getInput(), { target: { value: "DEACTIVATE" } });
+  return { onConfirm };
+}
+
+/** An `onConfirm` handler backed by a manually-resolved promise. */
+function deferredConfirm() {
+  let resolve!: () => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  const onConfirm = vi.fn(() => promise);
+  return { onConfirm, resolve, reject };
 }
 
 const getInput = () => screen.getByLabelText('Type "DEACTIVATE" to confirm');
@@ -104,7 +129,7 @@ describe("DestructiveActionDialog", () => {
     expect(getConfirmButton()).toBeDisabled();
   });
 
-  it("confirms only on an exact, case-correct token", () => {
+  it("confirms only on an exact, case-correct token", async () => {
     const { onConfirm } = renderOpenDialog();
 
     fireEvent.change(getInput(), { target: { value: "DEACTIVATE" } });
@@ -116,7 +141,129 @@ describe("DestructiveActionDialog", () => {
     const confirmButton = getConfirmButton();
     expect(confirmButton).toBeEnabled();
 
-    fireEvent.click(confirmButton);
+    await act(async () => {
+      fireEvent.click(confirmButton);
+    });
     expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Idempotency: one request per confirmation
+  // -------------------------------------------------------------------------
+
+  it("issues exactly one request on a rapid double click", async () => {
+    const { onConfirm, resolve } = deferredConfirm();
+    openDialogAndType(onConfirm);
+
+    const confirmButton = getConfirmButton();
+    // Both click events arrive before React re-renders, mimicking a fast
+    // double click / held pointer.
+    fireEvent.click(confirmButton);
+    fireEvent.click(confirmButton);
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await act(async () => resolve());
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("issues exactly one request on keyboard (Enter) repeat", async () => {
+    const { onConfirm, resolve } = deferredConfirm();
+    openDialogAndType(onConfirm);
+
+    const confirmButton = getConfirmButton();
+    confirmButton.focus();
+    // A held Enter synthesizes a click per keydown on the focused button; each
+    // keyboard-activated click carries `detail: 0`.
+    fireEvent.click(confirmButton, { detail: 0 });
+    fireEvent.click(confirmButton, { detail: 0 });
+    fireEvent.click(confirmButton, { detail: 0 });
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    // Once pending, the button is disabled so further key repeats are inert.
+    expect(confirmButton).toBeDisabled();
+
+    await act(async () => resolve());
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Pending state: dialog must not close before the request resolves
+  // -------------------------------------------------------------------------
+
+  it("stays open and disables its controls while the request is pending", async () => {
+    const { onConfirm, resolve } = deferredConfirm();
+    openDialogAndType(onConfirm);
+
+    fireEvent.click(getConfirmButton());
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(getConfirmButton()).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(getInput()).toBeDisabled();
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-busy", "true");
+
+    // Escape and the close (X) affordance must not dismiss while in flight.
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await act(async () => resolve());
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Rejection + retry
+  // -------------------------------------------------------------------------
+
+  it("keeps the dialog open and re-enables confirm when the request rejects", async () => {
+    const onConfirm = vi.fn(() => Promise.reject(new Error("Request failed")));
+    openDialogAndType(onConfirm);
+
+    fireEvent.click(getConfirmButton());
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/request failed/i);
+    expect(alert).toHaveTextContent(/retry/i);
+
+    // Dialog never closed, token is preserved, confirm is available again.
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(getInput()).toHaveValue("DEACTIVATE");
+    expect(getConfirmButton()).toBeEnabled();
+  });
+
+  it("allows a retry after a recoverable failure", async () => {
+    const onConfirm = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Request failed"))
+      .mockResolvedValueOnce(undefined);
+    openDialogAndType(onConfirm);
+
+    fireEvent.click(getConfirmButton());
+    await screen.findByRole("alert");
+
+    // Retry succeeds and the dialog closes once the request resolves.
+    fireEvent.click(getConfirmButton());
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    expect(onConfirm).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the failure notice when the user edits the confirmation input", async () => {
+    const onConfirm = vi.fn(() => Promise.reject(new Error("Request failed")));
+    openDialogAndType(onConfirm);
+
+    fireEvent.click(getConfirmButton());
+    await screen.findByRole("alert");
+
+    fireEvent.change(getInput(), { target: { value: "DEACTIVAT" } });
+    expect(screen.queryByText(/request failed/i)).not.toBeInTheDocument();
   });
 });

--- a/app/settings/preferences/components/destructive-action-dialog.tsx
+++ b/app/settings/preferences/components/destructive-action-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,6 +13,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { usePendingAction } from "@/hooks/usePendingAction";
 
 interface DestructiveActionDialogProps {
   triggerLabel: string;
@@ -22,7 +23,13 @@ interface DestructiveActionDialogProps {
   confirmationToken: string;
   confirmationLabel: string;
   confirmLabel: string;
-  onConfirm: () => void;
+  /**
+   * Runs once per confirmation. May return a promise; the dialog stays open
+   * (in a pending state) until it resolves, and only closes on success. When
+   * it rejects, the dialog stays open with an inline error so the user can
+   * retry.
+   */
+  onConfirm: () => void | Promise<void>;
 }
 
 /**
@@ -65,19 +72,29 @@ function getConfirmationError(value: string, token: string): string | null {
 
 /**
  * A confirmation dialog for irreversible, high-impact actions (e.g. account
- * deactivation, wallet removal).
+ * deactivation, wallet removal, key revocation).
  *
- * Accessibility & safety behaviour:
+ * Safety & idempotency behaviour:
+ * - Exactly one request is issued per confirmation. While `onConfirm` is
+ *   pending the dialog disables its controls (confirm, cancel, close, typed
+ *   input) and guards against re-entry, so a rapid double click or a held /
+ *   repeated Enter key can never fire the action twice.
+ * - The dialog only closes after `onConfirm` resolves successfully. It never
+ *   looks "done" while the request is still in flight.
+ * - If `onConfirm` rejects, the dialog stays open, surfaces the failure
+ *   inline, and leaves the confirm button enabled so the user can retry.
+ * - The confirm action requires an **exact** token match — the value is *not*
+ *   trimmed or lower-cased — so accidental whitespace or wrong casing can never
+ *   bypass the user's intent. Any mismatch is surfaced inline (including a
+ *   whitespace-specific hint) instead of failing silently.
+ *
+ * Accessibility:
  * - The confirmation input is auto-focused when the dialog opens
  *   (`onOpenAutoFocus`), and focus returns to the trigger button on close —
  *   focus trapping and restoration are provided by Radix's `Dialog`.
  * - The input is wired with `aria-required`, `aria-invalid`, and
  *   `aria-describedby` (instruction text + error) via the shared `Input`
- *   component.
- * - The confirm action requires an **exact** token match — the value is *not*
- *   trimmed or lower-cased — so accidental whitespace or wrong casing can never
- *   bypass the user's intent. Any mismatch is surfaced inline (including a
- *   whitespace-specific hint) instead of failing silently.
+ *   component, and the dialog signals `aria-busy` while the action runs.
  */
 export default function DestructiveActionDialog({
   triggerLabel,
@@ -91,11 +108,18 @@ export default function DestructiveActionDialog({
 }: DestructiveActionDialogProps) {
   const [open, setOpen] = useState(false);
   const [confirmationText, setConfirmationText] = useState("");
+  const {
+    isPending,
+    error: actionError,
+    run,
+    reset: resetAction,
+  } = usePendingAction();
 
   const inputId = `confirmation-${confirmationToken.toLowerCase()}`;
   const labelId = `${inputId}-label`;
   const instructionId = `${inputId}-instruction`;
   const errorId = `${inputId}-error`;
+  const actionErrorId = `${inputId}-action-error`;
 
   // Strict, exact comparison: whitespace and casing must match the token.
   const isConfirmed = confirmationText === confirmationToken;
@@ -105,18 +129,37 @@ export default function DestructiveActionDialog({
     [confirmationText, confirmationToken],
   );
 
-  const handleOpenChange = (nextOpen: boolean) => {
-    setOpen(nextOpen);
+  const closeDialog = () => {
+    setOpen(false);
     setConfirmationText("");
+    resetAction();
   };
 
-  const handleConfirm = () => {
-    if (!isConfirmed) {
+  const handleOpenChange = (nextOpen: boolean) => {
+    // Never let the dialog dismiss (Escape, overlay, close button, cancel)
+    // while a request is in flight — closing early would imply success.
+    if (isPending) {
       return;
     }
 
-    onConfirm();
-    handleOpenChange(false);
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setConfirmationText("");
+      resetAction();
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!isConfirmed || isPending) {
+      return;
+    }
+
+    const succeeded = await run(onConfirm);
+    if (succeeded) {
+      // Close directly: `handleOpenChange` would still see the stale pending
+      // state in this closure and refuse to dismiss.
+      closeDialog();
+    }
   };
 
   return (
@@ -131,8 +174,11 @@ export default function DestructiveActionDialog({
           // Override Radix's default (focus the content/close button) so the
           // user lands directly on the field they must fill in.
           event.preventDefault();
-          document.getElementById(inputId)?.focus();
+          if (!isPending) {
+            document.getElementById(inputId)?.focus();
+          }
         }}
+        aria-busy={isPending}
       >
         <DialogHeader className="space-y-3 text-left">
           <div className="flex items-center gap-3">
@@ -180,11 +226,17 @@ export default function DestructiveActionDialog({
             <Input
               id={inputId}
               value={confirmationText}
-              onChange={(event) => setConfirmationText(event.target.value)}
+              onChange={(event) => {
+                setConfirmationText(event.target.value);
+                if (actionError) {
+                  resetAction();
+                }
+              }}
               placeholder={confirmationToken}
               className="border-zinc-200 bg-white dark:border-white/10 dark:bg-white/5"
               required
               aria-required
+              disabled={isPending}
               error={Boolean(validationError)}
               labelId={labelId}
               descriptionId={instructionId}
@@ -200,19 +252,41 @@ export default function DestructiveActionDialog({
                 {validationError}
               </p>
             )}
+            {actionError && (
+              <p
+                id={actionErrorId}
+                role="alert"
+                aria-live="polite"
+                className="flex items-center gap-1.5 rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs font-medium text-red-500"
+              >
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                {actionError}. You can retry.
+              </p>
+            )}
           </div>
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+          <Button
+            variant="outline"
+            disabled={isPending}
+            onClick={() => handleOpenChange(false)}
+          >
             Cancel
           </Button>
           <Button
             variant="destructive"
-            disabled={!isConfirmed}
+            disabled={!isConfirmed || isPending}
             onClick={handleConfirm}
           >
-            {confirmLabel}
+            {isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {confirmLabel}
+              </>
+            ) : (
+              confirmLabel
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/app/settings/preferences/components/security-tab.test.tsx
+++ b/app/settings/preferences/components/security-tab.test.tsx
@@ -1428,3 +1428,52 @@ describe("SecurityTab — 2FA verification security", () => {
     expect(err).not.toContain("12345");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Destructive API-key actions — idempotent confirmation
+// ---------------------------------------------------------------------------
+
+describe("SecurityTab — API key revocation", () => {
+  it("issues a single revoke request across a rapid double click and closes only after it resolves", async () => {
+    render(<SecurityTab />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^revoke$/i })[0]);
+    fireEvent.change(screen.getByLabelText('Type "REVOKE" to continue'), {
+      target: { value: "REVOKE" },
+    });
+    const confirm = screen.getByRole("button", { name: "Revoke key" });
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+
+    // The key stays visible until the simulated request resolves (~350 ms),
+    // then the dialog closes and the key is removed exactly once.
+    await waitFor(
+      () =>
+        expect(
+          screen.queryByText("Mobile payouts service"),
+        ).not.toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.getByText("Reporting sync")).toBeInTheDocument();
+  });
+
+  it("keeps the revoke dialog pending (controls disabled) until the request resolves", async () => {
+    render(<SecurityTab />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^revoke$/i })[0]);
+    fireEvent.change(screen.getByLabelText('Type "REVOKE" to continue'), {
+      target: { value: "REVOKE" },
+    });
+    const confirm = screen.getByRole("button", { name: "Revoke key" });
+
+    fireEvent.click(confirm);
+    // Immediately after confirming, the confirm button is disabled while pending.
+    expect(confirm).toBeDisabled();
+
+    await waitFor(
+      () => expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+  });
+});

--- a/app/settings/preferences/components/security-tab.tsx
+++ b/app/settings/preferences/components/security-tab.tsx
@@ -41,7 +41,6 @@ import {
 } from "@/utils/authUtils";
 import DestructiveActionDialog from "./destructive-action-dialog";
 import { DEMO_SECURITY, DEMO_CONNECTED_APPS } from "@/lib/demo-data";
-import { DEMO_SECURITY } from "@/lib/demo-data";
 import { generateTotpSecret, verifyTotpCode } from "@/lib/totp";
 import QRCode from "qrcode";
 
@@ -635,7 +634,7 @@ export default function SecurityTab({
   };
 
   const handleRotateApiKey = (key: ApiKeyRecord) => {
-    void queueApiKeyAction(`rotate-${key.id}`, () => {
+    return queueApiKeyAction(`rotate-${key.id}`, () => {
       const secret = createApiKeySecret(key.name);
 
       setApiKeys((current) =>
@@ -661,7 +660,7 @@ export default function SecurityTab({
   };
 
   const handleRevokeApiKey = (key: ApiKeyRecord) => {
-    void queueApiKeyAction(`revoke-${key.id}`, () => {
+    return queueApiKeyAction(`revoke-${key.id}`, () => {
       setApiKeys((current) => current.filter((item) => item.id !== key.id));
       if (revealedApiSecret?.keyId === key.id) {
         setRevealedApiSecret(null);

--- a/app/settings/preferences/components/wallets-section.test.tsx
+++ b/app/settings/preferences/components/wallets-section.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { WalletsSection, WalletItem } from "./wallets-section";
@@ -30,7 +30,9 @@ describe("WalletsSection", () => {
 
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText("Remove Connected Wallet")).toBeInTheDocument();
-    expect(screen.getByText("Test Wallet 1")).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("dialog")).getByText("Test Wallet 1"),
+    ).toBeInTheDocument();
   });
 
   it("cancels wallet removal when cancel button is clicked", () => {
@@ -42,7 +44,7 @@ describe("WalletsSection", () => {
     expect(screen.getByText("Test Wallet 1")).toBeInTheDocument();
   });
 
-  it("removes wallet and calls onRemoveWallet when confirmed", () => {
+  it("removes wallet and calls onRemoveWallet when confirmed", async () => {
     const handleRemove = vi.fn();
     render(<WalletsSection wallets={mockWallets} onRemoveWallet={handleRemove} />);
 
@@ -50,7 +52,59 @@ describe("WalletsSection", () => {
     fireEvent.click(screen.getByRole("button", { name: /^remove wallet$/i }));
 
     expect(handleRemove).toHaveBeenCalledWith("1");
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
     expect(screen.queryByText("Test Wallet 1")).not.toBeInTheDocument();
+  });
+
+  it("issues a single removal request across a rapid double click on the confirm button", async () => {
+    const removeSpy = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, 50);
+        }),
+    );
+    render(<WalletsSection wallets={mockWallets} onRemoveWallet={removeSpy} />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /remove/i })[0]);
+    const confirm = screen.getByRole("button", { name: /^remove wallet$/i });
+    fireEvent.click(confirm);
+    // While the request is in flight the confirm button is disabled.
+    expect(confirm).toBeDisabled();
+    fireEvent.click(confirm);
+
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the dialog open with an error on failure, then retries successfully", async () => {
+    const removeSpy = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Network down"))
+      .mockResolvedValueOnce(undefined);
+    render(<WalletsSection wallets={mockWallets} onRemoveWallet={removeSpy} />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /remove/i })[0]);
+    fireEvent.click(screen.getByRole("button", { name: /^remove wallet$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/you can retry/i),
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("dialog")).getByText("Test Wallet 1"),
+    ).toBeInTheDocument();
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /^remove wallet$/i }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    expect(removeSpy).toHaveBeenCalledTimes(2);
   });
 
   // ── nickname editing ──────────────────────────────────────────────

--- a/app/settings/preferences/components/wallets-section.tsx
+++ b/app/settings/preferences/components/wallets-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { Check, Pencil, Trash2, Wallet as WalletIcon, X } from "lucide-react";
+import { Check, Loader2, Pencil, Trash2, Wallet as WalletIcon, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -13,6 +13,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { truncateStellarAddress } from "@/utils/stellarAddress";
+import { useSearchHighlight } from "@/hooks/useSearchHighlight";
+import { usePendingAction } from "@/hooks/usePendingAction";
 
 export interface WalletItem {
   id: string;
@@ -22,8 +24,11 @@ export interface WalletItem {
 
 interface WalletsSectionProps {
   wallets?: WalletItem[];
-  onRemoveWallet?: (id: string) => void;
+  /** May return a promise; the remove dialog stays pending until it resolves. */
+  onRemoveWallet?: (id: string) => void | Promise<void>;
   onUpdateNickname?: (id: string, nickname: string) => void;
+  /** When set, scrolls to and highlights the matching control. */
+  highlightedSearchLabel?: string | null;
 }
 
 const MAX_NICKNAME_LENGTH = 40;
@@ -37,12 +42,24 @@ export function WalletsSection({
   wallets = DEFAULT_WALLETS,
   onRemoveWallet,
   onUpdateNickname,
+  highlightedSearchLabel,
 }: WalletsSectionProps) {
   useSearchHighlight(highlightedSearchLabel ?? null);
   const [walletList, setWalletList] = useState<WalletItem[]>(wallets);
   const [walletToRemove, setWalletToRemove] = useState<WalletItem | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState("");
+  const {
+    isPending: isRemoving,
+    error: removeError,
+    run: runRemove,
+    reset: resetRemove,
+  } = usePendingAction({ genericErrorMessage: "Failed to remove the wallet." });
+
+  const openRemoveDialog = (wallet: WalletItem) => {
+    resetRemove();
+    setWalletToRemove(wallet);
+  };
 
   const startEditing = (wallet: WalletItem) => {
     setEditingId(wallet.id);
@@ -74,11 +91,13 @@ export function WalletsSection({
   };
 
   const handleConfirmRemove = () => {
-    if (!walletToRemove) return;
+    if (!walletToRemove || isRemoving) return;
     const { id } = walletToRemove;
-    setWalletList((prev) => prev.filter((w) => w.id !== id));
-    onRemoveWallet?.(id);
-    setWalletToRemove(null);
+    void runRemove(async () => {
+      setWalletList((prev) => prev.filter((w) => w.id !== id));
+      await onRemoveWallet?.(id);
+      setWalletToRemove(null);
+    });
   };
 
   return (
@@ -167,9 +186,10 @@ export function WalletsSection({
                 <Button
                   variant="ghost"
                   size="icon"
-                  onClick={() => setWalletToRemove(wallet)}
+                  onClick={() => openRemoveDialog(wallet)}
                   aria-label={`Remove ${displayName} (${wallet.address})`}
                   className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  disabled={isRemoving}
                 >
                   <Trash2 className="h-4 w-4" />
                 </Button>
@@ -180,8 +200,18 @@ export function WalletsSection({
       )}
 
       {/* WCAG 2.1 AA – Remove Confirmation Dialog */}
-      <Dialog open={!!walletToRemove} onOpenChange={(open) => !open && setWalletToRemove(null)}>
-        <DialogContent className="sm:max-w-[425px]">
+      <Dialog
+        open={!!walletToRemove}
+        onOpenChange={(nextOpen) => {
+          // Never dismiss while the removal request is in flight.
+          if (isRemoving) return;
+          if (!nextOpen) setWalletToRemove(null);
+        }}
+      >
+        <DialogContent
+          className="sm:max-w-[425px]"
+          showCloseButton={!isRemoving}
+        >
           <DialogHeader>
             <DialogTitle>Remove Connected Wallet</DialogTitle>
             <DialogDescription className="pt-2 text-sm">
@@ -195,11 +225,37 @@ export function WalletsSection({
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="mt-4 gap-2 sm:gap-0">
-            <Button type="button" variant="outline" onClick={() => setWalletToRemove(null)}>
+            {removeError && (
+              <p
+                role="alert"
+                aria-live="polite"
+                className="w-full text-xs font-medium text-destructive"
+              >
+                {removeError}. You can retry.
+              </p>
+            )}
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setWalletToRemove(null)}
+              disabled={isRemoving}
+            >
               Cancel
             </Button>
-            <Button type="button" variant="destructive" onClick={handleConfirmRemove}>
-              Remove Wallet
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleConfirmRemove}
+              disabled={isRemoving}
+            >
+              {isRemoving ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Removing...
+                </>
+              ) : (
+                "Remove Wallet"
+              )}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/transactions/layout.tsx
+++ b/app/transactions/layout.tsx
@@ -1,5 +1,6 @@
 import AppLayout from "@/components/common/app-layout";
 import { SidebarProvider } from "@/context/sidebar-context";
+import { ScopedErrorBoundary } from "@/components/common/scoped-error-boundary";
 import { Metadata } from "next";
 
 /**
@@ -56,7 +57,15 @@ export default function TransactionsLayout({
 }>) {
   return (
     <SidebarProvider>
-      <AppLayout>{children}</AppLayout>
+      <AppLayout>
+        <ScopedErrorBoundary
+          scope="transactions"
+          fallbackHref="/dashboard"
+          fallbackLabel="Back to dashboard"
+        >
+          {children}
+        </ScopedErrorBoundary>
+      </AppLayout>
     </SidebarProvider>
   );
 }

--- a/components/common/scoped-error-boundary.test.tsx
+++ b/components/common/scoped-error-boundary.test.tsx
@@ -1,0 +1,643 @@
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ScopedErrorBoundary,
+  deriveCorrelationToken,
+  redactSecretKey,
+} from "./scoped-error-boundary";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={typeof href === "string" ? href : "#"} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * A child component that renders normally. Replace with ThrowingChild below
+ * to simulate a render failure.
+ */
+function HealthyChild({ label = "healthy content" }: { label?: string }) {
+  return <div data-testid="healthy-child">{label}</div>;
+}
+
+/**
+ * Throws unconditionally in render to trip the error boundary.
+ */
+function ThrowingChild({ message = "boom" }: { message?: string }) {
+  throw new Error(message);
+}
+
+/**
+ * Controlled component: throws when `shouldThrow` is true.
+ */
+function ToggleChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error("controlled throw");
+  return <div data-testid="toggle-child">ok</div>;
+}
+
+/**
+ * Render a boundary wrapping a ThrowingChild and swallow the expected console
+ * errors so the test output stays clean.
+ */
+function renderWithError(
+  props: Partial<React.ComponentProps<typeof ScopedErrorBoundary>> & {
+    errorMessage?: string;
+  } = {},
+) {
+  const {
+    scope = "test-scope",
+    fallbackHref,
+    fallbackLabel,
+    resetKeys,
+    diagnosticId,
+    errorMessage = "boom",
+  } = props;
+
+  return render(
+    <ScopedErrorBoundary
+      scope={scope}
+      fallbackHref={fallbackHref}
+      fallbackLabel={fallbackLabel}
+      resetKeys={resetKeys}
+      diagnosticId={diagnosticId}
+    >
+      <ThrowingChild message={errorMessage} />
+    </ScopedErrorBoundary>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("ScopedErrorBoundary", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Suppress the expected React error-boundary noise so test output is clean.
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path — no error
+  // -------------------------------------------------------------------------
+
+  describe("when no error occurs", () => {
+    it("renders children normally", () => {
+      render(
+        <ScopedErrorBoundary scope="test">
+          <HealthyChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(screen.getByTestId("healthy-child")).toBeInTheDocument();
+    });
+
+    it("does not render the fallback UI", () => {
+      render(
+        <ScopedErrorBoundary scope="test">
+          <HealthyChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(
+        screen.queryByRole("alert"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state — fallback UI
+  // -------------------------------------------------------------------------
+
+  describe("when a render error is caught", () => {
+    it("shows an accessible alert region", () => {
+      renderWithError();
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("renders 'Something went wrong' heading inside the fallback", () => {
+      renderWithError();
+
+      expect(
+        screen.getByRole("heading", { name: /something went wrong/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders a 'Try again' button", () => {
+      renderWithError();
+
+      expect(
+        screen.getByRole("button", { name: /try again/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the fallback navigation link with the configured href", () => {
+      renderWithError({ fallbackHref: "/dashboard", fallbackLabel: "Back to dashboard" });
+
+      const link = screen.getByRole("link", { name: /back to dashboard/i });
+      expect(link).toHaveAttribute("href", "/dashboard");
+    });
+
+    it("uses default fallback href (/dashboard) and label when none supplied", () => {
+      renderWithError();
+
+      const link = screen.getByRole("link", { name: /go to dashboard/i });
+      expect(link).toHaveAttribute("href", "/dashboard");
+    });
+
+    it("does not render children in the error state", () => {
+      renderWithError();
+
+      expect(screen.queryByTestId("healthy-child")).not.toBeInTheDocument();
+    });
+
+    it("shows the correlation token in the fallback", () => {
+      renderWithError({ scope: "dashboard", errorMessage: "boom" });
+
+      const tokenEl = screen.getByTestId("scoped-error-correlation");
+      expect(tokenEl).toBeInTheDocument();
+      expect(tokenEl.textContent).toMatch(/Reference ID:/);
+      expect(tokenEl.textContent).toMatch(/dashboard-/);
+    });
+
+    it("uses the diagnosticId prop instead of the derived token when provided", () => {
+      renderWithError({ diagnosticId: "custom-id-abc" });
+
+      expect(
+        screen.getByTestId("scoped-error-correlation"),
+      ).toHaveTextContent("custom-id-abc");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Production vs development: dev-detail visibility
+  // -------------------------------------------------------------------------
+
+  describe("production / development detail visibility", () => {
+    it("does NOT render the error message in production", () => {
+      vi.stubEnv("NODE_ENV", "production");
+
+      renderWithError({ errorMessage: "secret-detail" });
+
+      expect(
+        screen.queryByTestId("scoped-error-dev-details"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("secret-detail")).not.toBeInTheDocument();
+    });
+
+    it("renders the error message in development", () => {
+      vi.stubEnv("NODE_ENV", "development");
+
+      renderWithError({ errorMessage: "local-dev-detail" });
+
+      expect(
+        screen.getByTestId("scoped-error-dev-details"),
+      ).toHaveTextContent("local-dev-detail");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // "Try again" reset
+  // -------------------------------------------------------------------------
+
+  describe('"Try again" button', () => {
+    it("clears the error state and re-renders children when clicked", async () => {
+      // We need a controllable child to flip to non-throwing after reset.
+      let shouldThrow = true;
+
+      function FlipChild() {
+        if (shouldThrow) throw new Error("initial error");
+        return <div data-testid="flipped-child">recovered</div>;
+      }
+
+      const { rerender } = render(
+        <ScopedErrorBoundary scope="test">
+          <FlipChild />
+        </ScopedErrorBoundary>,
+      );
+
+      // Fallback is shown.
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Stop throwing before the reset so the re-render succeeds.
+      shouldThrow = false;
+
+      fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+      await waitFor(() =>
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+      );
+      expect(screen.getByTestId("flipped-child")).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reset keys — automatic boundary clear on prop change
+  // -------------------------------------------------------------------------
+
+  describe("resetKeys", () => {
+    it("clears the error when a resetKey value changes", async () => {
+      const { rerender } = render(
+        <ScopedErrorBoundary scope="test" resetKeys={["account-A"]}>
+          <ThrowingChild />
+        </ScopedErrorBoundary>,
+      );
+
+      // Boundary has tripped.
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Simulate account switch: rerender with a healthy child and new resetKey.
+      rerender(
+        <ScopedErrorBoundary scope="test" resetKeys={["account-B"]}>
+          <HealthyChild />
+        </ScopedErrorBoundary>,
+      );
+
+      await waitFor(() =>
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+      );
+      expect(screen.getByTestId("healthy-child")).toBeInTheDocument();
+    });
+
+    it("does NOT clear the error when resetKeys values are unchanged", () => {
+      const { rerender } = render(
+        <ScopedErrorBoundary scope="test" resetKeys={["account-A"]}>
+          <ThrowingChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Same key value — boundary should stay in error state.
+      rerender(
+        <ScopedErrorBoundary scope="test" resetKeys={["account-A"]}>
+          <HealthyChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("handles a null resetKey in the array without throwing", () => {
+      const { rerender } = render(
+        <ScopedErrorBoundary scope="test" resetKeys={[null]}>
+          <ThrowingChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Changing null → a real address resets the boundary.
+      rerender(
+        <ScopedErrorBoundary
+          scope="test"
+          resetKeys={["GABC1234EFGH5678"]}
+        >
+          <HealthyChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("handles an empty resetKeys array without throwing", () => {
+      renderWithError({ resetKeys: [] });
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("handles resetKeys with multiple entries", async () => {
+      const { rerender } = render(
+        <ScopedErrorBoundary scope="test" resetKeys={["A", "page-1"]}>
+          <ThrowingChild />
+        </ScopedErrorBoundary>,
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Only the second key changes.
+      rerender(
+        <ScopedErrorBoundary scope="test" resetKeys={["A", "page-2"]}>
+          <HealthyChild />
+        </ScopedErrorBoundary>,
+      );
+
+      await waitFor(() =>
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error logging
+  // -------------------------------------------------------------------------
+
+  describe("error logging", () => {
+    it("logs scope and correlation token — never the raw error message", () => {
+      renderWithError({ scope: "dashboard", errorMessage: "raw-sensitive-message" });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[ScopedErrorBoundary] uncaught error in scope",
+        expect.objectContaining({
+          scope: "dashboard",
+          correlationToken: expect.stringMatching(/^dashboard-[0-9a-f]{8}$/),
+        }),
+      );
+
+      // The raw message must never appear in the log call arguments.
+      const calls = consoleErrorSpy.mock.calls;
+      const ourCall = calls.find(
+        (args) =>
+          typeof args[0] === "string" &&
+          args[0].includes("[ScopedErrorBoundary]"),
+      );
+      expect(ourCall).toBeDefined();
+      const serialised = JSON.stringify(ourCall);
+      expect(serialised).not.toContain("raw-sensitive-message");
+    });
+
+    it("uses the diagnosticId prop as the logged correlationToken", () => {
+      renderWithError({ scope: "test", diagnosticId: "override-id-xyz" });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[ScopedErrorBoundary] uncaught error in scope",
+        expect.objectContaining({
+          correlationToken: "override-id-xyz",
+        }),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Safe fallback navigation — no secret key in href
+  // -------------------------------------------------------------------------
+
+  describe("safe fallback navigation", () => {
+    it("renders the fallback link as a plain path with no query params", () => {
+      renderWithError({ fallbackHref: "/dashboard" });
+
+      const link = screen.getByRole("link", { name: /go to dashboard/i });
+      const href = link.getAttribute("href") ?? "";
+
+      // Must be a clean path — no ?, #, or raw key material injected.
+      expect(href).toBe("/dashboard");
+      expect(href).not.toContain("?");
+      expect(href).not.toContain("address");
+      expect(href).not.toContain("key");
+    });
+
+    it("respects a custom fallbackHref without leaking account state", () => {
+      renderWithError({
+        fallbackHref: "/account-summary",
+        fallbackLabel: "Back to account",
+      });
+
+      const link = screen.getByRole("link", { name: /back to account/i });
+      expect(link).toHaveAttribute("href", "/account-summary");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Accessibility
+  // -------------------------------------------------------------------------
+
+  describe("accessibility", () => {
+    it("uses role=alert on the fallback container", () => {
+      renderWithError();
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("uses aria-live=assertive on the fallback container", () => {
+      renderWithError();
+
+      expect(screen.getByRole("alert")).toHaveAttribute(
+        "aria-live",
+        "assertive",
+      );
+    });
+
+    it("renders the heading as an h2 inside the fallback", () => {
+      renderWithError();
+
+      const heading = screen.getByRole("heading", {
+        name: /something went wrong/i,
+        level: 2,
+      });
+      expect(heading).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scope isolation — boundary does not bleed into sibling trees
+  // -------------------------------------------------------------------------
+
+  describe("scope isolation", () => {
+    it("does not trip a sibling boundary when only one child throws", () => {
+      render(
+        <div>
+          <ScopedErrorBoundary scope="left">
+            <ThrowingChild />
+          </ScopedErrorBoundary>
+          <ScopedErrorBoundary scope="right">
+            <HealthyChild label="right sibling" />
+          </ScopedErrorBoundary>
+        </div>,
+      );
+
+      // Left boundary shows fallback.
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      // Right sibling still renders normally.
+      expect(screen.getByText("right sibling")).toBeInTheDocument();
+    });
+  });
+});
+
+  // -------------------------------------------------------------------------
+  // Offline behavior
+  // -------------------------------------------------------------------------
+
+  describe("offline behavior", () => {
+    let onlineSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      onlineSpy = vi.spyOn(navigator, "onLine", "get").mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      onlineSpy.mockRestore();
+    });
+
+    it("shows the fallback (not a blank screen) when a render error occurs while offline", () => {
+      // Simulate the browser being offline.
+      onlineSpy.mockReturnValue(false);
+
+      renderWithError({ errorMessage: "fetch failed" });
+
+      // The fallback must be visible — no blank screen.
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: /something went wrong/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("still shows Try again and navigation link when offline", () => {
+      onlineSpy.mockReturnValue(false);
+
+      renderWithError();
+
+      expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /go to dashboard/i })).toBeInTheDocument();
+    });
+
+    it("allows retry after coming back online — clears error when Try again is clicked and child no longer throws", async () => {
+      onlineSpy.mockReturnValue(false);
+
+      let shouldThrow = true;
+
+      function NetworkChild() {
+        if (shouldThrow) throw new Error("network failure");
+        return <div data-testid="network-child">online</div>;
+      }
+
+      render(
+        <ScopedErrorBoundary scope="test">
+          <NetworkChild />
+        </ScopedErrorBoundary>,
+      );
+
+      // Boundary is tripped while offline.
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Simulate coming back online and a successful re-render.
+      onlineSpy.mockReturnValue(true);
+      shouldThrow = false;
+
+      fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+      await waitFor(() =>
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+      );
+      expect(screen.getByTestId("network-child")).toBeInTheDocument();
+    });
+
+    it("does not expose navigator.onLine state in the rendered correlation token", () => {
+      onlineSpy.mockReturnValue(false);
+
+      renderWithError({ scope: "dashboard" });
+
+      const tokenEl = screen.getByTestId("scoped-error-correlation");
+      // Token must be the standard format — no "offline" string injected.
+      expect(tokenEl.textContent).toMatch(/dashboard-[0-9a-f]{8}/);
+      expect(tokenEl.textContent).not.toContain("offline");
+      expect(tokenEl.textContent).not.toContain("onLine");
+    });
+  });
+
+// ---------------------------------------------------------------------------
+// Unit tests for pure helper functions
+// ---------------------------------------------------------------------------
+
+describe("deriveCorrelationToken", () => {
+  it("returns a token with the scope prefix", () => {
+    const token = deriveCorrelationToken("dashboard", new Error("boom"));
+    expect(token).toMatch(/^dashboard-[0-9a-f]{8}$/);
+  });
+
+  it("is deterministic for the same scope and error message", () => {
+    const err = new Error("same-message");
+    expect(deriveCorrelationToken("test", err)).toBe(
+      deriveCorrelationToken("test", err),
+    );
+  });
+
+  it("produces different tokens for different error messages", () => {
+    const t1 = deriveCorrelationToken("test", new Error("alpha"));
+    const t2 = deriveCorrelationToken("test", new Error("beta"));
+    expect(t1).not.toBe(t2);
+  });
+
+  it("produces different tokens for different scopes", () => {
+    const err = new Error("same");
+    const t1 = deriveCorrelationToken("scopeA", err);
+    const t2 = deriveCorrelationToken("scopeB", err);
+    expect(t1).not.toBe(t2);
+  });
+
+  it("handles an error with no message without throwing", () => {
+    const err = new Error();
+    expect(() => deriveCorrelationToken("test", err)).not.toThrow();
+  });
+
+  it("does not include the raw error message in the returned token", () => {
+    const sensitiveMessage = "secret-detail-xyz";
+    const token = deriveCorrelationToken("test", new Error(sensitiveMessage));
+    expect(token).not.toContain(sensitiveMessage);
+  });
+});
+
+describe("redactSecretKey", () => {
+  it("redacts a valid Stellar secret key (S + 55 base32 chars)", () => {
+    // Valid Stellar secret key format: S followed by exactly 55 base32 chars
+    const secretKey = "S" + "A".repeat(55);
+    expect(redactSecretKey(secretKey)).toBe("[REDACTED_SECRET_KEY]");
+  });
+
+  it("does not redact a public G-address", () => {
+    const publicAddress = "GAAQEAYEAUDAOCAJBIFQYDIOB4IBCEQTCQKRMFYYDENBWHA5DYPSABOV";
+    expect(redactSecretKey(publicAddress)).toBe(publicAddress);
+  });
+
+  it("does not redact a plain string that is not a secret key", () => {
+    const plain = "some random string";
+    expect(redactSecretKey(plain)).toBe(plain);
+  });
+
+  it("does not redact an S-prefixed string that is too short", () => {
+    const short = "SABC";
+    expect(redactSecretKey(short)).toBe(short);
+  });
+
+  it("does not redact an S-prefixed string with lowercase chars", () => {
+    const mixed = "S" + "a".repeat(55);
+    // base32 is uppercase A-Z and 2-7 only; lowercase is not a valid secret key.
+    expect(redactSecretKey(mixed)).toBe(mixed);
+  });
+
+  it("handles an empty string without throwing", () => {
+    expect(() => redactSecretKey("")).not.toThrow();
+    expect(redactSecretKey("")).toBe("");
+  });
+});

--- a/components/common/scoped-error-boundary.tsx
+++ b/components/common/scoped-error-boundary.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+/**
+ * ScopedErrorBoundary
+ *
+ * A reusable React class component boundary that wraps individual route
+ * segments or feature areas. It differs from the route-level `app/error.tsx`
+ * in three ways:
+ *
+ *  1. **Reset keys** – the boundary resets automatically when any value in
+ *     `resetKeys` changes (e.g. the active account address or a route param).
+ *     This prevents a stale error state from persisting after the user switches
+ *     accounts or navigates to a different record.
+ *
+ *  2. **Safe fallback navigation** – the escape-hatch link is configurable via
+ *     `fallbackHref` and `fallbackLabel`. Neither the current address nor any
+ *     internal state is ever serialised into the link href.
+ *
+ *  3. **Redacted diagnostics** – a short, non-secret correlation identifier
+ *     (the first 8 hex chars of a SHA-1-style fingerprint derived from the
+ *     error message, not the raw address or key material) is shown in the
+ *     fallback UI so support teams can correlate reports without the UI ever
+ *     leaking sensitive state.
+ *
+ * Security invariants (see context/wallet-context.tsx):
+ *  - Stellar secret keys match /^S[A-Z2-7]+$/. They are *never* passed through
+ *    this component; the guard here is defense-in-depth only.
+ *  - Public G-addresses are safe to show truncated (GABC...F123 form) but this
+ *    component deliberately avoids rendering any address — the boundary fires
+ *    when the component using the address failed, so the address state may be
+ *    corrupt. The truncated form is only used by `formatAddress` in
+ *    wallet-context.tsx; we replicate that shape for the reset-key derivation
+ *    so callers do not need to truncate themselves.
+ *
+ * Usage:
+ * ```tsx
+ * <ScopedErrorBoundary
+ *   scope="dashboard"
+ *   resetKeys={[address]}
+ *   fallbackHref="/dashboard"
+ *   fallbackLabel="Back to dashboard"
+ * >
+ *   <DashboardContent />
+ * </ScopedErrorBoundary>
+ * ```
+ */
+
+import React from "react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+// ---------------------------------------------------------------------------
+// Diagnostic ID helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Produces a short, deterministic, human-readable correlation token from an
+ * error. The token is safe to log and display:
+ *
+ * - It is derived from the error message only (not the stack, not any
+ *   address or key material).
+ * - It does NOT use a cryptographic hash; the goal is a stable short tag for
+ *   correlating support tickets, not security.
+ * - The format is `<scope>-<8 char base-36 token>`, e.g. `dashboard-3f2a1b9c`.
+ *
+ * Callers that have a server-side digest (Next.js `error.digest`) should pass
+ * that directly via `diagnosticId` instead of relying on this derivation.
+ */
+export function deriveCorrelationToken(scope: string, error: Error): string {
+  const raw = error?.message ?? "unknown";
+
+  // Simple deterministic fold — not crypto, just a stable fingerprint.
+  let h = 0x811c_9dc5; // FNV-1a offset basis (32-bit)
+  for (let i = 0; i < raw.length; i++) {
+    h ^= raw.charCodeAt(i);
+    // 32-bit FNV prime multiply, keeping it in a 32-bit integer via >>> 0
+    h = Math.imul(h, 0x0100_0193) >>> 0;
+  }
+  const token = h.toString(16).padStart(8, "0");
+  return `${scope}-${token}`;
+}
+
+/**
+ * Redacts any string that looks like a Stellar secret key before it could
+ * accidentally be included in a diagnostic payload.
+ *
+ * A Stellar secret key is the letter S followed by 55 base32 characters
+ * (A-Z and 2-7). This guard mirrors the one in WalletProvider.connect().
+ */
+export function redactSecretKey(value: string): string {
+  return /^S[A-Z2-7]{55}$/.test(value.trim())
+    ? "[REDACTED_SECRET_KEY]"
+    : value;
+}
+
+// ---------------------------------------------------------------------------
+// Component types
+// ---------------------------------------------------------------------------
+
+export interface ScopedErrorBoundaryProps {
+  /** Semantic name for the boundary — used in the correlation token and logs. */
+  scope: string;
+
+  /**
+   * Values that, when changed, cause the boundary to clear the error and
+   * re-render its children. Typical candidates: the connected wallet address,
+   * a route param ID, or a page number.
+   *
+   * The boundary uses referential equality for comparison so primitive values
+   * (strings, numbers) work best. Pass a stable array reference if you want
+   * to avoid spurious resets.
+   */
+  resetKeys?: ReadonlyArray<string | number | null | undefined>;
+
+  /**
+   * URL the fallback's escape-hatch button links to. Defaults to `/dashboard`.
+   * Must not contain raw address or key material — callers are responsible for
+   * ensuring this is a static route path.
+   */
+  fallbackHref?: string;
+
+  /** Human-readable label for the fallback navigation link. */
+  fallbackLabel?: string;
+
+  /** Override the auto-derived correlation token, e.g. with `error.digest`. */
+  diagnosticId?: string;
+
+  /** Subtree to protect. */
+  children: React.ReactNode;
+}
+
+interface ScopedErrorBoundaryState {
+  /** Set to the caught error when the boundary trips; null when healthy. */
+  error: Error | null;
+
+  /**
+   * Snapshot of `resetKeys` taken when the boundary caught an error. Used to
+   * detect when resetKeys changes so we can clear the error state.
+   */
+  prevResetKeys: ReadonlyArray<string | number | null | undefined> | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// ScopedErrorBoundary class component
+// ---------------------------------------------------------------------------
+
+export class ScopedErrorBoundary extends React.Component<
+  ScopedErrorBoundaryProps,
+  ScopedErrorBoundaryState
+> {
+  static readonly defaultProps: Partial<ScopedErrorBoundaryProps> = {
+    fallbackHref: "/dashboard",
+    fallbackLabel: "Go to dashboard",
+    resetKeys: [],
+  };
+
+  constructor(props: ScopedErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null, prevResetKeys: props.resetKeys };
+  }
+
+  // -------------------------------------------------------------------------
+  // Static lifecycle: error capture
+  // -------------------------------------------------------------------------
+
+  static getDerivedStateFromError(
+    error: Error,
+  ): Partial<ScopedErrorBoundaryState> {
+    return { error };
+  }
+
+  // -------------------------------------------------------------------------
+  // Static lifecycle: reset key diffing
+  // -------------------------------------------------------------------------
+
+  static getDerivedStateFromProps(
+    props: ScopedErrorBoundaryProps,
+    state: ScopedErrorBoundaryState,
+  ): Partial<ScopedErrorBoundaryState> | null {
+    if (state.error === null) return null;
+
+    // If any resetKey value has changed, clear the error to re-render children.
+    const prev = state.prevResetKeys ?? [];
+    const next = props.resetKeys ?? [];
+
+    const changed =
+      prev.length !== next.length ||
+      prev.some((val, idx) => val !== next[idx]);
+
+    if (changed) {
+      return { error: null, prevResetKeys: next };
+    }
+
+    return null;
+  }
+
+  // -------------------------------------------------------------------------
+  // Instance lifecycle: error logging
+  // -------------------------------------------------------------------------
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    const { scope, diagnosticId } = this.props;
+    const correlationToken =
+      diagnosticId ?? deriveCorrelationToken(scope, error);
+
+    // Log scope and correlation token only — never the raw message, stack,
+    // or any address/key material.
+    console.error("[ScopedErrorBoundary] uncaught error in scope", {
+      scope,
+      correlationToken,
+      componentStack: info.componentStack
+        ? info.componentStack.slice(0, 300)
+        : undefined,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Reset handler
+  // -------------------------------------------------------------------------
+
+  private handleReset = (): void => {
+    this.setState({ error: null, prevResetKeys: this.props.resetKeys });
+  };
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  render(): React.ReactNode {
+    const { error } = this.state;
+
+    if (error === null) {
+      return this.props.children;
+    }
+
+    const {
+      scope,
+      diagnosticId,
+      fallbackHref = "/dashboard",
+      fallbackLabel = "Go to dashboard",
+    } = this.props;
+
+    const correlationToken =
+      diagnosticId ?? deriveCorrelationToken(scope, error);
+
+    const showDevDetails =
+      typeof process !== "undefined" &&
+      process.env.NODE_ENV !== "production" &&
+      Boolean(error?.message);
+
+    return (
+      <div
+        role="alert"
+        aria-live="assertive"
+        className="flex flex-col items-center justify-center min-h-[320px] w-full px-6 py-12 text-center"
+      >
+        <div className="w-full max-w-sm space-y-5">
+          <h2 className="text-xl font-semibold text-destructive">
+            Something went wrong
+          </h2>
+
+          <p className="text-sm text-muted-foreground">
+            This section encountered an unexpected error. You can try again or
+            navigate away.
+          </p>
+
+          {showDevDetails ? (
+            <pre
+              data-testid="scoped-error-dev-details"
+              className="text-left text-xs text-muted-foreground bg-muted/40 p-3 rounded-md overflow-auto"
+            >
+              {error.message}
+            </pre>
+          ) : null}
+
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="scoped-error-correlation"
+          >
+            Reference ID:{" "}
+            <span className="font-mono">{correlationToken}</span>
+          </p>
+
+          <div className="flex items-center justify-center gap-3">
+            <Button onClick={this.handleReset}>Try again</Button>
+            <Button variant="outline" asChild>
+              <Link href={fallbackHref}>{fallbackLabel}</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/components/dashboard/transaction-header.tsx
+++ b/components/dashboard/transaction-header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { Date } from "../transactions/date";
 import { ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
 import type { SortField, SortDirection } from "@/types/transaction";
@@ -32,8 +33,23 @@ export default function TransactionHeader({
   sortDirection,
   onSort,
 }: TransactionHeaderProps) {
+  const liveRegionRef = useRef<HTMLParagraphElement>(null);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    if (liveRegionRef.current && sortField && onSort) {
+      const direction = sortDirection === "asc" ? "ascending" : "descending";
+      liveRegionRef.current.textContent = `Sorted by ${sortField} ${direction}`;
+    }
+  }, [sortField, sortDirection, onSort]);
+
   return (
     <div className="w-full px-4 md:px-6 pt-4 border-b border-[#1A1A1A]">
+      <p ref={liveRegionRef} role="status" aria-live="polite" className="sr-only" />
       <div className="max-w-screen-xl mx-auto flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <h1 className="text-white text-2xl font-semibold pl-4">{pageTitle}</h1>
         <div className="flex items-center justify-between gap-4">
@@ -59,6 +75,13 @@ export default function TransactionHeader({
               <button
                 key={col.key}
                 onClick={() => onSort(col.key)}
+                aria-sort={
+                  isActive
+                    ? isAsc
+                      ? "ascending"
+                      : "descending"
+                    : "none"
+                }
                 className={`flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider transition-colors ${
                   isActive
                     ? "text-white"
@@ -68,12 +91,12 @@ export default function TransactionHeader({
                 {col.label}
                 {isActive ? (
                   isAsc ? (
-                    <ArrowUp className="w-3.5 h-3.5" />
+                    <ArrowUp className="w-3.5 h-3.5" aria-hidden="true" />
                   ) : (
-                    <ArrowDown className="w-3.5 h-3.5" />
+                    <ArrowDown className="w-3.5 h-3.5" aria-hidden="true" />
                   )
                 ) : (
-                  <ArrowUpDown className="w-3.5 h-3.5 text-zinc-600" />
+                  <ArrowUpDown className="w-3.5 h-3.5 text-zinc-600" aria-hidden="true" />
                 )}
               </button>
             );

--- a/components/dashboard/transaction-history.tsx
+++ b/components/dashboard/transaction-history.tsx
@@ -24,9 +24,53 @@ interface TransactionRowProps {
     status: string;
     statusColor: "success" | "warning" | "destructive";
   };
+  onRetry?: () => void;
 }
 
-const TransactionRow: React.FC<TransactionRowProps> = ({ transaction }) => {
+const isCurrentStatus = (status: string) =>
+  /pending|processing|confirming/i.test(status);
+
+const isCompletedStatus = (status: string) =>
+  /success|completed|complete/i.test(status);
+
+const isRetryStatus = (status: string) => /retry/i.test(status);
+
+const isFailureStatus = (status: string) =>
+  /fail|reject|timeout|timed out|error|cancel|retry/i.test(status);
+
+const getStatusLabel = (status: string) => {
+  if (isCurrentStatus(status)) return `Current step: ${status}`;
+  if (isCompletedStatus(status)) return `Completed: ${status}`;
+  if (isRetryStatus(status)) return `Action needed: ${status}`;
+  if (isFailureStatus(status)) return `Failed: ${status}`;
+  return `Status: ${status}`;
+};
+
+const getStatusState = (status: string) => {
+  if (isCurrentStatus(status)) return "current";
+  if (isCompletedStatus(status)) return "completed";
+  if (isRetryStatus(status)) return "retry";
+  return "failed";
+};
+
+const getStatusAnnouncement = (
+  transaction: TransactionRowProps["transaction"],
+) => {
+  const status = transaction.status;
+  if (isCurrentStatus(status)) return `${transaction.type} ${transaction.txId} pending`;
+  if (isCompletedStatus(status)) return `${transaction.type} ${transaction.txId} completed`;
+  if (isRetryStatus(status)) return `${transaction.type} ${transaction.txId} retry`;
+  if (status.toLowerCase().includes("reject"))
+    return `${transaction.type} ${transaction.txId} rejected`;
+  if (status.toLowerCase().includes("timeout"))
+    return `${transaction.type} ${transaction.txId} timed out`;
+  return `${transaction.type} ${transaction.txId} ${status}`;
+};
+
+const TransactionRow: React.FC<TransactionRowProps> = ({
+  transaction,
+  onRetry,
+}) => {
   const statusColorMap = {
     success:
       "bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
@@ -82,11 +126,33 @@ const TransactionRow: React.FC<TransactionRowProps> = ({ transaction }) => {
         </span>
       </td>
       <td className="py-4 px-4 whitespace-nowrap">
-        <span
-          className={`inline-flex items-center px-2.5 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider ${statusColorMap[transaction.statusColor]}`}
-        >
-          {transaction.status}
-        </span>
+        <div className="flex items-center gap-2">
+          <span
+            className={`inline-flex items-center px-2.5 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider ${statusColorMap[transaction.statusColor]}`}
+            aria-label={getStatusLabel(transaction.status)}
+            aria-current={isCurrentStatus(transaction.status) ? "step" : undefined}
+            data-state={getStatusState(transaction.status)}
+          >
+            {transaction.status}
+          </span>
+          {isFailureStatus(transaction.status) && (
+            <button
+              type="button"
+              onClick={onRetry}
+              aria-label={`Retry ${transaction.type} ${transaction.txId}`}
+              className="text-[10px] font-bold text-blue-600 dark:text-blue-400 underline underline-offset-2 rounded hover:text-blue-700 dark:hover:text-blue-300"
+            >
+              Retry
+            </button>
+          )}
+          <a
+            href={`/transactions/${transaction.id}`}
+            aria-label={`View details for ${transaction.type} ${transaction.txId}`}
+            className="text-[10px] font-bold text-zinc-400 dark:text-zinc-500 underline underline-offset-2 rounded hover:text-zinc-600 dark:hover:text-zinc-300"
+          >
+            Details
+          </a>
+        </div>
       </td>
     </tr>
   );
@@ -95,19 +161,46 @@ const TransactionRow: React.FC<TransactionRowProps> = ({ transaction }) => {
 const TransactionHistory: React.FC = () => {
   const { data, isLoading, error, refetch } = useTransactions();
   const wasLoadingRef = useRef(true);
+  const previousCountRef = useRef<number | null>(null);
+  const previousStatusesRef = useRef<Record<string, string>>({});
   const [announcement, setAnnouncement] = useState("");
 
   useEffect(() => {
     if (wasLoadingRef.current && !isLoading && data) {
       const count = data.data.length;
-      setAnnouncement(
-        count === 0
-          ? "No transactions loaded"
-          : `${count} transaction${count === 1 ? "" : "s"} loaded`,
-      );
+      if (
+        previousCountRef.current === null ||
+        previousCountRef.current !== count
+      ) {
+        setAnnouncement(
+          count === 0
+            ? "No transactions loaded"
+            : `${count} transaction${count === 1 ? "" : "s"} loaded`,
+        );
+      }
+      previousCountRef.current = count;
     }
     wasLoadingRef.current = isLoading;
   }, [isLoading, data]);
+
+  useEffect(() => {
+    if (!data) return;
+    const currentStatuses: Record<string, string> = {};
+    const announcements: string[] = [];
+
+    for (const transaction of data.data) {
+      currentStatuses[transaction.id] = transaction.status;
+      const previousStatus = previousStatusesRef.current[transaction.id];
+      if (previousStatus && previousStatus !== transaction.status) {
+        announcements.push(getStatusAnnouncement(transaction));
+      }
+    }
+
+    if (announcements.length > 0) {
+      setAnnouncement(announcements.join(". "));
+    }
+    previousStatusesRef.current = currentStatuses;
+  }, [data]);
 
   if (isLoading) {
     return (
@@ -213,10 +306,12 @@ const TransactionHistory: React.FC = () => {
               Transaction History
             </h2>
           </div>
-          <a href="/">
-            <button className="h-10 px-4 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 text-zinc-700 dark:text-zinc-300 text-sm font-medium hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors flex items-center gap-2">
-              View All
-            </button>
+          <a
+            href="/"
+            aria-label="View all transactions"
+            className="h-10 px-4 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 text-zinc-700 dark:text-zinc-300 text-sm font-medium hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors inline-flex items-center gap-2"
+          >
+            View All
           </a>
         </div>
 
@@ -249,6 +344,7 @@ const TransactionHistory: React.FC = () => {
                 <TransactionRow
                   key={transaction.id}
                   transaction={transaction}
+                  onRetry={() => refetch()}
                 />
               ))}
             </tbody>

--- a/components/help-support/ticket-status-widget.tsx
+++ b/components/help-support/ticket-status-widget.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import { SupportTicket, SupportTicketStatus } from "@/types/support";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -39,6 +40,30 @@ interface TicketStatusWidgetProps {
   isLoading?: boolean;
 }
 
+const STATUS_STEPS: Array<{ value: SupportTicketStatus; label: string }> = [
+  { value: "open", label: "Open" },
+  { value: "in-progress", label: "In Progress" },
+  { value: "resolved", label: "Resolved" },
+];
+
+function getStepState(
+  step: SupportTicketStatus,
+  currentStatus: SupportTicketStatus,
+): "current" | "completed" | "upcoming" {
+  if (currentStatus === "resolved") return "completed";
+
+  const currentIndex = STATUS_STEPS.findIndex(
+    (statusStep) => statusStep.value === currentStatus,
+  );
+  const stepIndex = STATUS_STEPS.findIndex(
+    (statusStep) => statusStep.value === step,
+  );
+
+  if (stepIndex === currentIndex) return "current";
+  if (stepIndex < currentIndex) return "completed";
+  return "upcoming";
+}
+
 /**
  * Formats a timestamp to a human-readable relative time string.
  *
@@ -65,6 +90,26 @@ function formatRelativeTime(dateString: string): string {
   return `${months} month${months > 1 ? "s" : ""} ago`;
 }
 
+function StatusLiveRegion({ ticket }: { ticket: SupportTicket }) {
+  const previousStatus = useRef(ticket.status);
+  const [announcement, setAnnouncement] = useState("");
+
+  useEffect(() => {
+    if (previousStatus.current !== ticket.status) {
+      setAnnouncement(
+        `Ticket ${ticket.id} status changed to ${ticket.status.replace("-", " ")}`,
+      );
+      previousStatus.current = ticket.status;
+    }
+  }, [ticket.id, ticket.status]);
+
+  return (
+    <span role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+      {announcement}
+    </span>
+  );
+}
+
 /**
  * Renders a single support ticket row with status badge, category, and timestamps.
  * Accessible via keyboard and screen readers.
@@ -74,10 +119,34 @@ function TicketRow({ ticket }: { ticket: SupportTicket }) {
   const statusStyle = STATUS_STYLES[ticket.status];
 
   return (
-    <div
+    <li
       className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4 p-4 rounded-lg border border-zinc-200 bg-white/50 hover:bg-white/70 transition-colors dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
-      role="listitem"
     >
+      {/* Screen reader status timeline */}
+      <ol
+        className="sr-only"
+        aria-label={`Status timeline for ticket ${ticket.id}`}
+      >
+        {STATUS_STEPS.map((step) => {
+          const state = getStepState(step.value, ticket.status);
+          return (
+            <li
+              key={step.value}
+              data-state={state}
+              aria-current={state === "current" ? "step" : undefined}
+            >
+              <span className="sr-only">
+                {state === "current"
+                  ? "Current step: "
+                  : state === "completed"
+                    ? "Completed step: "
+                    : "Upcoming step: "}
+              </span>
+              {step.label}
+            </li>
+          );
+        })}
+      </ol>
       {/* Left side: Ticket info */}
       <div className="flex-1 min-w-0">
         <div className="flex items-start gap-3">
@@ -109,6 +178,8 @@ function TicketRow({ ticket }: { ticket: SupportTicket }) {
             "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium whitespace-nowrap",
             statusStyle,
           )}
+          data-state={ticket.status === "resolved" ? "completed" : "current"}
+          aria-current={ticket.status === "resolved" ? undefined : "step"}
           aria-label={`Status: ${ticket.status.replace("-", " ")}`}
         >
           <StatusIcon className="h-3 w-3" />
@@ -123,7 +194,8 @@ function TicketRow({ ticket }: { ticket: SupportTicket }) {
           </time>
         </div>
       </div>
-    </div>
+      <StatusLiveRegion ticket={ticket} />
+    </li>
   );
 }
 
@@ -215,15 +287,14 @@ export default function TicketStatusWidget({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <div
+        <ul
           className="space-y-3"
-          role="list"
           aria-label="Support tickets list"
         >
           {tickets.map((ticket) => (
             <TicketRow key={ticket.id} ticket={ticket} />
           ))}
-        </div>
+        </ul>
 
         {/* Legend for status badges */}
         <div className="mt-6 pt-4 border-t border-zinc-200 dark:border-white/10">

--- a/components/transactions/transactions-content.test.tsx
+++ b/components/transactions/transactions-content.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, within, act } from "@testing-library/react";
+import { render, screen, within, act, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {
@@ -16,6 +16,16 @@ const navigationMock = vi.hoisted(() => ({
   },
   pathname: "/transactions",
   searchParams: new URLSearchParams(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => navigationMock.router,
+  usePathname: () => navigationMock.pathname,
+  useSearchParams: () => navigationMock.searchParams,
+}));
+
+vi.mock("@/hooks/useTransactions", () => ({
+  useTransactions: vi.fn(),
 }));
 
 // next/image is not available in jsdom — swap it for a plain <img>.
@@ -319,7 +329,7 @@ describe("TransactionsContent states", () => {
   it("renders empty state table when fetch succeeds but returns empty array", () => {
     mockTransactionsSuccess();
 
-    render(<TransactionsContent />);
+    renderTransactionsContent();
 
     // No error state
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
@@ -337,7 +347,7 @@ describe("TransactionsContent states", () => {
     );
     mockTransactionsSuccess(42);
 
-    render(<TransactionsContent />);
+    renderTransactionsContent();
 
     const firstHookOptions = vi.mocked(useTransactions).mock.calls[0][0];
 
@@ -360,7 +370,7 @@ describe("TransactionsContent states", () => {
     navigationMock.searchParams = new URLSearchParams("page=4");
     mockTransactionsSuccess(42);
 
-    render(<TransactionsContent />);
+    renderTransactionsContent();
     navigationMock.router.replace.mockClear();
 
     fireEvent.change(screen.getByLabelText("Search transactions"), {
@@ -379,7 +389,7 @@ describe("TransactionsContent states", () => {
     navigationMock.searchParams = new URLSearchParams("q=USDC");
     mockTransactionsSuccess(42);
 
-    render(<TransactionsContent />);
+    renderTransactionsContent();
     navigationMock.router.replace.mockClear();
 
     fireEvent.click(screen.getByRole("button", { name: "Page 2" }));

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -112,6 +112,20 @@ function persistSavedViews(address: string | null, views: SavedView[]): void {
   safeStorage.setItem(getSavedViewsKey(address), JSON.stringify(views));
 }
 
+const TRANSACTION_STATUS_LABELS: Record<string, TransactionProps["status"]> = {
+  completed: "Completed",
+  success: "Completed",
+  pending: "Pending",
+  retry: "Pending",
+  rejection: "Failed",
+  timeout: "Failed",
+  failed: "Failed",
+};
+
+function getTransactionStatusLabel(status: string): TransactionProps["status"] {
+  return TRANSACTION_STATUS_LABELS[status.toLowerCase()] ?? "Pending";
+}
+
 /** Convert internal Transaction → display TransactionProps */
 const toTransactionProps = (
   t: Transaction,
@@ -128,11 +142,111 @@ const toTransactionProps = (
     t.amount >= 0
       ? `+$${t.amount.toFixed(2)}`
       : `-$${Math.abs(t.amount).toFixed(2)}`,
-  status: t.status as "Completed" | "Pending" | "Failed",
+  status: getTransactionStatusLabel(t.status),
   tokenIcon: getTokenIcon(t.token),
   memo: t.memo,
   tags: getTagNames(t.id),
 });
+function getTransactionTimelineSteps(status: string) {
+  switch (status) {
+    case "success":
+    case "completed":
+      return [
+        { label: "Submitted", state: "completed" },
+        { label: "Processed", state: "completed" },
+        { label: "Completed", state: "completed" },
+      ];
+    case "rejection":
+      return [
+        { label: "Submitted", state: "completed" },
+        { label: "Processing", state: "failed" },
+        { label: "Rejected", state: "failed" },
+      ];
+    case "timeout":
+      return [
+        { label: "Submitted", state: "completed" },
+        { label: "Processing", state: "failed" },
+        { label: "Timed out", state: "failed" },
+      ];
+    case "retry":
+      return [
+        { label: "Submitted", state: "completed" },
+        { label: "Processing", state: "current" },
+        { label: "Completed", state: "upcoming" },
+      ];
+    case "pending":
+    default:
+      return [
+        { label: "Submitted", state: "completed" },
+        { label: "Processing", state: "current" },
+        { label: "Completed", state: "upcoming" },
+      ];
+  }
+}
+
+export function TransactionStatusTimeline({
+  status,
+  failureReason,
+  onRetry,
+  onDetails,
+}: {
+  status: string;
+  failureReason?: string;
+  onRetry?: () => void;
+  onDetails?: () => void;
+}) {
+  const [liveMessage, setLiveMessage] = useState("");
+  const prevStatusRef = useRef(status);
+
+  useEffect(() => {
+    if (prevStatusRef.current === status) return;
+    prevStatusRef.current = status;
+    const statusLabel = status.charAt(0).toUpperCase() + status.slice(1);
+    setLiveMessage(`Transaction status changed to ${statusLabel}.`);
+  }, [status]);
+
+  const steps = getTransactionTimelineSteps(status);
+  const isFailed = status === "rejection" || status === "timeout" || status === "failed";
+
+  return (
+    <div className="transaction-status-timeline">
+      <div role="status" aria-live="polite" className="sr-only">
+        {liveMessage}
+      </div>
+      <ol aria-label="Transaction status">
+        {steps.map((step) => (
+          <li
+            key={step.label}
+            data-state={step.state}
+            aria-current={step.state === "current" || step.state === "failed" ? "step" : undefined}
+            aria-label={`${step.label}, ${step.state}`}
+          >
+            <span className="sr-only">{step.state}.</span>
+            {step.label}
+          </li>
+        ))}
+      </ol>
+      {isFailed && failureReason ? (
+        <p role="alert">{failureReason}</p>
+      ) : null}
+      {(onRetry || onDetails) ? (
+        <div className="transaction-status-actions">
+          {onRetry ? (
+            <button type="button" onClick={onRetry}>
+              Retry
+            </button>
+          ) : null}
+          {onDetails ? (
+            <button type="button" onClick={onDetails}>
+              Details
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 
 export default function TransactionsContent() {
   const router = useRouter();

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -29,6 +29,7 @@ import {
   generateTransactionsCsv,
   downloadCsvContent,
 } from "@/utils/csvUtils";
+import { dedupeTransactionsById } from "@/utils/transactionUtils";
 import {
   TRANSACTIONS_PAGE_SIZE,
   getDefaultDateRange,
@@ -516,8 +517,10 @@ export default function TransactionsContent() {
   }, [data, isLoading, error]);
 
   const paginatedTransactions: TransactionProps[] = useMemo(() => {
-    const transactions = (data?.data ?? []).map((t) =>
-      toTransactionProps(t, getTagNamesForTransaction),
+    const transactions = dedupeTransactionsById(
+      (data?.data ?? []).map((t) =>
+        toTransactionProps(t, getTagNamesForTransaction),
+      ),
     );
     if (tagFilter) {
       return transactions.filter((t) => t.tags?.includes(tagFilter));

--- a/components/transactions/transactions-content.tsx
+++ b/components/transactions/transactions-content.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { FileText } from "lucide-react";
 import type {
   SortField,
   SortConfig,
-  SortDirection,
   TransactionFilters,
   Transaction,
   TransactionProps,
   SavedView,
 } from "@/types/transaction";
 import { useTransactions } from "@/hooks/useTransactions";
+import { useTransactionTags } from "@/hooks/useTransactionTags";
 import { getTransactions, MAX_TRANSACTION_PAGE_SIZE } from "@/lib/api";
 import { TransactionTableSkeleton } from "@/components/ui/table-skeleton";
 import TransactionsHeader from "./transactions-header";
@@ -23,243 +25,39 @@ import { ErrorState } from "@/components/ui/error-state";
 import AdvancedFilterPanel, {
   type AdvancedFilterValues,
 } from "./advanced-filter-panel";
-import FilterChips, { type FilterChip } from "./filter-chips";
 import CsvExportToolbar from "./transactions-export-toolbar";
 import {
   generateTransactionsCsv,
   downloadCsvContent,
 } from "@/utils/csvUtils";
-import {
-  TRANSACTIONS_PAGE_SIZE,
-  getDefaultDateRange,
-} from "./transactions-config";
+import { TRANSACTIONS_PAGE_SIZE } from "./transactions-config";
 import { safeStorage } from "@/utils/safeStorage";
 import { useWallet } from "@/context/wallet-context";
 
-const DEFAULT_SELECTED_FILTER = "All Transactions";
-const DEFAULT_SORT_CONFIGS: readonly SortConfig[] = [
-  { field: "date", direction: "desc" },
-];
+import {
+  TRANSACTIONS_QUERY_KEYS,
+  type TransactionsUrlState,
+  cloneSortConfigs,
+  createDefaultTransactionFilters,
+  parseSortConfigs,
+  serializeSortConfigs,
+  parseTransactionsUrlState,
+  buildTransactionsQueryString,
+  buildShareableTransactionsQueryString,
+  buildShareableTransactionsUrl,
+} from "./transactions-url-state";
 
-const FILTER_QUERY_VALUE_TO_LABEL: Readonly<Record<string, string>> = {
-  all: DEFAULT_SELECTED_FILTER,
-  sent: "Payment Sent",
-  received: "Payment Received",
+export {
+  TRANSACTIONS_QUERY_KEYS,
+  type TransactionsUrlState,
+  createDefaultTransactionFilters,
+  parseSortConfigs,
+  serializeSortConfigs,
+  parseTransactionsUrlState,
+  buildTransactionsQueryString,
+  buildShareableTransactionsQueryString,
+  buildShareableTransactionsUrl,
 };
-
-const FILTER_LABEL_TO_QUERY_VALUE: Readonly<Record<string, string>> = {
-  [DEFAULT_SELECTED_FILTER]: "all",
-  "Payment Sent": "sent",
-  "Payment Received": "received",
-};
-
-const SORT_FIELDS = [
-  "date",
-  "amount",
-  "type",
-  "status",
-] as const satisfies readonly SortField[];
-const SORT_DIRECTIONS = [
-  "asc",
-  "desc",
-] as const satisfies readonly SortDirection[];
-const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
-
-export const TRANSACTIONS_QUERY_KEYS = {
-  search: "q",
-  filter: "filter",
-  fromDate: "from",
-  toDate: "to",
-  sort: "sort",
-  page: "page",
-} as const;
-
-type SearchParamsLike = Pick<URLSearchParams, "get" | "toString">;
-
-export interface TransactionsUrlState {
-  filters: TransactionFilters;
-  page: number;
-}
-
-function cloneSortConfigs(configs: readonly SortConfig[]): SortConfig[] {
-  return configs.map(({ field, direction }) => ({ field, direction }));
-}
-
-export function createDefaultTransactionFilters(): TransactionFilters {
-  return {
-    searchQuery: "",
-    filterQuery: "",
-    ...getDefaultDateRange(),
-    selectedFilter: DEFAULT_SELECTED_FILTER,
-    sortConfigs: cloneSortConfigs(DEFAULT_SORT_CONFIGS),
-  };
-}
-
-function isValidIsoDate(value: string | null): value is string {
-  if (!value || !ISO_DATE_PATTERN.test(value)) return false;
-
-  const parsedDate = new Date(`${value}T00:00:00.000Z`);
-  return (
-    !Number.isNaN(parsedDate.getTime()) &&
-    parsedDate.toISOString().slice(0, 10) === value
-  );
-}
-
-function isSortField(value: string): value is SortField {
-  return (SORT_FIELDS as readonly string[]).includes(value);
-}
-
-function isSortDirection(value: string): value is SortDirection {
-  return (SORT_DIRECTIONS as readonly string[]).includes(value);
-}
-
-function parsePage(value: string | null): number {
-  if (!value) return 1;
-  const numericValue = Number(value);
-  return Number.isInteger(numericValue) && numericValue > 0 ? numericValue : 1;
-}
-
-function parseSelectedFilter(value: string | null): string {
-  if (!value) return DEFAULT_SELECTED_FILTER;
-
-  const normalizedValue = value.trim().toLowerCase();
-  if (normalizedValue in FILTER_QUERY_VALUE_TO_LABEL) {
-    return FILTER_QUERY_VALUE_TO_LABEL[normalizedValue];
-  }
-
-  const matchingLabel = Object.values(FILTER_QUERY_VALUE_TO_LABEL).find(
-    (label) => label.toLowerCase() === normalizedValue,
-  );
-
-  return matchingLabel ?? DEFAULT_SELECTED_FILTER;
-}
-
-function serializeSelectedFilter(label: string): string {
-  return FILTER_LABEL_TO_QUERY_VALUE[label] ?? "all";
-}
-
-export function parseSortConfigs(value: string | null): SortConfig[] {
-  if (!value) return cloneSortConfigs(DEFAULT_SORT_CONFIGS);
-
-  const seenFields = new Set<SortField>();
-  const sortConfigs: SortConfig[] = [];
-
-  for (const rawToken of value.split(",")) {
-    if (sortConfigs.length >= 2) break;
-
-    const token = rawToken.trim();
-    if (!token) continue;
-
-    // Support both `date.desc` and `date:desc` for hand-written links while
-    // always writing the compact dot format back into the address bar.
-    const [field, direction] = token.split(/[.:]/);
-    if (!field || !direction) continue;
-    if (!isSortField(field) || !isSortDirection(direction)) continue;
-    if (seenFields.has(field)) continue;
-
-    seenFields.add(field);
-    sortConfigs.push({ field, direction });
-  }
-
-  return sortConfigs.length > 0
-    ? sortConfigs
-    : cloneSortConfigs(DEFAULT_SORT_CONFIGS);
-}
-
-export function serializeSortConfigs(configs: readonly SortConfig[]): string {
-  const seenFields = new Set<SortField>();
-  const safeConfigs = configs.filter(({ field, direction }) => {
-    if (!isSortField(field) || !isSortDirection(direction)) return false;
-    if (seenFields.has(field)) return false;
-    seenFields.add(field);
-    return true;
-  });
-
-  const configsToSerialize =
-    safeConfigs.length > 0
-      ? safeConfigs
-      : cloneSortConfigs(DEFAULT_SORT_CONFIGS);
-
-  return configsToSerialize
-    .slice(0, 2)
-    .map(({ field, direction }) => `${field}.${direction}`)
-    .join(",");
-}
-
-export function parseTransactionsUrlState(
-  searchParams: SearchParamsLike,
-  defaults: TransactionFilters = createDefaultTransactionFilters(),
-): TransactionsUrlState {
-  const fromDateParam = searchParams.get(TRANSACTIONS_QUERY_KEYS.fromDate);
-  const toDateParam = searchParams.get(TRANSACTIONS_QUERY_KEYS.toDate);
-
-  let fromDate = isValidIsoDate(fromDateParam)
-    ? fromDateParam
-    : defaults.fromDate;
-  let toDate = isValidIsoDate(toDateParam) ? toDateParam : defaults.toDate;
-
-  if (new Date(fromDate) > new Date(toDate)) {
-    fromDate = defaults.fromDate;
-    toDate = defaults.toDate;
-  }
-
-  return {
-    filters: {
-      ...defaults,
-      searchQuery: searchParams.get(TRANSACTIONS_QUERY_KEYS.search) ?? "",
-      selectedFilter: parseSelectedFilter(
-        searchParams.get(TRANSACTIONS_QUERY_KEYS.filter),
-      ),
-      fromDate,
-      toDate,
-      sortConfigs: parseSortConfigs(
-        searchParams.get(TRANSACTIONS_QUERY_KEYS.sort),
-      ),
-    },
-    page: parsePage(searchParams.get(TRANSACTIONS_QUERY_KEYS.page)),
-  };
-}
-
-export function buildTransactionsQueryString(
-  currentSearchParams: SearchParamsLike,
-  state: TransactionsUrlState,
-  defaults: TransactionFilters = createDefaultTransactionFilters(),
-): string {
-  const nextParams = new URLSearchParams(currentSearchParams.toString());
-
-  Object.values(TRANSACTIONS_QUERY_KEYS).forEach((key) => {
-    nextParams.delete(key);
-  });
-
-  const searchQuery = state.filters.searchQuery;
-  if (searchQuery.trim().length > 0) {
-    nextParams.set(TRANSACTIONS_QUERY_KEYS.search, searchQuery);
-  }
-
-  const selectedFilter = serializeSelectedFilter(state.filters.selectedFilter);
-  if (selectedFilter !== "all") {
-    nextParams.set(TRANSACTIONS_QUERY_KEYS.filter, selectedFilter);
-  }
-
-  if (state.filters.fromDate !== defaults.fromDate) {
-    nextParams.set(TRANSACTIONS_QUERY_KEYS.fromDate, state.filters.fromDate);
-  }
-
-  if (state.filters.toDate !== defaults.toDate) {
-    nextParams.set(TRANSACTIONS_QUERY_KEYS.toDate, state.filters.toDate);
-  }
-
-  const serializedSort = serializeSortConfigs(state.filters.sortConfigs);
-  if (serializedSort !== serializeSortConfigs(defaults.sortConfigs)) {
-    nextParams.set(TRANSACTIONS_QUERY_KEYS.sort, serializedSort);
-  }
-
-  if (state.page > 1) {
-    nextParams.set(TRANSACTIONS_QUERY_KEYS.page, String(state.page));
-  }
-
-  return nextParams.toString();
-}
 
 /** Map token symbol → icon path */
 const getTokenIcon = (token: string): string => {
@@ -340,6 +138,7 @@ export default function TransactionsContent() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const { address } = useWallet();
 
   const {
     allTags,
@@ -349,6 +148,12 @@ export default function TransactionsContent() {
     addTag,
     getTagNamesForTransaction,
   } = useTransactionTags();
+
+  const [tagFilter, setTagFilter] = useState<string>("");
+  const [statementRange, setStatementRange] = useState<{
+    fromDate: string;
+    toDate: string;
+  } | null>(null);
 
   const defaultFiltersRef = useRef<TransactionFilters | null>(null);
   if (defaultFiltersRef.current === null) {
@@ -363,17 +168,20 @@ export default function TransactionsContent() {
     );
   }
 
-export default function TransactionsContent() {
-  const { address } = useWallet();
+  const defaultFilters = defaultFiltersRef.current;
+  const initialUrlState = initialUrlStateRef.current;
+  const currentQueryString = searchParams.toString();
 
   const [filters, setFilters] = useState<TransactionFilters>(() => ({
     ...initialUrlState.filters,
     sortConfigs: cloneSortConfigs(initialUrlState.filters.sortConfigs),
   }));
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(initialUrlState.page);
   const [savedViews, setSavedViews] = useState<SavedView[]>([]);
   const [hasHydratedViews, setHasHydratedViews] = useState(false);
   const addressRef = useRef(address);
+  const [advancedPanelOpen, setAdvancedPanelOpen] = useState(false);
+  const itemsPerPage = TRANSACTIONS_PAGE_SIZE;
 
   // Hydrate saved views from localStorage on mount
   useEffect(() => {
@@ -391,8 +199,6 @@ export default function TransactionsContent() {
   useEffect(() => {
     addressRef.current = address;
   }, [address]);
-  const [advancedPanelOpen, setAdvancedPanelOpen] = useState(false);
-  const itemsPerPage = TRANSACTIONS_PAGE_SIZE;
 
   // ── Selection state ─────────────────────────────────────────────────────────
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -425,6 +231,7 @@ export default function TransactionsContent() {
     });
   }, []);
 
+  // ── URL Synchronization ─────────────────────────────────────────────────────
   useEffect(() => {
     const nextQueryString = buildTransactionsQueryString(
       new URLSearchParams(currentQueryString),
@@ -454,10 +261,6 @@ export default function TransactionsContent() {
     pageSize: itemsPerPage,
   });
 
-  // A statement needs the ledger before the selected range to calculate its
-  // opening balance. Keep this request independent of table search/filter UI.
-  // The API currently caps a response at 100 records; production APIs should
-  // expose a server-side statement endpoint for ledgers larger than that.
   const statementLedger = useTransactions({
     filters: {
       fromDate: "",
@@ -477,22 +280,18 @@ export default function TransactionsContent() {
   const [liveMessage, setLiveMessage] = useState("");
 
   useEffect(() => {
-    // Only announce when data is present and not in a loading / error state.
     if (isLoading || error || !data) return;
 
     const total = data.total ?? 0;
     const prev = prevTotalRef.current;
 
-    // Suppress announcement on the initial render.
     if (prev === undefined) {
       prevTotalRef.current = total;
       return;
     }
 
-    // Suppress when the count hasn't actually changed (e.g. re-render).
     if (prev === total) return;
 
-    // Debounce so rapid filter changes only produce one announcement.
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
     debounceRef.current = setTimeout(() => {
@@ -505,8 +304,6 @@ export default function TransactionsContent() {
 
     prevTotalRef.current = total;
 
-    // Cancel pending timer on re-run (e.g. when transitioning to
-    // loading / error) or on unmount.
     return () => {
       if (debounceRef.current) {
         clearTimeout(debounceRef.current);
@@ -532,7 +329,6 @@ export default function TransactionsContent() {
   const [isLoadingPreview, setIsLoadingPreview] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
 
-  /** Fetch the count of rows matching a given date range (independent of pagination). */
   const handlePreviewRequest = useCallback(
     async (dateRange: { fromDate: string; toDate: string }) => {
       setIsLoadingPreview(true);
@@ -557,7 +353,6 @@ export default function TransactionsContent() {
     [],
   );
 
-  /** Fetch all matching rows for the date range and trigger CSV download. */
   const handleExport = useCallback(
     async (
       selectedColumns: string[],
@@ -574,7 +369,9 @@ export default function TransactionsContent() {
           page: 1,
           pageSize: MAX_TRANSACTION_PAGE_SIZE,
         });
-        const displayRows = result.data.map(toTransactionProps);
+        const displayRows = result.data.map((t) =>
+          toTransactionProps(t, getTagNamesForTransaction),
+        );
         const csvContent = generateTransactionsCsv(
           displayRows,
           selectedColumns,
@@ -587,15 +384,13 @@ export default function TransactionsContent() {
         setIsExporting(false);
       }
     },
-    [],
+    [getTagNamesForTransaction],
   );
 
-  /** Reset export preview when the export toolbar dialog closes. */
   const handleExportDialogClose = useCallback(() => {
     setExportPreviewCount(null);
   }, []);
 
-  // ── Stable select-all that has access to current page ids ────────────────────
   const paginatedTransactionsRef = useRef(paginatedTransactions);
   paginatedTransactionsRef.current = paginatedTransactions;
 
@@ -607,7 +402,7 @@ export default function TransactionsContent() {
     [handleSelectAll],
   );
 
-  // ── Filter helpers (clear selection on any filter/page change) ───────────────
+  // ── Filter helpers ──────────────────────────────────────────────────────────
   const updateFilter = useCallback(
     <K extends keyof TransactionFilters>(
       key: K,
@@ -634,10 +429,8 @@ export default function TransactionsContent() {
         const currentConfigs = prev.sortConfigs;
         const primary = currentConfigs[0];
 
-        // Shift-click: add/modify secondary sort
         if (options?.shiftKey && primary && primary.field !== field) {
           const secondary = currentConfigs[1];
-          // If this field is already the secondary sort, toggle direction
           if (secondary?.field === field) {
             const newConfigs: SortConfig[] = [
               { field: primary.field, direction: primary.direction },
@@ -648,7 +441,6 @@ export default function TransactionsContent() {
             ];
             return { ...prev, sortConfigs: newConfigs };
           }
-          // Otherwise set it as secondary with 'asc' default
           const newConfigs: SortConfig[] = [
             { field: primary.field, direction: primary.direction },
             { field, direction: "asc" },
@@ -656,8 +448,6 @@ export default function TransactionsContent() {
           return { ...prev, sortConfigs: newConfigs };
         }
 
-        // Click without shift: set as primary sort,
-        // toggling direction if it's already the primary field
         const isSameField = primary?.field === field;
         const newDirection =
           isSameField && primary?.direction === "asc" ? "desc" : "asc";
@@ -669,12 +459,10 @@ export default function TransactionsContent() {
       setCurrentPage(1);
       clearSelection();
     },
-    [],
+    [clearSelection],
   );
 
-  // ── Saved views helpers ────────────────────────────────────────────────
-
-  /** Save the current filter/sort state as a named view. */
+  // ── Saved views helpers ─────────────────────────────────────────────────────
   const handleSaveView = useCallback(
     (name: string) => {
       const trimmed = name.trim();
@@ -682,7 +470,9 @@ export default function TransactionsContent() {
       if (savedViews.length >= MAX_SAVED_VIEWS) return;
 
       const newView: SavedView = {
-        id: crypto.randomUUID?.() ?? `sv-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+        id:
+          crypto.randomUUID?.() ??
+          `sv-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
         name: trimmed,
         filters: { ...filters },
         createdAt: new Date().toISOString(),
@@ -692,13 +482,11 @@ export default function TransactionsContent() {
     [filters, savedViews.length],
   );
 
-  /** Load (apply) a saved view's filter/sort state. */
   const handleLoadView = useCallback((view: SavedView) => {
     setFilters(view.filters);
     setCurrentPage(1);
   }, []);
 
-  /** Rename a saved view. */
   const handleRenameView = useCallback(
     (view: SavedView, newName: string) => {
       const trimmed = newName.trim();
@@ -710,14 +498,11 @@ export default function TransactionsContent() {
     [],
   );
 
-  /** Delete a saved view. */
   const handleDeleteView = useCallback((view: SavedView) => {
     setSavedViews((prev) => prev.filter((v) => v.id !== view.id));
   }, []);
 
-  // ── Advanced filter panel helpers ──────────────────────────────────────
-
-  /** Draft values for the open panel (pre-apply). */
+  // ── Advanced filter panel helpers ───────────────────────────────────────────
   const advancedPanelValues: AdvancedFilterValues = useMemo(
     () => ({
       status: filters.selectedFilter,
@@ -732,10 +517,46 @@ export default function TransactionsContent() {
     [filters],
   );
 
+  const handleApplyAdvancedFilters = useCallback(
+    (values: AdvancedFilterValues) => {
+      setFilters((prev) => ({
+        ...prev,
+        selectedFilter: values.status,
+        minAmount:
+          values.minAmount.trim() !== ""
+            ? parseFloat(values.minAmount)
+            : undefined,
+        maxAmount:
+          values.maxAmount.trim() !== ""
+            ? parseFloat(values.maxAmount)
+            : undefined,
+        counterparty: values.counterparty.trim() || undefined,
+        fromDate: values.fromDate,
+        toDate: values.toDate,
+      }));
+      setCurrentPage(1);
+      clearSelection();
+      setAdvancedPanelOpen(false);
+    },
+    [clearSelection],
+  );
+
+  const handleClearAdvancedFilters = useCallback(() => {
+    setFilters((prev) => ({
+      ...prev,
+      selectedFilter: "All Transactions",
+      minAmount: undefined,
+      maxAmount: undefined,
+      counterparty: undefined,
+      ...defaultFilters,
+    }));
+    setCurrentPage(1);
+    clearSelection();
+    setAdvancedPanelOpen(false);
+  }, [defaultFilters, clearSelection]);
+
   // ── Bulk action handlers ─────────────────────────────────────────────────────
   const handleBulkExport = useCallback(() => {
-    // Stub: collect the selected transactions and trigger a CSV download.
-    // Replace with a real implementation once the export endpoint is available.
     const selected = paginatedTransactions.filter((t) => selectedIds.has(t.id));
     const csv = [
       ["ID", "Type", "Address", "Date", "Token", "Amount", "Status"].join(","),
@@ -756,9 +577,31 @@ export default function TransactionsContent() {
     clearSelection();
   }, [paginatedTransactions, selectedIds, clearSelection]);
 
+  const handleBulkTag = useCallback(() => {
+    console.log("Tag transactions:", Array.from(selectedIds));
+  }, [selectedIds]);
+
+  const handleBulkArchive = useCallback(() => {
+    console.log("Archive transactions:", Array.from(selectedIds));
+    clearSelection();
+  }, [selectedIds, clearSelection]);
+
   return (
     <div className="min-h-screen text-white mt-4">
-      <div className="w-full max-w-7xl mx-auto mb-4">
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+        data-testid="selection-announcement"
+      >
+        {selectedIds.size > 0
+          ? selectedIds.size === 1
+            ? "1 transaction selected"
+            : `${selectedIds.size} transactions selected`
+          : ""}
+      </div>
+
+      <div className="w-full max-w-7xl mx-auto mb-4 transactions-print-root">
         <div className="flex flex-col lg:flex-row lg:items-center justify-between px-6 py-4 bg-[#1a0c1d] mb-4 rounded-lg">
           <TransactionsHeader
             fromDate={filters.fromDate}
@@ -779,45 +622,6 @@ export default function TransactionsContent() {
             />
           </div>
         </div>
-  const handleBulkTag = useCallback(() => {
-    // Stub: open a tag-assignment dialog.
-    // Replace with real implementation once the tag feature is built.
-    console.log("Tag transactions:", Array.from(selectedIds));
-  }, [selectedIds]);
-
-  const handleBulkArchive = useCallback(() => {
-    // Stub: send archive request for all selected ids.
-    // Replace with real implementation once the archive endpoint is available.
-    console.log("Archive transactions:", Array.from(selectedIds));
-    clearSelection();
-  }, [selectedIds, clearSelection]);
-
-  return (
-    <div className="min-h-screen text-white mt-4">
-      {/*
-        aria-live region announces selection count changes to screen readers
-        without interrupting the user's current focus.
-      */}
-      <div
-        aria-live="polite"
-        aria-atomic="true"
-        className="sr-only"
-        data-testid="selection-announcement"
-      >
-        {selectedIds.size > 0
-          ? selectedIds.size === 1
-            ? "1 transaction selected"
-            : `${selectedIds.size} transactions selected`
-          : ""}
-      </div>
-
-      <div className="w-full max-w-7xl mx-auto mb-4 transactions-print-root">
-        <TransactionsHeader
-          fromDate={filters.fromDate}
-          toDate={filters.toDate}
-          onFromDateChange={(date) => updateFilter("fromDate", date)}
-          onToDateChange={(date) => updateFilter("toDate", date)}
-        />
 
         <div className="mb-4 flex justify-end px-4 sm:px-6 lg:px-8 print:hidden">
           <button
@@ -828,12 +632,23 @@ export default function TransactionsContent() {
                 toDate: filters.toDate,
               })
             }
-            savedViews={hasHydratedViews ? savedViews : undefined}
-            onSaveView={handleSaveView}
-            onLoadView={handleLoadView}
-            onRenameView={handleRenameView}
-            onDeleteView={handleDeleteView}
-          />
+            disabled={statementLedger.isLoading || !!statementLedger.error}
+            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:cursor-not-allowed disabled:opacity-60"
+            aria-describedby="statement-help"
+          >
+            <FileText aria-hidden="true" size={16} />
+            Generate statement
+          </button>
+          <span id="statement-help" className="sr-only">
+            Creates a printable reconciliation statement for the selected date
+            range.
+          </span>
+          {statementLedger.error && (
+            <p role="status" className="ml-3 self-center text-sm text-red-300">
+              Statement data could not be loaded. Try again later.
+            </p>
+          )}
+        </div>
 
         {statementRange && (
           <TransactionsStatement
@@ -844,9 +659,6 @@ export default function TransactionsContent() {
           />
         )}
 
-        {/* Visually-hidden live region that announces filter result counts to
-             screen readers. Uses aria-live="polite" so announcements do not
-             interrupt the user's current task. */}
         <div
           role="status"
           aria-live="polite"
@@ -865,6 +677,17 @@ export default function TransactionsContent() {
               onSearchChange={(q) => updateFilter("searchQuery", q)}
               onFilterChange={(f) => updateFilter("selectedFilter", f)}
               onSort={handleSort}
+              onAdvancedFilterToggle={() => setAdvancedPanelOpen(true)}
+              hasAdvancedFilters={Boolean(
+                filters.minAmount !== undefined ||
+                  filters.maxAmount !== undefined ||
+                  filters.counterparty,
+              )}
+              savedViews={hasHydratedViews ? savedViews : undefined}
+              onSaveView={handleSaveView}
+              onLoadView={handleLoadView}
+              onRenameView={handleRenameView}
+              onDeleteView={handleDeleteView}
               tagFilter={tagFilter}
               allTags={allTags}
               onTagFilterChange={(tagName) => {
@@ -876,10 +699,8 @@ export default function TransactionsContent() {
           </div>
 
           <div className="py-4">
-            {/* Loading state */}
             {isLoading && <TransactionTableSkeleton rows={itemsPerPage} />}
 
-            {/* Error state */}
             {!isLoading && error && (
               <ErrorState
                 title="Failed to Load"
@@ -888,7 +709,6 @@ export default function TransactionsContent() {
               />
             )}
 
-            {/* Data state */}
             {!isLoading && !error && (
               <>
                 <TransactionsTable
@@ -916,8 +736,15 @@ export default function TransactionsContent() {
         </div>
       </div>
 
-      {/* Floating bulk-action bar – rendered outside the scrollable content area
-          so it always stays anchored to the viewport bottom */}
+      <AdvancedFilterPanel
+        open={advancedPanelOpen}
+        onOpenChange={setAdvancedPanelOpen}
+        currentValues={advancedPanelValues}
+        onValuesChange={() => {}}
+        onApply={() => handleApplyAdvancedFilters(advancedPanelValues)}
+        onClearAll={handleClearAdvancedFilters}
+      />
+
       <div className="print:hidden">
         <BulkActionBar
           selectedCount={selectedIds.size}

--- a/components/transactions/transactions-filters.test.tsx
+++ b/components/transactions/transactions-filters.test.tsx
@@ -5,6 +5,11 @@ import userEvent from "@testing-library/user-event";
 import TransactionsFilters from "./transactions-filters";
 import type { SortConfig, SavedView } from "@/types/transaction";
 
+vi.mock("@/context/sidebar-context", () => ({
+  __esModule: true,
+  default: () => ({ isSidebarOpen: true, isMobile: false }),
+}));
+
 // ─── Mock Radix UI DropdownMenu ─────────────────────────────────────────
 vi.mock("@/components/ui/dropdown-menu", () => {
   // We use a plain div/button wrapper so that the dropdown items always

--- a/components/transactions/transactions-filters.tsx
+++ b/components/transactions/transactions-filters.tsx
@@ -50,7 +50,15 @@ export default function TransactionsFilters({
   onLoadView,
   onRenameView,
   onDeleteView,
-}: TransactionsFiltersProps) {
+  debounceMs = 0,
+  tagFilter,
+  allTags = [],
+  onTagFilterChange,
+}: TransactionsFiltersProps & {
+  tagFilter?: string;
+  allTags?: { id: string; name: string; color: string }[];
+  onTagFilterChange?: (tagName: string) => void;
+}) {
   const renderSortIndicator = (field: SortField) => {
     const indicators: string[] = [];
     for (const [idx, config] of sortConfigs.entries()) {
@@ -92,14 +100,9 @@ export default function TransactionsFilters({
           <DropdownMenuTrigger asChild>
             <Button
               variant="ghost"
-              className="relative text-xl text-white hover:bg-[#160f17] hover:text-white px-2"
+              className="text-xl text-white hover:bg-[#160f17] hover:text-white px-2"
             >
               {selectedFilter}
-              {activeFilterCount > 0 && (
-                <span className="absolute -top-1 -right-1 inline-flex items-center justify-center px-1.5 py-0.5 rounded-full text-xs font-medium bg-[#34D399] text-black">
-                  {activeFilterCount}
-                </span>
-              )}
               <ChevronDown
                 size={16}
                 color="currentColor"

--- a/components/transactions/transactions-pagination-resilience.test.tsx
+++ b/components/transactions/transactions-pagination-resilience.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Component-level tests for resilient transaction pagination.
+ *
+ * A backend can change between cursor requests — records reordered, deleted,
+ * or duplicated across page boundaries. These tests verify the component
+ * layer never renders the same transaction id twice for the three failure
+ * modes called out by the issue: overlap, deletion, and repeated cursors.
+ *
+ * The harness below mirrors exactly how the transactions view consumes
+ * fetched pages: every incoming page is identity-deduplicated before being
+ * rendered (keyed by a stable `id`), so adjacent/accumulated pages can only
+ * ever show unique transaction rows.
+ */
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { TransactionProps } from "@/types/transaction";
+import { dedupeTransactionsById } from "@/utils/transactionUtils";
+
+function makeTransaction(id: string): TransactionProps {
+  return {
+    id,
+    type: "Payment Sent",
+    address: `GABC${id}`,
+    date: "2024-01-01",
+    time: "10:00",
+    token: "XLM",
+    amount: `+10 XLM`,
+    status: "Completed",
+    tokenIcon: "/xlm.svg",
+  };
+}
+
+/**
+ * Minimal renderable list that consumes accumulated pages and deduplicates by
+ * identity before rendering — the same invariant the real transactions view
+ * relies on. Each row is rendered with a data-testid of its id so the test can
+ * assert that every visible row has a unique id.
+ */
+function TransactionList({ pages }: { pages: TransactionProps[][] }) {
+  const rows = dedupeTransactionsById(pages.flat());
+  return (
+    <ul role="list">
+      {rows.map((t) => (
+        <li key={t.id} data-testid="transaction-row">
+          <span data-testid={`tx-${t.id}`}>{t.id}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+const renderIds = () =>
+  screen
+    .getAllByTestId(/^tx-/) // every rendered row id
+    .map((el) => el.textContent!);
+
+describe("transaction pagination resilience (component)", () => {
+  it("adjacent pages never render duplicate ids when the backend overlaps", () => {
+    // Page 2 re-sends id "2" (a record re-inserted before the boundary).
+    const page1 = [makeTransaction("1"), makeTransaction("2")];
+    const page2 = [makeTransaction("2"), makeTransaction("3")];
+
+    render(<TransactionList pages={[page1, page2]} />);
+
+    const rendered = screen.getAllByTestId("transaction-row");
+    const ids = renderIds();
+    expect(rendered).toHaveLength(3);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("deleted records do not leave gaps or render duplicates", () => {
+    // Record "2" is deleted server-side between page 1 and page 2.
+    const page1 = [makeTransaction("1"), makeTransaction("2")];
+    const page2 = [makeTransaction("3"), makeTransaction("4")];
+
+    render(<TransactionList pages={[page1, page2]} />);
+
+    const ids = renderIds();
+    expect(ids).toEqual(["1", "2", "3", "4"]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("repeated cursors that re-deliver the same page do not duplicate rows", () => {
+    // A repeated cursor re-delivers the same page instead of advancing.
+    const page1 = [makeTransaction("1"), makeTransaction("2")];
+    const page1Again = [makeTransaction("1"), makeTransaction("2")];
+    const page3 = [makeTransaction("3")];
+
+    render(<TransactionList pages={[page1, page1Again, page3]} />);
+
+    const ids = renderIds();
+    expect(ids).toEqual(["1", "2", "3"]);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(screen.getAllByText("1")).toHaveLength(1);
+  });
+
+  it("renders each id exactly once within a single screenful", () => {
+    // Server erroneously returns a fully duplicated page back-to-back.
+    const pages = [
+      [makeTransaction("a"), makeTransaction("b")],
+      [makeTransaction("a"), makeTransaction("b")],
+    ];
+    render(<TransactionList pages={pages} />);
+
+    const list = screen.getByRole("list");
+    expect(within(list).getAllByTestId(/^tx-/)).toHaveLength(2);
+  });
+});

--- a/components/transactions/transactions-table.tsx
+++ b/components/transactions/transactions-table.tsx
@@ -2,46 +2,7 @@
 
 import * as React from "react";
 
-import { cn } from "@/utils/commonUtils";
 
-interface TableProps extends React.ComponentProps<"table"> {
-  /** Makes the <thead> row stick to the top of the scroll container. */
-  stickyHeader?: boolean;
-  /** Makes the first column (th/td) stick to the left edge of the scroll container. */
-  stickyFirstColumn?: boolean;
-  /** Extra classes for the scroll container div (e.g. max-h-[480px] for vertical scroll). */
-  containerClassName?: string;
-}
-
-function Table({
-  className,
-  containerClassName,
-  stickyHeader = false,
-  stickyFirstColumn = false,
-  ...props
-}: TableProps) {
-  return (
-    <div
-      data-slot="table-container"
-      data-sticky-header={stickyHeader || undefined}
-      data-sticky-first-column={stickyFirstColumn || undefined}
-      className={cn("relative w-full overflow-auto", containerClassName)}
-    >
-      <table
-        data-slot="table"
-        className={cn(
-          "w-full caption-bottom text-sm",
-          stickyHeader &&
-            "[&_thead]:sticky [&_thead]:top-0 [&_thead]:z-20 [&_thead_th]:bg-background",
-          stickyFirstColumn &&
-            "[&_tbody_tr>:first-child]:sticky [&_tbody_tr>:first-child]:left-0 [&_tbody_tr>:first-child]:z-10 [&_tbody_tr>:first-child]:bg-background [&_tbody_tr>:first-child]:border-r [&_thead_tr>:first-child]:sticky [&_thead_tr>:first-child]:left-0 [&_thead_tr>:first-child]:z-30 [&_thead_tr>:first-child]:border-r",
-          className,
-        )}
-        {...props}
-      />
-    </div>
-  );
-}
 import {
   Table,
   TableBody,
@@ -348,63 +309,7 @@ export function TransactionsTable({
 
   const isSelectable = Boolean(onSelectRow && onSelectAll);
 
-function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
   return (
-    <thead
-      data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
-      {...props}
-    />
-  );
-}
-
-function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
-  return (
-    <tbody
-      data-slot="table-body"
-      className={cn("[&_tr:last-child]:border-0", className)}
-      {...props}
-    />
-  );
-}
-
-function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
-  return (
-    <tfoot
-      data-slot="table-footer"
-      className={cn(
-        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
-
-function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
-  return (
-    <tr
-      data-slot="table-row"
-      className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
-
-function TableHead({ className, ...props }: React.ComponentProps<"th">) {
-  return (
-    <th
-      data-slot="table-head"
-      scope="col"
-      className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className,
-      )}
-      {...props}
-    />
     <>
       {/* Desktop Table */}
       <div
@@ -711,39 +616,4 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
   );
 }
 
-function TableCell({ className, ...props }: React.ComponentProps<"td">) {
-  return (
-    <td
-      data-slot="table-cell"
-      className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
 
-function TableCaption({
-  className,
-  ...props
-}: React.ComponentProps<"caption">) {
-  return (
-    <caption
-      data-slot="table-caption"
-      className={cn("text-muted-foreground mt-4 text-sm", className)}
-      {...props}
-    />
-  );
-}
-
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-};

--- a/components/transactions/transactions-table.tsx
+++ b/components/transactions/transactions-table.tsx
@@ -28,7 +28,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, RotateCw } from "lucide-react";
 import Link from "next/link";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DownloadReceiptButton } from "@/components/transactions/download-receipt-button";
@@ -59,6 +59,17 @@ interface TransactionsTablePropsExtended extends TransactionsTableProps {
   onUnassignTag?: (txId: string, tagId: string) => void;
   /** Create a new tag and return it */
   onCreateTag?: (name: string) => Tag;
+  /** Retry a failed or timed-out transaction. */
+  onRetryTransaction?: (id: string) => void;
+}
+
+const RETRYABLE_STATUSES = new Set(["Rejected", "Timeout", "Failed", "Retry"]);
+
+function getTransactionStatusState(status: string): "completed" | "current" | "error" | undefined {
+  if (status === "Pending" || status === "Retry") return "current";
+  if (status === "Completed" || status === "Success") return "completed";
+  if (status === "Rejected" || status === "Timeout" || status === "Failed") return "error";
+  return undefined;
 }
 
 /**
@@ -257,6 +268,7 @@ export function TransactionsTable({
   onAssignTag,
   onUnassignTag,
   onCreateTag,
+  onRetryTransaction,
 }: TransactionsTablePropsExtended) {
   const isEmpty = !isLoading && transactions.length === 0;
   
@@ -265,6 +277,21 @@ export function TransactionsTable({
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
   const triggerRef = React.useRef<HTMLButtonElement | null>(null);
   const tableWrapperRef = React.useRef<HTMLDivElement | null>(null);
+
+  const [liveAnnouncement, setLiveAnnouncement] = React.useState("");
+  const previousStatusesRef = React.useRef<Record<string, string>>({});
+
+  React.useEffect(() => {
+    transactions.forEach((transaction) => {
+      const previousStatus = previousStatusesRef.current[transaction.id];
+      if (previousStatus && previousStatus !== transaction.status) {
+        setLiveAnnouncement(
+          `Transaction ${transaction.id} status changed from ${previousStatus} to ${transaction.status}.`,
+        );
+      }
+      previousStatusesRef.current[transaction.id] = transaction.status;
+    });
+  }, [transactions]);
 
   const handleRowClick = (transaction: TransactionProps, event: React.MouseEvent<HTMLButtonElement>) => {
     triggerRef.current = event.currentTarget;
@@ -311,6 +338,9 @@ export function TransactionsTable({
 
   return (
     <>
+      <span role="status" aria-live="polite" className="sr-only">
+        {liveAnnouncement}
+      </span>
       {/* Desktop Table */}
       <div
         ref={tableWrapperRef}
@@ -468,7 +498,13 @@ export function TransactionsTable({
                   <TableCell className="py-4 px-6">
                     <Badge
                       aria-label={`Status: ${transaction.status}`}
+                      aria-current={
+                        transaction.status === "Pending" || transaction.status === "Retry"
+                          ? "step"
+                          : undefined
+                      }
                       className={getStatusColor(transaction.status)}
+                      data-state={getTransactionStatusState(transaction.status)}
                     >
                       <span className="text-sm">{transaction.status}</span>
                     </Badge>
@@ -497,6 +533,16 @@ export function TransactionsTable({
                         <circle cx="12" cy="12" r="3" />
                       </svg>
                     </button>
+                    {onRetryTransaction && RETRYABLE_STATUSES.has(transaction.status) && (
+                      <button
+                        type="button"
+                        onClick={() => onRetryTransaction(transaction.id)}
+                        className="p-2 rounded-md hover:bg-[#2D2D2D] focus:outline-none focus:ring-2 focus:ring-[#D7E0EF] transition-colors"
+                        aria-label={`Retry transaction ${transaction.id}`}
+                      >
+                        <RotateCw className="h-4 w-4" aria-hidden="true" />
+                      </button>
+                    )}
                     <DownloadReceiptButton
                       transaction={{
                         id: transaction.id,
@@ -552,6 +598,12 @@ export function TransactionsTable({
                   </p>
                 </div>
                 <Badge
+                  aria-current={
+                    transaction.status === "Pending" || transaction.status === "Retry"
+                      ? "step"
+                      : undefined
+                  }
+                  data-state={getTransactionStatusState(transaction.status)}
                   variant={
                     transaction.status === "Completed"
                       ? "default"

--- a/components/transactions/transactions-url-state.test.ts
+++ b/components/transactions/transactions-url-state.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect } from "vitest";
+import {
+  TRANSACTIONS_QUERY_KEYS,
+  createDefaultTransactionFilters,
+  parseTransactionsUrlState,
+  buildTransactionsQueryString,
+  buildShareableTransactionsQueryString,
+  buildShareableTransactionsUrl,
+  parseSortConfigs,
+  serializeSortConfigs,
+  isValidIsoDate,
+  parsePage,
+  parseSelectedFilter,
+  serializeSelectedFilter,
+  DEFAULT_SORT_CONFIGS,
+  type TransactionsUrlState,
+} from "./transactions-url-state";
+import type { TransactionFilters, SortConfig } from "@/types/transaction";
+
+function makeDeterministicDefaults(): TransactionFilters {
+  return {
+    ...createDefaultTransactionFilters(),
+    fromDate: "2024-01-01",
+    toDate: "2024-01-31",
+    sortConfigs: [{ field: "date", direction: "desc" }],
+  };
+}
+
+describe("transactions-url-state", () => {
+  // ── 1. Allowlisted URL Serialization ───────────────────────────────────────
+  describe("Allowlist serialization", () => {
+    it("serializes only supported filter, sort, and pagination fields", () => {
+      const defaults = makeDeterministicDefaults();
+      const filters: TransactionFilters = {
+        ...defaults,
+        searchQuery: "USDC payment",
+        selectedFilter: "Payment Sent",
+        fromDate: "2024-02-01",
+        toDate: "2024-02-28",
+        sortConfigs: [
+          { field: "amount", direction: "asc" },
+          { field: "date", direction: "desc" },
+        ],
+      };
+
+      const queryString = buildShareableTransactionsQueryString(
+        { filters, page: 2 },
+        defaults,
+      );
+      const params = new URLSearchParams(queryString);
+
+      // Verify all expected keys are serialized
+      expect(params.get("q")).toBe("USDC payment");
+      expect(params.get("filter")).toBe("sent");
+      expect(params.get("from")).toBe("2024-02-01");
+      expect(params.get("to")).toBe("2024-02-28");
+      expect(params.get("sort")).toBe("amount.asc,date.desc");
+      expect(params.get("page")).toBe("2");
+
+      // Verify no other keys are serialized
+      const keys = Array.from(params.keys());
+      expect(keys.sort()).toEqual(["filter", "from", "page", "q", "sort", "to"]);
+    });
+
+    it("omits default values to keep shareable URLs clean and canonical", () => {
+      const defaults = makeDeterministicDefaults();
+      const queryString = buildShareableTransactionsQueryString(
+        { filters: defaults, page: 1 },
+        defaults,
+      );
+      expect(queryString).toBe("");
+    });
+
+    it("formats full shareable URLs correctly with buildShareableTransactionsUrl", () => {
+      const defaults = makeDeterministicDefaults();
+      const filters: TransactionFilters = {
+        ...defaults,
+        searchQuery: "Invoice 123",
+      };
+      const url = buildShareableTransactionsUrl(
+        "/transactions",
+        { filters, page: 1 },
+        defaults,
+      );
+      expect(url).toBe("/transactions?q=Invoice+123");
+    });
+  });
+
+  // ── 2. Sensitive Parameter & Private Metadata Exclusion ─────────────────────
+  describe("Exclusion of wallet identifiers and private metadata", () => {
+    it("strips wallet addresses, accounts, secrets, and private metadata when building shareable URLs", () => {
+      const defaults = makeDeterministicDefaults();
+      const currentParams = new URLSearchParams(
+        "wallet=GBRPYHIL2AZW0123456789&account=12345&publicKey=GABC...&secret=SB123&session=sess-999&counterparty=GXYZ&viewId=v1&tab=overview",
+      );
+
+      const filters: TransactionFilters = {
+        ...defaults,
+        searchQuery: "Stellar",
+      };
+
+      const shareableQuery = buildShareableTransactionsQueryString(
+        { filters, page: 1 },
+        defaults,
+      );
+      const shareableParams = new URLSearchParams(shareableQuery);
+
+      expect(shareableParams.has("wallet")).toBe(false);
+      expect(shareableParams.has("account")).toBe(false);
+      expect(shareableParams.has("publicKey")).toBe(false);
+      expect(shareableParams.has("secret")).toBe(false);
+      expect(shareableParams.has("session")).toBe(false);
+      expect(shareableParams.has("counterparty")).toBe(false);
+      expect(shareableParams.has("viewId")).toBe(false);
+      expect(shareableParams.has("tab")).toBe(false);
+      expect(shareableParams.get("q")).toBe("Stellar");
+    });
+
+    it("purges sensitive parameters during regular navigation query building while preserving safe UI parameters", () => {
+      const defaults = makeDeterministicDefaults();
+      const currentParams = new URLSearchParams(
+        "tab=ledger&view=compact&wallet=GBRPYHIL2AZW&secretKey=S12345&privateKey=P987&userId=user_42",
+      );
+
+      const filters: TransactionFilters = {
+        ...defaults,
+        searchQuery: "Salary",
+      };
+
+      const queryString = buildTransactionsQueryString(
+        currentParams,
+        { filters, page: 1 },
+        defaults,
+      );
+      const params = new URLSearchParams(queryString);
+
+      // Safe ambient UI parameters are preserved
+      expect(params.get("tab")).toBe("ledger");
+      expect(params.get("view")).toBe("compact");
+      expect(params.get("q")).toBe("Salary");
+
+      // Sensitive parameters are stripped
+      expect(params.has("wallet")).toBe(false);
+      expect(params.has("secretKey")).toBe(false);
+      expect(params.has("privateKey")).toBe(false);
+      expect(params.has("userId")).toBe(false);
+    });
+
+    it("ignores sensitive query values in incoming URLs when parsing state", () => {
+      const defaults = makeDeterministicDefaults();
+      const incomingParams = new URLSearchParams(
+        "wallet=GBRPYHIL2AZW&account=acc_99&apiKey=secret_key&q=test&filter=sent",
+      );
+
+      const parsed = parseTransactionsUrlState(incomingParams, defaults);
+
+      expect(parsed.filters.searchQuery).toBe("test");
+      expect(parsed.filters.selectedFilter).toBe("Payment Sent");
+      // Verify internal filter object does not inherit sensitive fields from URL
+      expect((parsed.filters as Record<string, unknown>).wallet).toBeUndefined();
+      expect((parsed.filters as Record<string, unknown>).account).toBeUndefined();
+      expect((parsed.filters as Record<string, unknown>).apiKey).toBeUndefined();
+    });
+  });
+
+  // ── 3. Encoded Query Values ────────────────────────────────────────────────
+  describe("Encoded query values handling", () => {
+    it("correctly decodes URI encoded search queries", () => {
+      const defaults = makeDeterministicDefaults();
+      const params = new URLSearchParams(
+        "q=%E2%9C%A8%20Payment%20to%20Alice%20%26%20Bob",
+      );
+      const parsed = parseTransactionsUrlState(params, defaults);
+      expect(parsed.filters.searchQuery).toBe("✨ Payment to Alice & Bob");
+    });
+
+    it("correctly parses URL encoded filter labels and values", () => {
+      const defaults = makeDeterministicDefaults();
+      const params = new URLSearchParams("filter=Payment%20Received");
+      const parsed = parseTransactionsUrlState(params, defaults);
+      expect(parsed.filters.selectedFilter).toBe("Payment Received");
+    });
+
+    it("correctly parses encoded sort tokens with commas and colons", () => {
+      const parsed = parseSortConfigs("amount%2Easc%2Cstatus%3Adesc");
+      // When decoded by URLSearchParams or passed directly:
+      expect(parseSortConfigs("amount.asc,status:desc")).toEqual([
+        { field: "amount", direction: "asc" },
+        { field: "status", direction: "desc" },
+      ]);
+    });
+
+    it("safely trims and sanitizes special characters without throwing", () => {
+      const defaults = makeDeterministicDefaults();
+      const params = new URLSearchParams(
+        'q=%3Cscript%3Ealert(%22xss%22)%3C%2Fscript%3E&filter=%20%20sent%20%20',
+      );
+      const parsed = parseTransactionsUrlState(params, defaults);
+      expect(parsed.filters.searchQuery).toBe('<script>alert("xss")</script>');
+      expect(parsed.filters.selectedFilter).toBe("Payment Sent");
+    });
+  });
+
+  // ── 4. Repeated Query Values ───────────────────────────────────────────────
+  describe("Repeated query values handling", () => {
+    it("handles repeated filter parameters deterministically", () => {
+      const defaults = makeDeterministicDefaults();
+      const params = new URLSearchParams();
+      params.append("filter", "sent");
+      params.append("filter", "received");
+
+      const parsed = parseTransactionsUrlState(params, defaults);
+      expect(parsed.filters.selectedFilter).toBe("Payment Sent");
+    });
+
+    it("handles repeated search query parameters deterministically", () => {
+      const defaults = makeDeterministicDefaults();
+      const params = new URLSearchParams();
+      params.append("q", "primary-query");
+      params.append("q", "secondary-query");
+
+      const parsed = parseTransactionsUrlState(params, defaults);
+      expect(parsed.filters.searchQuery).toBe("primary-query");
+    });
+
+    it("handles repeated page parameters deterministically", () => {
+      const defaults = makeDeterministicDefaults();
+      const params = new URLSearchParams();
+      params.append("page", "4");
+      params.append("page", "9");
+
+      const parsed = parseTransactionsUrlState(params, defaults);
+      expect(parsed.page).toBe(4);
+    });
+
+    it("handles repeated from/to date parameters deterministically", () => {
+      const defaults = makeDeterministicDefaults();
+      const params = new URLSearchParams();
+      params.append("from", "2024-03-01");
+      params.append("from", "2024-05-01");
+      params.append("to", "2024-03-31");
+      params.append("to", "2024-05-31");
+
+      const parsed = parseTransactionsUrlState(params, defaults);
+      expect(parsed.filters.fromDate).toBe("2024-03-01");
+      expect(parsed.filters.toDate).toBe("2024-03-31");
+    });
+  });
+
+  // ── 5. Invalid & Malformed Query Values ─────────────────────────────────────
+  describe("Invalid and out-of-bounds query values", () => {
+    it("validates ISO dates strictly without auto-rollover", () => {
+      expect(isValidIsoDate("2024-01-15")).toBe(true);
+      expect(isValidIsoDate("2024-02-29")).toBe(true); // 2024 is a leap year
+      expect(isValidIsoDate("2023-02-29")).toBe(false); // 2023 is not a leap year
+      expect(isValidIsoDate("2024-02-30")).toBe(false); // Feb 30 does not exist
+      expect(isValidIsoDate("2024-04-31")).toBe(false); // April has 30 days
+      expect(isValidIsoDate("2024-13-01")).toBe(false); // Month 13 is invalid
+      expect(isValidIsoDate("not-a-date")).toBe(false);
+      expect(isValidIsoDate("")).toBe(false);
+      expect(isValidIsoDate(null)).toBe(false);
+    });
+
+    it("falls back to default dates when date bounds are invalid", () => {
+      const defaults = makeDeterministicDefaults();
+      const params = new URLSearchParams("from=2024-02-30&to=invalid-date");
+      const parsed = parseTransactionsUrlState(params, defaults);
+
+      expect(parsed.filters.fromDate).toBe(defaults.fromDate);
+      expect(parsed.filters.toDate).toBe(defaults.toDate);
+    });
+
+    it("falls back to default dates when fromDate > toDate (inverted range)", () => {
+      const defaults = makeDeterministicDefaults();
+      const params = new URLSearchParams("from=2024-12-01&to=2024-01-01");
+      const parsed = parseTransactionsUrlState(params, defaults);
+
+      expect(parsed.filters.fromDate).toBe(defaults.fromDate);
+      expect(parsed.filters.toDate).toBe(defaults.toDate);
+    });
+
+    it("falls back to page 1 for invalid page parameters (negative, float, string)", () => {
+      expect(parsePage("-5")).toBe(1);
+      expect(parsePage("0")).toBe(1);
+      expect(parsePage("abc")).toBe(1);
+      expect(parsePage("1.5")).toBe(1);
+      expect(parsePage("Infinity")).toBe(1);
+      expect(parsePage(null)).toBe(1);
+      expect(parsePage("5")).toBe(5);
+    });
+
+    it("filters out invalid sort fields and directions", () => {
+      expect(parseSortConfigs("unknown.asc,date.invalid,wallet.desc")).toEqual(
+        DEFAULT_SORT_CONFIGS,
+      );
+      expect(parseSortConfigs("date.asc,amount.desc,status.asc")).toEqual([
+        { field: "date", direction: "asc" },
+        { field: "amount", direction: "desc" },
+      ]); // Capped at 2
+    });
+
+    it("deduplicates identical sort fields in the query string", () => {
+      expect(parseSortConfigs("date.asc,date.desc")).toEqual([
+        { field: "date", direction: "asc" },
+      ]);
+    });
+
+    it("falls back to default filter for unknown filter values", () => {
+      expect(parseSelectedFilter("invalid-filter")).toBe("All Transactions");
+      expect(parseSelectedFilter(null)).toBe("All Transactions");
+      expect(parseSelectedFilter("sent")).toBe("Payment Sent");
+      expect(parseSelectedFilter("received")).toBe("Payment Received");
+      expect(parseSelectedFilter("all")).toBe("All Transactions");
+    });
+  });
+
+  // ── 6. Deterministic Round-Trip (Idempotency) ──────────────────────────────
+  describe("Deterministic state & round-trip idempotency", () => {
+    it("produces identical output on parse -> serialize -> parse round-trip", () => {
+      const defaults = makeDeterministicDefaults();
+      const rawUrlParams = new URLSearchParams(
+        "q=payroll&filter=sent&from=2024-03-01&to=2024-03-31&sort=amount.desc,date.asc&page=3",
+      );
+
+      const parsed1 = parseTransactionsUrlState(rawUrlParams, defaults);
+      const serialized1 = buildShareableTransactionsQueryString(parsed1, defaults);
+      const parsed2 = parseTransactionsUrlState(new URLSearchParams(serialized1), defaults);
+      const serialized2 = buildShareableTransactionsQueryString(parsed2, defaults);
+
+      expect(parsed1).toEqual(parsed2);
+      expect(serialized1).toBe(serialized2);
+    });
+
+    it("normalizes arbitrary messy input into canonical query parameters", () => {
+      const defaults = makeDeterministicDefaults();
+      const messyParams = new URLSearchParams(
+        "wallet=GABC123&sort=date:asc,amount.desc,date.desc&filter=PAYMENT%20SENT&page=2&q=%20%20Stellar%20XLM%20%20",
+      );
+
+      const parsed = parseTransactionsUrlState(messyParams, defaults);
+      const canonicalQuery = buildShareableTransactionsQueryString(parsed, defaults);
+      const nextParams = new URLSearchParams(canonicalQuery);
+
+      expect(nextParams.get("q")).toBe("Stellar XLM");
+      expect(nextParams.get("filter")).toBe("sent");
+      expect(nextParams.get("sort")).toBe("date.asc,amount.desc");
+      expect(nextParams.get("page")).toBe("2");
+      expect(nextParams.has("wallet")).toBe(false);
+    });
+  });
+});

--- a/components/transactions/transactions-url-state.ts
+++ b/components/transactions/transactions-url-state.ts
@@ -1,0 +1,468 @@
+/**
+ * @fileoverview Allowlisted URL state model and serialization utilities for the
+ * Transactions view.
+ *
+ * Provides pure parsing, validation, and serialization functions that enforce:
+ * - Only supported filter, sort, and pagination parameters are serialized.
+ * - Wallet addresses, account identifiers, tokens, secrets, and private metadata
+ *   are strictly excluded from serialized query strings.
+ * - Shared URLs parse deterministically when handling encoded, repeated,
+ *   invalid, or sensitive query parameters.
+ */
+
+import type {
+  SortField,
+  SortConfig,
+  SortDirection,
+  TransactionFilters,
+} from "@/types/transaction";
+import {
+  DEFAULT_SELECTED_FILTER,
+  getDefaultDateRange,
+} from "./transactions-config";
+
+/**
+ * Allowlisted query parameter keys supported by the transactions URL state model.
+ */
+export const TRANSACTIONS_QUERY_KEYS = {
+  search: "q",
+  filter: "filter",
+  fromDate: "from",
+  toDate: "to",
+  sort: "sort",
+  page: "page",
+} as const;
+
+export type TransactionsQueryKey =
+  (typeof TRANSACTIONS_QUERY_KEYS)[keyof typeof TRANSACTIONS_QUERY_KEYS];
+
+export const ALLOWLISTED_QUERY_KEY_SET: ReadonlySet<string> = new Set(
+  Object.values(TRANSACTIONS_QUERY_KEYS),
+);
+
+/**
+ * Common sensitive parameter keys that must never be serialized or retained
+ * in shareable transaction URLs.
+ */
+export const SENSITIVE_QUERY_KEY_SET: ReadonlySet<string> = new Set([
+  "wallet",
+  "walletaddress",
+  "address",
+  "account",
+  "accountid",
+  "publickey",
+  "secret",
+  "secretkey",
+  "privatekey",
+  "seed",
+  "token",
+  "authtoken",
+  "session",
+  "sessionid",
+  "user",
+  "userid",
+  "auth",
+  "authorization",
+  "signature",
+  "counterparty",
+  "internalid",
+  "viewid",
+  "savedview",
+  "memo",
+  "metadata",
+  "balance",
+  "pin",
+  "password",
+  "key",
+  "apikey",
+]);
+
+export const DEFAULT_SORT_CONFIGS: readonly SortConfig[] = [
+  { field: "date", direction: "desc" },
+];
+
+export const FILTER_QUERY_VALUE_TO_LABEL: Readonly<Record<string, string>> = {
+  all: DEFAULT_SELECTED_FILTER,
+  sent: "Payment Sent",
+  received: "Payment Received",
+};
+
+export const FILTER_LABEL_TO_QUERY_VALUE: Readonly<Record<string, string>> = {
+  [DEFAULT_SELECTED_FILTER]: "all",
+  "Payment Sent": "sent",
+  "Payment Received": "received",
+};
+
+const SORT_FIELDS = [
+  "date",
+  "amount",
+  "type",
+  "status",
+] as const satisfies readonly SortField[];
+
+const SORT_DIRECTIONS = [
+  "asc",
+  "desc",
+] as const satisfies readonly SortDirection[];
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export type SearchParamsLike = {
+  get(name: string): string | null;
+  getAll?(name: string): string[];
+  toString(): string;
+};
+
+export interface TransactionsUrlState {
+  filters: TransactionFilters;
+  page: number;
+}
+
+export function cloneSortConfigs(
+  configs: readonly SortConfig[],
+): SortConfig[] {
+  return configs.map(({ field, direction }) => ({ field, direction }));
+}
+
+export function createDefaultTransactionFilters(): TransactionFilters {
+  return {
+    searchQuery: "",
+    filterQuery: "",
+    ...getDefaultDateRange(),
+    selectedFilter: DEFAULT_SELECTED_FILTER,
+    sortConfigs: cloneSortConfigs(DEFAULT_SORT_CONFIGS),
+  };
+}
+
+/**
+ * Validates that a string is a valid ISO 8601 calendar date (`YYYY-MM-DD`).
+ * Checks month and day boundaries strictly without auto-rollover
+ * (e.g. rejects `2024-02-30` or `2023-02-29`).
+ */
+export function isValidIsoDate(value: string | null | undefined): value is string {
+  if (!value || !ISO_DATE_PATTERN.test(value)) return false;
+
+  const [yearStr, monthStr, dayStr] = value.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+
+  if (month < 1 || month > 12 || day < 1 || day > 31) return false;
+
+  const parsedDate = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(parsedDate.getTime())) return false;
+
+  // Verify that UTC year, month, and day match the input components
+  return (
+    parsedDate.getUTCFullYear() === year &&
+    parsedDate.getUTCMonth() + 1 === month &&
+    parsedDate.getUTCDate() === day
+  );
+}
+
+export function isSortField(value: string): value is SortField {
+  return (SORT_FIELDS as readonly string[]).includes(value as SortField);
+}
+
+export function isSortDirection(value: string): value is SortDirection {
+  return (SORT_DIRECTIONS as readonly string[]).includes(
+    value as SortDirection,
+  );
+}
+
+/**
+ * Safely extracts the first valid, non-empty value for a query parameter,
+ * supporting both single-valued `.get()` and repeated `.getAll()`.
+ */
+function getFirstParamValue(
+  searchParams: SearchParamsLike,
+  key: string,
+): string | null {
+  if (typeof searchParams.getAll === "function") {
+    const all = searchParams.getAll(key);
+    if (all && all.length > 0) {
+      for (const item of all) {
+        if (typeof item === "string" && item.trim().length > 0) {
+          return item.trim();
+        }
+      }
+    }
+  }
+  const val = searchParams.get(key);
+  return val ? val.trim() : null;
+}
+
+export function parsePage(value: string | null | undefined): number {
+  if (!value) return 1;
+  const numericValue = Number(value);
+  return Number.isInteger(numericValue) && numericValue > 0 ? numericValue : 1;
+}
+
+export function parseSelectedFilter(
+  value: string | null | undefined,
+): string {
+  if (!value) return DEFAULT_SELECTED_FILTER;
+
+  const normalizedValue = value.trim().toLowerCase();
+  if (normalizedValue in FILTER_QUERY_VALUE_TO_LABEL) {
+    return FILTER_QUERY_VALUE_TO_LABEL[normalizedValue];
+  }
+
+  const matchingLabel = Object.values(FILTER_QUERY_VALUE_TO_LABEL).find(
+    (label) => label.toLowerCase() === normalizedValue,
+  );
+
+  return matchingLabel ?? DEFAULT_SELECTED_FILTER;
+}
+
+export function serializeSelectedFilter(label: string): string {
+  return FILTER_LABEL_TO_QUERY_VALUE[label] ?? "all";
+}
+
+/**
+ * Parses sort configurations from a query string token (e.g. `date.desc,amount.asc`
+ * or `date:desc`). Only allowlisted sort fields and directions are accepted.
+ * Up to 2 distinct sort fields are parsed.
+ */
+export function parseSortConfigs(value: string | null | undefined): SortConfig[] {
+  if (!value) return cloneSortConfigs(DEFAULT_SORT_CONFIGS);
+
+  const seenFields = new Set<SortField>();
+  const sortConfigs: SortConfig[] = [];
+
+  // Support encoded commas or multiple tokens
+  const tokens = value.split(/[,\s]+/);
+
+  for (const rawToken of tokens) {
+    if (sortConfigs.length >= 2) break;
+
+    const token = rawToken.trim();
+    if (!token) continue;
+
+    // Support both `date.desc` and `date:desc`
+    const [field, direction] = token.split(/[.:]/);
+    if (!field || !direction) continue;
+
+    const normalizedField = field.trim().toLowerCase();
+    const normalizedDir = direction.trim().toLowerCase();
+
+    if (
+      !isSortField(normalizedField) ||
+      !isSortDirection(normalizedDir)
+    ) {
+      continue;
+    }
+
+    if (seenFields.has(normalizedField)) continue;
+
+    seenFields.add(normalizedField);
+    sortConfigs.push({
+      field: normalizedField,
+      direction: normalizedDir,
+    });
+  }
+
+  return sortConfigs.length > 0
+    ? sortConfigs
+    : cloneSortConfigs(DEFAULT_SORT_CONFIGS);
+}
+
+/**
+ * Serializes sort configurations into a canonical `field.direction` string.
+ * Strips invalid fields/directions and caps at 2 sort criteria.
+ */
+export function serializeSortConfigs(
+  configs: readonly SortConfig[],
+): string {
+  const seenFields = new Set<SortField>();
+  const safeConfigs = configs.filter(({ field, direction }) => {
+    if (!isSortField(field) || !isSortDirection(direction)) return false;
+    if (seenFields.has(field)) return false;
+    seenFields.add(field);
+    return true;
+  });
+
+  const configsToSerialize =
+    safeConfigs.length > 0
+      ? safeConfigs
+      : cloneSortConfigs(DEFAULT_SORT_CONFIGS);
+
+  return configsToSerialize
+    .slice(0, 2)
+    .map(({ field, direction }) => `${field}.${direction}`)
+    .join(",");
+}
+
+/**
+ * Deterministically parses transaction filter and pagination state from URL search params.
+ * Safely ignores unknown, sensitive, or malformed parameters.
+ */
+export function parseTransactionsUrlState(
+  searchParams: SearchParamsLike,
+  defaults: TransactionFilters = createDefaultTransactionFilters(),
+): TransactionsUrlState {
+  const fromDateParam = getFirstParamValue(
+    searchParams,
+    TRANSACTIONS_QUERY_KEYS.fromDate,
+  );
+  const toDateParam = getFirstParamValue(
+    searchParams,
+    TRANSACTIONS_QUERY_KEYS.toDate,
+  );
+
+  let fromDate = isValidIsoDate(fromDateParam)
+    ? fromDateParam
+    : defaults.fromDate;
+  let toDate = isValidIsoDate(toDateParam) ? toDateParam : defaults.toDate;
+
+  // Inverted range check: if start date is after end date, fallback to defaults
+  if (new Date(fromDate) > new Date(toDate)) {
+    fromDate = defaults.fromDate;
+    toDate = defaults.toDate;
+  }
+
+  const rawSearch = getFirstParamValue(
+    searchParams,
+    TRANSACTIONS_QUERY_KEYS.search,
+  );
+  const searchQuery = rawSearch ? rawSearch.trim() : "";
+
+  const filterParam = getFirstParamValue(
+    searchParams,
+    TRANSACTIONS_QUERY_KEYS.filter,
+  );
+  const selectedFilter = parseSelectedFilter(filterParam);
+
+  const sortParam = getFirstParamValue(
+    searchParams,
+    TRANSACTIONS_QUERY_KEYS.sort,
+  );
+  const sortConfigs = parseSortConfigs(sortParam);
+
+  const pageParam = getFirstParamValue(
+    searchParams,
+    TRANSACTIONS_QUERY_KEYS.page,
+  );
+  const page = parsePage(pageParam);
+
+  return {
+    filters: {
+      ...defaults,
+      searchQuery,
+      selectedFilter,
+      fromDate,
+      toDate,
+      sortConfigs,
+    },
+    page,
+  };
+}
+
+export interface BuildQueryStringOptions {
+  /**
+   * When true (default for shareable links), strips any parameter not in the
+   * allowlist and strips all known sensitive keys (wallet, address, secret, etc.).
+   */
+  stripSensitiveAndUnlisted?: boolean;
+}
+
+/**
+ * Builds a clean, deterministic query string for transaction state.
+ *
+ * By default, retains unrelated safe query parameters (like UI tabs) while
+ * purging known sensitive keys (like wallet addresses, accounts, secrets).
+ * When `stripSensitiveAndUnlisted: true`, guarantees that ONLY allowlisted
+ * transaction parameters are included.
+ */
+export function buildTransactionsQueryString(
+  currentSearchParams: SearchParamsLike,
+  state: TransactionsUrlState,
+  defaults: TransactionFilters = createDefaultTransactionFilters(),
+  options: BuildQueryStringOptions = {},
+): string {
+  const { stripSensitiveAndUnlisted = false } = options;
+  const currentParams = new URLSearchParams(currentSearchParams.toString());
+  const nextParams = new URLSearchParams();
+
+  if (stripSensitiveAndUnlisted) {
+    // Only copy over allowlisted params that are active in state below
+  } else {
+    // Copy existing params excluding transaction keys and sensitive keys
+    for (const [key, value] of currentParams.entries()) {
+      const lowerKey = key.toLowerCase();
+      if (
+        ALLOWLISTED_QUERY_KEY_SET.has(key) ||
+        SENSITIVE_QUERY_KEY_SET.has(lowerKey)
+      ) {
+        continue;
+      }
+      nextParams.append(key, value);
+    }
+  }
+
+  const searchQuery = state.filters.searchQuery?.trim() ?? "";
+  if (searchQuery.length > 0) {
+    nextParams.set(TRANSACTIONS_QUERY_KEYS.search, searchQuery);
+  }
+
+  const selectedFilter = serializeSelectedFilter(state.filters.selectedFilter);
+  if (selectedFilter !== "all") {
+    nextParams.set(TRANSACTIONS_QUERY_KEYS.filter, selectedFilter);
+  }
+
+  if (
+    state.filters.fromDate &&
+    isValidIsoDate(state.filters.fromDate) &&
+    state.filters.fromDate !== defaults.fromDate
+  ) {
+    nextParams.set(TRANSACTIONS_QUERY_KEYS.fromDate, state.filters.fromDate);
+  }
+
+  if (
+    state.filters.toDate &&
+    isValidIsoDate(state.filters.toDate) &&
+    state.filters.toDate !== defaults.toDate
+  ) {
+    nextParams.set(TRANSACTIONS_QUERY_KEYS.toDate, state.filters.toDate);
+  }
+
+  const serializedSort = serializeSortConfigs(state.filters.sortConfigs);
+  const defaultSortSerialized = serializeSortConfigs(defaults.sortConfigs);
+  if (serializedSort !== defaultSortSerialized) {
+    nextParams.set(TRANSACTIONS_QUERY_KEYS.sort, serializedSort);
+  }
+
+  if (state.page > 1) {
+    nextParams.set(TRANSACTIONS_QUERY_KEYS.page, String(state.page));
+  }
+
+  return nextParams.toString();
+}
+
+/**
+ * Builds a standalone shareable URL or query string containing ONLY
+ * allowlisted filter/sort/pagination parameters.
+ */
+export function buildShareableTransactionsQueryString(
+  state: TransactionsUrlState,
+  defaults: TransactionFilters = createDefaultTransactionFilters(),
+): string {
+  return buildTransactionsQueryString(
+    new URLSearchParams(),
+    state,
+    defaults,
+    { stripSensitiveAndUnlisted: true },
+  );
+}
+
+/**
+ * Formats a full pathname with the shareable query string.
+ */
+export function buildShareableTransactionsUrl(
+  pathname: string,
+  state: TransactionsUrlState,
+  defaults: TransactionFilters = createDefaultTransactionFilters(),
+): string {
+  const query = buildShareableTransactionsQueryString(state, defaults);
+  return query ? `${pathname}?${query}` : pathname;
+}

--- a/design/security-headers-check.md
+++ b/design/security-headers-check.md
@@ -1,0 +1,52 @@
+# Security Headers — Production Preview Check
+
+This document explains the acceptance-criteria test added for
+[#1174](https://github.com/Stellopay/stellopay-frontend/issues/1174): make the
+deployed preview prove it serves the intended security policy.
+
+## Outcome
+
+- Required headers (`Content-Security-Policy`, `X-Frame-Options`,
+  `Strict-Transport-Security`, `Referrer-Policy`, `X-Content-Type-Options`)
+  are asserted on representative routes and a hashed static asset.
+- The policy rejects unsafe inline scripts (`'unsafe-inline'`, `'unsafe-eval'`
+  in `script-src`) and cross-origin framing (`frame-ancestors 'none'`).
+- Failures name the missing or weakened header and directive.
+
+## Source of truth
+
+The exact header values live once in `lib/security-headers.ts` and are wired
+into `next.config.ts` via the `headers()` hook. Both the unit tests
+(`lib/security-headers.test.ts`) and the preview check
+(`tests/security-headers.spec.ts`) import that module, so the policy cannot
+drift from what the server actually sends.
+
+## Validation
+
+### 1. Unit coverage
+
+```bash
+npx vitest run lib/security-headers.test.ts --coverage.enabled=false
+```
+
+### 2. Against a local production build
+
+Build and run the production server, then point the preview check at it:
+
+```bash
+npm run build
+npm run start   # next start, default port 3000
+npm run test:security-headers
+```
+
+### 3. Against a configured preview
+
+Point Playwright at the deployment URL:
+
+```bash
+BASE_URL=https://<preview-url> npx playwright test tests/security-headers.spec.ts --project=chromium
+```
+
+The check uses `request.get()` with redirect-following, so authenticated
+routes that 307 to the public session-expired page still get their headers
+verified on the final response.

--- a/hooks/usePendingAction.test.tsx
+++ b/hooks/usePendingAction.test.tsx
@@ -1,0 +1,130 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { usePendingAction } from "./usePendingAction";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("usePendingAction", () => {
+  it("starts idle with no error", () => {
+    const { result } = renderHook(() => usePendingAction());
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("marks pending while the action runs and clears it afterwards", async () => {
+    const d = deferred<void>();
+    const action = vi.fn(() => d.promise);
+    const { result } = renderHook(() => usePendingAction());
+
+    let runPromise: Promise<boolean> | undefined;
+    act(() => {
+      runPromise = result.current.run(action);
+    });
+
+    expect(result.current.isPending).toBe(true);
+    expect(action).toHaveBeenCalledTimes(1);
+
+    await act(async () => d.resolve());
+    const succeeded = await runPromise;
+    expect(succeeded).toBe(true);
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("ignores a second run while one is still in flight (the action runs once)", async () => {
+    const d = deferred<void>();
+    const action = vi.fn(() => d.promise);
+    const { result } = renderHook(() => usePendingAction());
+
+    let first: Promise<boolean> | undefined;
+    let second: Promise<boolean> | undefined;
+    act(() => {
+      first = result.current.run(action);
+      second = result.current.run(action);
+    });
+    expect(action).toHaveBeenCalledTimes(1);
+
+    await act(async () => d.resolve());
+    expect(await first).toBe(true);
+    expect(await second).toBe(false);
+  });
+
+  it("surfaces a rejection and returns false so the caller can retry", async () => {
+    const action = vi.fn(() => Promise.reject(new Error("Network down")));
+    const { result } = renderHook(() => usePendingAction());
+
+    let runPromise: Promise<boolean> | undefined;
+    act(() => {
+      runPromise = result.current.run(action);
+    });
+
+    await act(async () => {
+      await runPromise;
+    });
+    expect(result.current.error).toBe("Network down");
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("uses the generic message when a rejection carries no error message", async () => {
+    const action = vi.fn(() => Promise.reject(new Error("")));
+    const { result } = renderHook(() =>
+      usePendingAction({ genericErrorMessage: "Nope." }),
+    );
+
+    await act(async () => {
+      await result.current.run(action);
+    });
+
+    expect(result.current.error).toBe("Nope.");
+  });
+
+  it("re-runs after a failure when asked (retry path)", async () => {
+    const action = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("First attempt failed"))
+      .mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => usePendingAction());
+
+    let first: Promise<boolean> | undefined;
+    let second: Promise<boolean> | undefined;
+    await act(async () => {
+      first = result.current.run(action);
+      second = undefined;
+    });
+    await act(async () => {
+      await first;
+    });
+    expect(result.current.error).not.toBeNull();
+    expect(action).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      second = result.current.run(action);
+    });
+    await act(async () => {
+      await second;
+    });
+    expect(result.current.error).toBeNull();
+    expect(action).toHaveBeenCalledTimes(2);
+  });
+
+  it("reset clears a stored error", async () => {
+    const action = vi.fn(() => Promise.reject(new Error("boom")));
+    const { result } = renderHook(() => usePendingAction());
+
+    await act(async () => {
+      await result.current.run(action);
+    });
+    expect(result.current.error).toBe("boom");
+
+    act(() => result.current.reset());
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/hooks/usePendingAction.ts
+++ b/hooks/usePendingAction.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+export interface UsePendingActionOptions {
+  /** Human-readable error to show when the action rejects with no message. */
+  genericErrorMessage?: string;
+}
+
+export interface UsePendingActionResult {
+  /** `true` while the action is in flight (confirm button disabled/loading). */
+  isPending: boolean;
+  /** Message from the most recent rejected attempt, or `null` when idle. */
+  error: string | null;
+  /**
+   * Runs `action` exactly once per confirmation. Any call made while a run is
+   * still in flight is ignored, so a double click or keyboard repeat can never
+   * issue the request twice.
+   *
+   * Resolves `true` when the action completed, `false` when it rejected
+   * (in which case `error` is populated and the caller may retry).
+   */
+  run: (action: () => void | Promise<void>) => Promise<boolean>;
+  /** Clears the stored error (e.g. when the user starts over). */
+  reset: () => void;
+}
+
+/**
+ * Centralizes the "one request per confirmation" guard shared by destructive
+ * action dialogs.
+ *
+ * - The first `run` call wins; later calls before the previous run settles are
+ *   no-ops (idempotent from the UI's perspective), which makes rapid double
+ *   clicks and held/repeated Enter keys safe.
+ * - While a run is pending, `isPending` is `true` so the caller can disable its
+ *   controls and show progress.
+ * - A rejected attempt leaves `error` populated and resolves `false`, letting
+ *   the caller keep its dialog open and offer a retry.
+ */
+export function usePendingAction(
+  options: UsePendingActionOptions = {},
+): UsePendingActionResult {
+  const { genericErrorMessage = "Something went wrong. Please try again." } =
+    options;
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inFlightRef = useRef(false);
+
+  const run = useCallback(
+    async (action: () => void | Promise<void>) => {
+      if (inFlightRef.current) {
+        return false;
+      }
+
+      inFlightRef.current = true;
+      setIsPending(true);
+      setError(null);
+
+      try {
+        await action();
+        return true;
+      } catch (caught) {
+        setError(
+          caught instanceof Error && caught.message
+            ? caught.message
+            : genericErrorMessage,
+        );
+        return false;
+      } finally {
+        inFlightRef.current = false;
+        setIsPending(false);
+      }
+    },
+    [genericErrorMessage],
+  );
+
+  const reset = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return { isPending, error, run, reset };
+}

--- a/lib/api/__tests__/transactions.test.ts
+++ b/lib/api/__tests__/transactions.test.ts
@@ -2,9 +2,11 @@ import {
   MAX_TRANSACTION_PAGE_SIZE,
   MIN_TRANSACTION_PAGE_SIZE,
   getTransactions,
+  getTransactionsCursor,
   getAccountSummary,
   getPaymentHistory,
 } from "../transactions";
+import { allTransactions } from "@/lib/transactions";
 
 beforeAll(() => {
   vi.stubEnv("NODE_ENV", "test");
@@ -164,6 +166,129 @@ describe("getTransactions", () => {
       expect(typeof t.amount).toBe("number");
       expect(["Completed", "Pending", "Failed"]).toContain(t.status);
     });
+  });
+});
+
+// ─── Resilient cursor (keyset) pagination ──────────────────────────────────
+//
+// Cursor pagination resumes "after the boundary record" in a stable total
+// order (sort criteria + id tiebreaker) instead of by a numeric offset, so
+// records deleted or reordered between requests cannot duplicate or skip rows.
+
+describe("getTransactionsCursor", () => {
+  // Snapshot/restore the shared mock dataset so deletion tests never leak.
+  const originalData = [...allTransactions];
+
+  afterEach(() => {
+    allTransactions.splice(0, allTransactions.length, ...originalData);
+  });
+
+  it("walks the whole list with no duplicate ids across adjacent pages", async () => {
+    const seen = new Set<string>();
+    let cursor: string | null = null;
+    let pageCount = 0;
+
+    do {
+      const page = await getTransactionsCursor({ pageSize: 2, cursor });
+      expect(page.data.length).toBeGreaterThan(0);
+      for (const t of page.data) {
+        expect(seen.has(t.id)).toBe(false); // adjacent pages never duplicate
+        seen.add(t.id);
+      }
+      pageCount += 1;
+      cursor = page.nextCursor;
+      expect(page.hasMore).toBe(cursor !== null);
+    } while (cursor !== null);
+
+    expect(pageCount).toBeGreaterThan(1);
+    expect(seen.size).toBe(originalData.length);
+  });
+
+  it("overlap across pages is impossible: next page never re-sends a returned id", async () => {
+    const page1 = await getTransactionsCursor({ pageSize: 2 });
+    const page1Ids = page1.data.map((t) => t.id);
+
+    const page2 = await getTransactionsCursor({ pageSize: 2, cursor: page1.nextCursor });
+    const page2Ids = page2.data.map((t) => t.id);
+
+    const intersection = page1Ids.filter((id) => page2Ids.includes(id));
+    expect(intersection).toEqual([]);
+  });
+
+  it("deleted records do not break subsequent pagination", async () => {
+    const page1 = await getTransactionsCursor({ pageSize: 2 });
+    const sentIds = new Set(page1.data.map((t) => t.id));
+
+    // Simulate a backend deletion of a record that was already returned.
+    const toDelete = allTransactions.find((t) => sentIds.has(t.id));
+    expect(toDelete).toBeDefined();
+    const deleteIndex = allTransactions.indexOf(toDelete!);
+    allTransactions.splice(deleteIndex, 1);
+
+    const page2 = await getTransactionsCursor({ pageSize: 2, cursor: page1.nextCursor });
+    expect(page2.total).toBe(originalData.length - 1);
+
+    // No duplicate of an already-seen id, and it still completes the walk.
+    const allIds = new Set(sentIds);
+    for (const t of page2.data) {
+      expect(allIds.has(t.id)).toBe(false);
+      allIds.add(t.id);
+    }
+  });
+
+  it("deleting a record before the boundary does not shift the next page", async () => {
+    const pageSize = 2;
+    const page1 = await getTransactionsCursor({ pageSize });
+    const boundary = page1.nextCursor;
+
+    // Record the full expected continuation by walking the *unmodified* data.
+    const page2Unmodified = await getTransactionsCursor({ pageSize, cursor: boundary });
+    const expectedIds = page2Unmodified.data.map((t) => t.id);
+
+    // Now delete one of the *earlier* (already-returned) records and re-request.
+    const toDelete = allTransactions.find((t) => !expectedIds.includes(t.id));
+    expect(toDelete).toBeDefined();
+    allTransactions.splice(allTransactions.indexOf(toDelete!), 1);
+
+    const page2AfterDeletion = await getTransactionsCursor({ pageSize, cursor: boundary });
+    const actualIds = page2AfterDeletion.data.map((t) => t.id);
+    expect(actualIds).toEqual(expectedIds);
+  });
+
+  it("repeated cursors are deterministic and never loop", async () => {
+    const page1 = await getTransactionsCursor({ pageSize: 2 });
+    const page1Ids = page1.data.map((t) => t.id);
+
+    const repeatA = await getTransactionsCursor({ pageSize: 2, cursor: page1.nextCursor });
+    const repeatB = await getTransactionsCursor({ pageSize: 2, cursor: page1.nextCursor });
+
+    expect(repeatA.data.map((t) => t.id)).toEqual(repeatB.data.map((t) => t.id));
+    expect(repeatA.nextCursor).toBe(repeatB.nextCursor);
+    expect(repeatA.hasMore).toBe(repeatB.hasMore);
+    expect(repeatA.nextCursor).not.toBe(page1.nextCursor); // advanced past page 1
+    expect(page1Ids.includes(repeatA.data[0]?.id)).toBe(false);
+  });
+
+  it("stops cleanly at the end of the list", async () => {
+    // With a page size >= total, one request returns everything and ends the list.
+    const first = await getTransactionsCursor({ pageSize: 100 });
+    expect(first.hasMore).toBe(false);
+    expect(first.nextCursor).toBeNull();
+  });
+
+  it("treats an invalid cursor as the first page instead of looping", async () => {
+    const result = await getTransactionsCursor({ pageSize: 2, cursor: "!!!not-a-cursor!!!" });
+    expect(result.data).toHaveLength(2);
+    expect(result.total).toBe(originalData.length);
+  });
+
+  it("honours filters and reports the filtered total", async () => {
+    const result = await getTransactionsCursor({
+      filters: { selectedFilter: "Payment Sent" },
+      pageSize: 100,
+    });
+    expect(result.total).toBeGreaterThan(0);
+    result.data.forEach((t) => expect(t.type).toBe("Payment Sent"));
   });
 });
 

--- a/lib/api/authRecovery.test.ts
+++ b/lib/api/authRecovery.test.ts
@@ -8,6 +8,7 @@ import {
   resetRecoveryState,
   AuthExpiredError,
   generateIdempotencyKey,
+  completeReauth,
 } from "./authRecovery";
 
 describe("authRecovery service", () => {
@@ -181,5 +182,94 @@ describe("authRecovery service", () => {
     const headers = new Headers(init?.headers);
     expect(headers.get("Idempotency-Key")).toBeTruthy();
     expect(headers.get("Idempotency-Key")).toMatch(/^idempotency-|^[0-9a-f-]{36}$/);
+  });
+
+  it("clears protected tokens when refresh fails (session invalidated)", async () => {
+    setTokens({ accessToken: "expired-token", csrfToken: "expired-csrf" });
+
+    const refreshHandler = vi.fn().mockRejectedValue(new Error("Refresh token expired"));
+
+    setCustomRefreshHandler(refreshHandler);
+
+    const failureListener = vi.fn();
+    setAuthFailureHandler(failureListener);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "Token expired" }), { status: 401 })
+    );
+
+    await expect(
+      authenticatedFetch("https://api.example.com/protected")
+    ).rejects.toThrow(AuthExpiredError);
+
+    // Protected tokens must be cleared on failed refresh
+    expect(getTokens()).toEqual({});
+    expect(refreshHandler).toHaveBeenCalledTimes(1);
+    expect(failureListener).toHaveBeenCalledTimes(1);
+    expect(failureListener.mock.calls[0][0]).toBeInstanceOf(AuthExpiredError);
+  });
+
+  it("allows retry with new tokens after successful refresh", async () => {
+    setTokens({ accessToken: "expired-token", csrfToken: "expired-csrf" });
+
+    let refreshCallCount = 0;
+    const refreshHandler = vi.fn().mockImplementation(async () => {
+      refreshCallCount++;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return { accessToken: "new-access-token", csrfToken: "new-csrf-token" };
+    });
+    setCustomRefreshHandler(refreshHandler);
+
+    let requestAttempts = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      requestAttempts++;
+      const headers = new Headers(init?.headers);
+
+      if (headers.get("Authorization") === "Bearer expired-token") {
+        return new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 });
+      }
+
+      if (headers.get("Authorization") === "Bearer new-access-token") {
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+
+      return new Response(null, { status: 500 });
+    });
+
+    const promises = [
+      authenticatedFetch("https://api.example.com/resource1"),
+      authenticatedFetch("https://api.example.com/resource2"),
+    ];
+
+    const results = await Promise.all(promises);
+
+    expect(results).toHaveLength(2);
+    results.forEach((res) => expect(res.status).toBe(200));
+    expect(refreshCallCount).toBe(1);
+    expect(getTokens()).toEqual({
+      accessToken: "new-access-token",
+      csrfToken: "new-csrf-token",
+    });
+  });
+
+  it("triggers reauth dialog when refresh fails via context failure handler", async () => {
+    resetRecoveryState();
+
+    const refreshHandler = vi.fn().mockRejectedValue(new Error("Invalid refresh token"));
+    setCustomRefreshHandler(refreshHandler);
+
+    const failureListener = vi.fn();
+    setAuthFailureHandler(failureListener);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "Token expired" }), { status: 401 })
+    );
+
+    await expect(
+      authenticatedFetch("https://api.example.com/protected")
+    ).rejects.toThrow(AuthExpiredError);
+
+    expect(failureListener).toHaveBeenCalledTimes(1);
+    expect(failureListener.mock.calls[0][0]).toBeInstanceOf(AuthExpiredError);
   });
 });

--- a/lib/api/authRecovery.ts
+++ b/lib/api/authRecovery.ts
@@ -80,6 +80,7 @@ export function generateIdempotencyKey(): string {
 /**
  * Executes a deduplicated token refresh attempt.
  * Multiple concurrent callers will receive the same shared Promise.
+ * On failure, protected tokens are cleared and pending queue is rejected.
  */
 
 export async function requestTokenRefresh(): Promise<TokenState> {
@@ -95,6 +96,9 @@ export async function requestTokenRefresh(): Promise<TokenState> {
       setTokens(newTokens);
       return newTokens;
     } catch (err) {
+      // Clear protected tokens on unrecoverable refresh failure
+      currentTokens = {};
+
       const authError =
         err instanceof AuthExpiredError
           ? err

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -5,9 +5,12 @@ export {
   getAccountSummary,
   getPaymentHistory,
   getTransactions,
+  getTransactionsCursor,
 } from "./transactions";
 export type {
   AccountSummary,
+  CursorPaginatedTransactions,
+  GetTransactionsCursorParams,
   GetTransactionsParams,
   PaginatedTransactions,
   PaymentHistoryItem,

--- a/lib/api/transactions.ts
+++ b/lib/api/transactions.ts
@@ -6,11 +6,15 @@
  * replace the mock return with a fetch() call to NEXT_PUBLIC_API_BASE_URL.
  */
 
-import type { Transaction, TransactionFilters } from "@/types/transaction";
+import type {
+  Transaction,
+  TransactionFilters,
+  SortField,
+  SortConfig,
+} from "@/types/transaction";
 import { allTransactions } from "@/lib/transactions";
 import {
   filterTransactions,
-  sortTransactionsMulti,
 } from "@/utils/transactionUtils";
 
 export interface PaginatedTransactions {
@@ -24,6 +28,36 @@ export interface PaginatedTransactions {
 export interface GetTransactionsParams {
   filters?: Partial<TransactionFilters>;
   page?: number;
+  pageSize?: number;
+}
+
+/**
+ * A single page of cursor-based (keyset) pagination.
+ *
+ * Unlike offset-based pages, a cursor identifies *where the previous page
+ * ended* in a stable order, so records deleted or reordered between requests
+ * cannot shift the window and cause duplicates or skips.
+ *
+ * - {@link CursorPaginatedTransactions.nextCursor}: an opaque token that must
+ *   be passed back as {@link GetTransactionsCursorParams.cursor} to fetch the
+ *   next page. It is `null` when there are no more records — this is the
+ *   end-of-list signal.
+ * - {@link CursorPaginatedTransactions.hasMore}: short-hand for
+ *   `nextCursor !== null`.
+ * - {@link CursorPaginatedTransactions.total}: the total number of matching
+ *   records (independent of pagination), for building page-number UIs.
+ */
+export interface CursorPaginatedTransactions {
+  data: Transaction[];
+  total: number;
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+export interface GetTransactionsCursorParams {
+  filters?: Partial<TransactionFilters>;
+  /** Opaque cursor from a previous page. Omitting it starts from the first record. */
+  cursor?: string | null;
   pageSize?: number;
 }
 
@@ -72,6 +106,275 @@ const normalizeDateFilter = (
 
   return value;
 };
+
+// ── Stable ordering + keyset pagination helpers ────────────────────────────
+//
+// Offset-based pagination ("slice index n..n+pageSize") duplicates or skips
+// rows whenever the underlying dataset is reordered or has records deleted
+// between requests. To make pagination resilient we:
+//
+// 1. Sort by a *stable total order* — the caller's sort criteria plus an `id`
+//    tiebreaker — so every record has a unique, deterministic position.
+// 2. Paginate by *keyset*: the returned cursor captures the boundary record's
+//    sort values + id, and the next request continues strictly after that
+//    boundary by comparison, not by a fragile absolute index. Deleting
+//    earlier records never shifts the window.
+// 3. Deduplicate by identity (`id`), and expose an explicit end-of-list signal
+//    (`nextCursor === null` / `hasMore === false`) so a repeated cursor can
+//    never spin into an infinite request loop.
+
+/** A normalized, comparable sort-key value for a single sort field. */
+type CursorSortValue = number | string;
+
+/** Encodes a record's position in the stable order for keyset resumption. */
+interface CursorPayload {
+  /** Normalized sort-key values, one per sort config (in config order). */
+  values: CursorSortValue[];
+  /** Boundary record id (final tiebreaker — unique). */
+  id: string;
+}
+
+const normalizeSortValue = (
+  transaction: Transaction,
+  field: SortField,
+): CursorSortValue => {
+  switch (field) {
+    case "date": {
+      const parsed = new Date(transaction.date);
+      const time = Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime();
+      return time;
+    }
+    case "amount": {
+      const amount = Math.abs(transaction.amount);
+      return Number.isFinite(amount) ? amount : 0;
+    }
+    case "type":
+      return transaction.type;
+    case "status":
+      return transaction.status;
+    default:
+      return transaction.status;
+  }
+};
+
+const compareCursorValues = (a: CursorSortValue, b: CursorSortValue): number => {
+  if (typeof a === "number" && typeof b === "number") {
+    return a < b ? -1 : a > b ? 1 : 0;
+  }
+  const sa = String(a);
+  const sb = String(b);
+  return sa < sb ? -1 : sa > sb ? 1 : 0;
+};
+
+const compareStable = (
+  aValues: CursorSortValue[],
+  aId: string,
+  bValues: CursorSortValue[],
+  bId: string,
+  sortConfigs: SortConfig[],
+): number => {
+  for (let i = 0; i < sortConfigs.length; i += 1) {
+    const raw = compareCursorValues(aValues[i], bValues[i]);
+    if (raw !== 0) {
+      return sortConfigs[i].direction === "asc" ? raw : -raw;
+    }
+  }
+  // Id is the deterministic total order tiebreaker, always ascending.
+  return aId < bId ? -1 : aId > bId ? 1 : 0;
+};
+
+const stableSort = (
+  transactions: Transaction[],
+  sortConfigs: SortConfig[],
+): { transaction: Transaction; values: CursorSortValue[] }[] => {
+  const decorated = transactions.map((transaction) => ({
+    transaction,
+    values: sortConfigs.map(({ field }) => normalizeSortValue(transaction, field)),
+  }));
+
+  return decorated.sort((a, b) =>
+    compareStable(
+      a.values,
+      a.transaction.id,
+      b.values,
+      b.transaction.id,
+      sortConfigs,
+    ),
+  );
+};
+
+const encodeCursor = (payload: CursorPayload): string =>
+  encodeURIComponent(JSON.stringify(payload));
+
+/**
+ * Decodes an opaque pagination cursor.
+ * Returns `null` for a missing cursor, an invalid token, or a malformed
+ * payload — an untrusted/invalid cursor is treated as "start from the
+ * beginning" rather than throwing or looping.
+ */
+const decodeCursor = (cursor: string | null | undefined): CursorPayload | null => {
+  if (cursor === undefined || cursor === null || cursor === "") return null;
+
+  try {
+    const parsed: unknown = JSON.parse(decodeURIComponent(cursor));
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !Array.isArray((parsed as CursorPayload).values) ||
+      typeof (parsed as CursorPayload).id !== "string"
+    ) {
+      return null;
+    }
+    return parsed as CursorPayload;
+  } catch {
+    return null;
+  }
+};
+
+const DEFAULT_SORT_CONFIGS: readonly SortConfig[] = [
+  { field: "date", direction: "desc" },
+];
+
+/** Normalizes sort configs to a non-empty list (falling back to the default). */
+const normalizeSortConfigs = (
+  sortConfigs: SortConfig[] | undefined,
+): SortConfig[] =>
+  sortConfigs && sortConfigs.length > 0
+    ? sortConfigs
+    : [...DEFAULT_SORT_CONFIGS];
+
+/** Applies filters, validates date filters, and sorts into a stable total order. */
+const stableSortFilter = (
+  filters: Partial<TransactionFilters>,
+): { transaction: Transaction; values: CursorSortValue[] }[] => {
+  const {
+    searchQuery = "",
+    filterQuery = "",
+    selectedFilter = "All Transactions",
+    fromDate = MOCK_FROM_DATE,
+    toDate = MOCK_TO_DATE,
+    minAmount,
+    maxAmount,
+    counterparty,
+  } = filters;
+
+  const safeFromDate = normalizeDateFilter(fromDate, MOCK_FROM_DATE, "fromDate");
+  const safeToDate = normalizeDateFilter(toDate, MOCK_TO_DATE, "toDate");
+
+  const filtered = filterTransactions(
+    allTransactions,
+    searchQuery,
+    selectedFilter,
+    safeFromDate,
+    safeToDate,
+    filterQuery,
+    minAmount,
+    maxAmount,
+    counterparty,
+  );
+
+  return stableSort(filtered, normalizeSortConfigs(filters.sortConfigs));
+};
+
+/**
+ * Shared abortable dev-mode delay used by the resilient pagination API so the
+ * demo UI exercises its loading states. When `signal` fires mid-delay (or is
+ * already aborted), it rejects with a `DOMException` whose `.name` is
+ * `"AbortError"`.
+ */
+const abortableDelay = (signal?: AbortSignal): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    const timeoutId = setTimeout(() => resolve(), 400);
+
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+
+/**
+ * Fetch a page of transactions using resilient keyset (cursor) pagination.
+ *
+ * Every page returns an opaque {@link CursorPaginatedTransactions.nextCursor}
+ * that must be passed back via {@link GetTransactionsCursorParams.cursor}.
+ * Because pagination resumes "after this boundary record" in a stable
+ * total order (sort criteria + `id` tiebreaker) rather than by a numeric
+ * offset:
+ *
+ * - **Deletion resilience** — a record deleted between requests cannot shift
+ *   the window; the next page continues after the boundary by comparison.
+ * - **No duplicates** — identity is the total-order tiebreaker and each page
+ *   is deduplicated by `id`, so adjacent pages never render the same id.
+ * - **End-of-list policy** — when fewer than `pageSize` records remain (or
+ *   none), `nextCursor` is `null` so `hasMore` is `false`. Passing a repeated
+ *   cursor deterministically returns the same page, so callers can never
+ *   trigger an infinite request loop.
+ *
+ * An invalid or missing cursor is treated as "first page".
+ *
+ * @throws {RangeError} When `filters.fromDate` or `filters.toDate` is
+ *   non-empty and cannot be parsed as a valid date.
+ */
+export async function getTransactionsCursor(
+  params: GetTransactionsCursorParams = {},
+  signal?: AbortSignal,
+): Promise<CursorPaginatedTransactions> {
+  const { filters = {}, cursor, pageSize: requestedPageSize } = params;
+
+  const safePageSize = normalizePositiveInteger(
+    requestedPageSize,
+    DEFAULT_TRANSACTION_PAGE_SIZE,
+    MIN_TRANSACTION_PAGE_SIZE,
+    MAX_TRANSACTION_PAGE_SIZE,
+  );
+
+  if (process.env.NODE_ENV === "development") {
+    await abortableDelay(signal);
+  }
+  if (signal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
+
+  const sortConfigs = normalizeSortConfigs(filters.sortConfigs);
+  const appliedStable = stableSortFilter(filters);
+
+  // Only consider records strictly after the boundary cursor (keyset window).
+  const boundary = decodeCursor(cursor);
+  let window = appliedStable;
+  if (boundary) {
+    window = appliedStable.filter(({ transaction, values }) =>
+      compareStable(
+        values,
+        transaction.id,
+        boundary.values,
+        boundary.id,
+        sortConfigs,
+      ) > 0,
+    );
+  }
+
+  const page = window.slice(0, safePageSize);
+  const remaining = window.length - page.length;
+  const last = page[page.length - 1];
+
+  return {
+    data: page.map(({ transaction }) => transaction),
+    total: appliedStable.length,
+    nextCursor:
+      remaining > 0 && last
+        ? encodeCursor({ values: last.values, id: last.transaction.id })
+        : null,
+    hasMore: remaining > 0,
+  };
+}
 
 /**
  * Fetch a paginated, filtered, sorted list of transactions.
@@ -159,18 +462,6 @@ export async function getTransactions(
     pageSize: requestedPageSize = DEFAULT_TRANSACTION_PAGE_SIZE,
   } = params;
 
-  const {
-    searchQuery = "",
-    filterQuery = "",
-    selectedFilter = "All Transactions",
-    fromDate = MOCK_FROM_DATE,
-    toDate = MOCK_TO_DATE,
-    minAmount,
-    maxAmount,
-    sortConfigs = [{ field: "date" as const, direction: "desc" as const }],
-    counterparty,
-  } = filters;
-
   const safePageSize = normalizePositiveInteger(
     requestedPageSize,
     DEFAULT_TRANSACTION_PAGE_SIZE,
@@ -183,12 +474,6 @@ export async function getTransactions(
     1,
     Number.MAX_SAFE_INTEGER,
   );
-  const safeFromDate = normalizeDateFilter(
-    fromDate,
-    MOCK_FROM_DATE,
-    "fromDate",
-  );
-  const safeToDate = normalizeDateFilter(toDate, MOCK_TO_DATE, "toDate");
 
   // ── Real backend swap point ──────────────────────────────────────────────
   // const base = process.env.NEXT_PUBLIC_API_BASE_URL;
@@ -222,25 +507,15 @@ export async function getTransactions(
     throw new DOMException("Aborted", "AbortError");
   }
 
-  const filtered = filterTransactions(
-    allTransactions,
-    searchQuery,
-    selectedFilter,
-    safeFromDate,
-    safeToDate,
-    filterQuery,
-    minAmount,
-    maxAmount,
-    counterparty,
-  );
+  const stableOrder = stableSortFilter(filters);
 
-  const sorted = sortTransactionsMulti(filtered, sortConfigs);
-
-  const total = sorted.length;
+  const total = stableOrder.length;
   const totalPages = Math.max(1, Math.ceil(total / safePageSize));
   const safePage = Math.min(requestedSafePage, totalPages);
   const start = (safePage - 1) * safePageSize;
-  const data = sorted.slice(start, start + safePageSize);
+  const data = stableOrder
+    .slice(start, start + safePageSize)
+    .map(({ transaction }) => transaction);
 
   return { data, total, page: safePage, pageSize: safePageSize, totalPages };
 }

--- a/lib/security-headers.test.ts
+++ b/lib/security-headers.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONTENT_SECURITY_POLICY,
+  CSP_DIRECTIVES,
+  PERMISSIONS_POLICY,
+  REFERRER_POLICY,
+  SECURITY_HEADERS,
+  STRICT_TRANSPORT_SECURITY,
+  X_CONTENT_TYPE_OPTIONS,
+  X_FRAME_OPTIONS,
+  X_XSS_PROTECTION,
+} from "./security-headers";
+
+describe("security-headers", () => {
+  it("applies the full set of required headers", () => {
+    const keys = SECURITY_HEADERS.map((h) => h.key);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        "Content-Security-Policy",
+        "X-Frame-Options",
+        "Strict-Transport-Security",
+        "Referrer-Policy",
+        "X-Content-Type-Options",
+      ]),
+    );
+  });
+
+  it("rejects unsafe inline scripts and eval in script-src", () => {
+    const scriptSrc = CSP_DIRECTIVES.find((d) => d.startsWith("script-src"));
+    expect(scriptSrc).toBe("script-src 'self'");
+    // Explicitly assert no unsafe-inline / unsafe-eval in the script directive.
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+    expect(scriptSrc).not.toContain("'unsafe-eval'");
+  });
+
+  it("still permits inline styles required by Next/Tailwind in style-src only", () => {
+    const styleSrc = CSP_DIRECTIVES.find((d) => d.startsWith("style-src"));
+    expect(styleSrc).toContain("'self'");
+    // style-src may keep 'unsafe-inline', but script-src must not inherit it.
+    expect(
+      CSP_DIRECTIVES.find((d) => d.startsWith("script-src")),
+    ).not.toContain("'unsafe-inline'");
+  });
+
+  it("rejects all cross-origin framing via frame-ancestors 'none'", () => {
+    expect(CSP_DIRECTIVES).toContain("frame-ancestors 'none'");
+    expect(X_FRAME_OPTIONS).toBe("DENY");
+  });
+
+  it("enforces transport security via HSTS", () => {
+    expect(STRICT_TRANSPORT_SECURITY).toContain("max-age=");
+    expect(STRICT_TRANSPORT_SECURITY).toContain("includeSubDomains");
+  });
+
+  it("restricts referrer leakage to same-origin", () => {
+    expect(REFERRER_POLICY).toBe("strict-origin-when-cross-origin");
+  });
+
+  it("prevents MIME type sniffing", () => {
+    expect(X_CONTENT_TYPE_OPTIONS).toBe("nosniff");
+  });
+});

--- a/lib/security-headers.ts
+++ b/lib/security-headers.ts
@@ -1,0 +1,72 @@
+/**
+ * @file lib/security-headers.ts
+ *
+ * Single source of truth for the app's HTTP security headers.
+ *
+ * These values are consumed by:
+ *  - next.config.ts  (applied to every route via the Next.js `headers()` hook)
+ *  - tests/security-headers.spec.ts  (Playwright preview checks)
+ *
+ * Centralizing the policy here means the test asserts against the exact
+ * directives the server actually sends — a header can't drift without the
+ * check failing. A failing assertion names the header and directive that
+ * regressed, so the policy can be corrected rather than silently weakened.
+ *
+ * Requirement coverage (issue #1174):
+ *  - CSP            → Content-Security-Policy
+ *  - frame          → X-Frame-Options + CSP frame-ancestors
+ *  - transport      → Strict-Transport-Security (HSTS)
+ *  - referrer       → Referrer-Policy
+ *  - content-type   → X-Content-Type-Options
+ */
+
+/** Collectively enforced CSP directives that reject unsafe inline/cross-origin behavior. */
+export const CSP_DIRECTIVES: string[] = [
+  // No inline or eval'd scripts: resources must come from the same origin.
+  "default-src 'self'",
+  "script-src 'self'",
+  // Styles allow inline so Tailwind/Next injected <style> nodes work.
+  "style-src 'self' 'unsafe-inline'",
+  // Images may be data/blob for icons & avatars; nothing external besides self.
+  "img-src 'self' data: blob:",
+  "font-src 'self'",
+  // Same-origin API + specific Stellar network hosts only.
+  "connect-src 'self' https://stellar.org https://horizon.stellar.org https://soroban.stellar.org",
+  // Reject all framing of this site (clickjacking defence).
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "upgrade-insecure-requests",
+];
+
+/** Full serialized Content-Security-Policy header value. */
+export const CONTENT_SECURITY_POLICY = CSP_DIRECTIVES.join("; ");
+
+export const X_FRAME_OPTIONS = "DENY";
+
+/** 2-year HSTS; includeSubDomains + preload for transport security. */
+export const STRICT_TRANSPORT_SECURITY =
+  "max-age=63072000; includeSubDomains; preload";
+
+export const REFERRER_POLICY = "strict-origin-when-cross-origin";
+
+export const X_CONTENT_TYPE_OPTIONS = "nosniff";
+
+export const X_XSS_PROTECTION = "1; mode=block";
+
+export const PERMISSIONS_POLICY =
+  "camera=(), microphone=(), geolocation=(), interest-cohort=()";
+
+/**
+ * The exact { key, value } objects applied by Next.js `headers()`.
+ * Exported so the Playwright preview check and config can never disagree.
+ */
+export const SECURITY_HEADERS = [
+  { key: "Content-Security-Policy", value: CONTENT_SECURITY_POLICY },
+  { key: "X-Frame-Options", value: X_FRAME_OPTIONS },
+  { key: "Strict-Transport-Security", value: STRICT_TRANSPORT_SECURITY },
+  { key: "Referrer-Policy", value: REFERRER_POLICY },
+  { key: "X-Content-Type-Options", value: X_CONTENT_TYPE_OPTIONS },
+  { key: "X-XSS-Protection", value: X_XSS_PROTECTION },
+  { key: "Permissions-Policy", value: PERMISSIONS_POLICY },
+] as const;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import bundleAnalyzer from "@next/bundle-analyzer";
+import { SECURITY_HEADERS } from "./lib/security-headers";
 
 const nextConfig: NextConfig = {
   // ESLint now runs during `next build` so lint errors surface in CI.
@@ -9,6 +10,15 @@ const nextConfig: NextConfig = {
     // supported by the framework build worker.
     useTypeScriptCli: true,
   },
+
+  // Apply the security policy to every route so the deployed preview and
+  // production serve identical protection.
+  headers: async () => [
+    {
+      source: "/(.*)",
+      headers: [...SECURITY_HEADERS] as { key: string; value: string }[],
+    },
+  ],
 };
 
 const withBundleAnalyzer = bundleAnalyzer({

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.5.7",
-        "@material-tailwind/react": "^2.1.10",
         "@radix-ui/react-checkbox": "^1.3.11",
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-dropdown-menu": "^2.1.24",
@@ -19,11 +21,13 @@
         "@radix-ui/react-separator": "^1.1.15",
         "@radix-ui/react-slot": "^1.3.3",
         "@radix-ui/react-tabs": "^1.1.21",
+        "@tailwindcss/oxide-linux-x64-gnu": "^4.3.3",
         "@testing-library/dom": "^10.4.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
         "framer-motion": "^12.43.0",
+        "jspdf": "^4.2.1",
         "lucide-react": "^1.27.0",
         "next": "16.2.12",
         "next-auth": "^4.24.15",
@@ -61,7 +65,7 @@
         "tailwindcss": "^4.1.4",
         "tw-animate-css": "^1.4.0",
         "typescript": "7.0.2",
-        "vitest": "^4.1.9",
+        "vitest": "^4.1.10",
         "vitest-axe": "^0.1.0"
       }
     },
@@ -625,6 +629,59 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
@@ -668,23 +725,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emotion/memoize": "0.7.4"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -828,34 +868,6 @@
       "dependencies": {
         "@floating-ui/core": "^1.8.0",
         "@floating-ui/utils": "^0.2.12"
-      }
-    },
-    "node_modules/@floating-ui/react": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.19.0.tgz",
-      "integrity": "sha512-fgYvN4ksCi5OvmPXkyOT8o5a8PSKHMzPHt+9mR6KYWdF16IAjWRLZPAAziI2sznaWT23drRFrYw64wdvYqqaQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^1.2.2",
-        "aria-hidden": "^1.1.3",
-        "tabbable": "^6.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
-      "integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.2.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@floating-ui/utils": {
@@ -1554,152 +1566,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@material-tailwind/react": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@material-tailwind/react/-/react-2.1.10.tgz",
-      "integrity": "sha512-xGU/mLDKDBp/qZ8Dp2XR7fKcTpDuFeZEBqoL9Bk/29kakKxNxjUGYSRHEFLsyOFf4VIhU6WGHdIS7tOA3QGJHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react": "0.19.0",
-        "classnames": "2.3.2",
-        "deepmerge": "4.2.2",
-        "framer-motion": "6.5.1",
-        "material-ripple-effects": "2.0.1",
-        "prop-types": "15.8.1",
-        "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "tailwind-merge": "1.8.1"
-      },
-      "peerDependencies": {
-        "react": "^16 || ^17 || ^18",
-        "react-dom": "^16 || ^17 || ^18"
-      }
-    },
-    "node_modules/@material-tailwind/react/node_modules/framer-motion": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
-      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/dom": "10.12.0",
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "popmotion": "11.0.3",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
-      },
-      "optionalDependencies": {
-        "@emotion/is-prop-valid": "^0.8.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
-        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@material-tailwind/react/node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@material-tailwind/react/node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@material-tailwind/react/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/@material-tailwind/react/node_modules/tailwind-merge": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.8.1.tgz",
-      "integrity": "sha512-+fflfPxvHFr81hTJpQ3MIwtqgvefHZFUHFiIHpVIRXvG/nX9+gu2P7JNlFu2bfDMJ+uHhi/pUgzaYacMoXv+Ww==",
-      "license": "MIT"
-    },
-    "node_modules/@motionone/animation": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.18.0.tgz",
-      "integrity": "sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/easing": "^10.18.0",
-        "@motionone/types": "^10.17.1",
-        "@motionone/utils": "^10.18.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/dom": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
-      "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/animation": "^10.12.0",
-        "@motionone/generators": "^10.12.0",
-        "@motionone/types": "^10.12.0",
-        "@motionone/utils": "^10.12.0",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/easing": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.18.0.tgz",
-      "integrity": "sha512-VcjByo7XpdLS4o9T8t99JtgxkdMcNWD3yHU/n6CLEz3bkmKDRZyYQ/wmSf6daum8ZXqfUAgFeCZSpJZIMxaCzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/utils": "^10.18.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/generators": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.18.0.tgz",
-      "integrity": "sha512-+qfkC2DtkDj4tHPu+AFKVfR/C30O1vYdvsGYaR13W/1cczPrrcjdvYCj0VLFuRMN+lP1xvpNZHCRNM4fBzn1jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/types": "^10.17.1",
-        "@motionone/utils": "^10.18.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/types": {
-      "version": "10.17.1",
-      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.17.1.tgz",
-      "integrity": "sha512-KaC4kgiODDz8hswCrS0btrVrzyU2CSQKO7Ps90ibBVSQmjkrt2teqta6/sOG59v7+dPnKMAg13jyqtMKV2yJ7A==",
-      "license": "MIT"
-    },
-    "node_modules/@motionone/utils": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.18.0.tgz",
-      "integrity": "sha512-3XVF7sgyTSI2KWvTf6uLlBJ5iAgRgmvp3bpuOiQJvInd4nZ19ET8lX5unn30SlmRH7hXbBbH+Gxd0m0klJ3Xtw==",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/types": "^10.17.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3273,9 +3139,7 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
@@ -3650,6 +3514,12 @@
         "undici-types": "~8.3.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/qrcode": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
@@ -3659,6 +3529,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
@@ -3689,6 +3566,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -4942,6 +4826,16 @@
       "integrity": "sha512-EGHIRiegFa62/SsA1J+Xs2tIzludPdzM064N9wjbiEgHnGnJ1V0WEpA4pEwCYT5nDvZk3ubf0shqaCS7k6xeUQ==",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz",
@@ -5103,6 +4997,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -5124,12 +5038,6 @@
       "funding": {
         "url": "https://polar.sh/cva"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-      "license": "MIT"
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -5208,6 +5116,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5221,6 +5144,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -5511,15 +5444,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -5605,6 +5529,16 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6707,6 +6641,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -6716,6 +6661,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -6824,20 +6775,10 @@
         }
       }
     },
-    "node_modules/framesync": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7177,12 +7118,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-    "node_modules/hey-listen": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
-      "license": "MIT"
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -7202,6 +7137,20 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -7266,6 +7215,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -7888,6 +7843,23 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -8236,6 +8208,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -8309,12 +8282,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/material-ripple-effects": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/material-ripple-effects/-/material-ripple-effects-2.0.1.tgz",
-      "integrity": "sha512-hHlUkZAuXbP94lu02VgrPidbZ3hBtgXBtjlwR8APNqOIgDZMV8MCIcsclL8FmGJQHvnORyvoQgC965vPsiyXLQ==",
-      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -8628,6 +8595,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8906,6 +8874,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -8951,6 +8935,13 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9010,18 +9001,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/popmotion": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
-      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
-      "license": "MIT",
-      "dependencies": {
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -9155,6 +9134,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -9166,6 +9146,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -9215,6 +9196,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/react": {
       "version": "19.2.8",
@@ -9459,6 +9450,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -9554,6 +9552,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rolldown": {
@@ -9967,6 +9975,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
@@ -10157,16 +10175,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/style-value-types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
-      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
-      "license": "MIT",
-      "dependencies": {
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -10216,17 +10224,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tabbable": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
-      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
@@ -10258,6 +10270,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tiny-invariant": {
@@ -10743,6 +10765,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:e2e": "playwright test --project=chromium",
     "test:a11y": "playwright test tests/a11y.spec.ts",
     "type-check": "tsc --noEmit",
-    "test:e2e:settings": "playwright test tests/settings.spec.ts"
+    "test:e2e:settings": "playwright test tests/settings.spec.ts",
+    "test:security-headers": "playwright test tests/security-headers.spec.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/tests/security-headers.spec.ts
+++ b/tests/security-headers.spec.ts
@@ -1,0 +1,141 @@
+// End-to-end security-header check (issue #1174).
+//
+// This spec asserts that the deployed preview (or the local production build)
+// actually serves the intended security policy. It runs against whatever
+// server the Playwright webServer/browserBaseURL points at — in CI that is
+// the production preview; locally you can point it at `npm run build` +
+// `npm run start`.
+//
+// The policy it verifies is defined once in lib/security-headers.ts and wired
+// into next.config.ts, so a header cannot drift without this test failing.
+//
+// Representative routes:  HTML document (public + authenticated shell) and a
+// hashed static asset (declares the content-type / inline protections that
+// apply to served files).
+//
+// A failing assertion names the exact header + directive that regressed.
+
+import { expect, test, type APIResponse } from "@playwright/test";
+import {
+  CONTENT_SECURITY_POLICY,
+  REFERRER_POLICY,
+  STRICT_TRANSPORT_SECURITY,
+  X_CONTENT_TYPE_OPTIONS,
+  X_FRAME_OPTIONS,
+} from "../lib/security-headers";
+
+/** Routes exercised by the check: a public page and the app shell. */
+const REPRESENTATIVE_ROUTES = ["/", "/dashboard"];
+
+/**
+ * Required headers asserted on every representative route and on a hashed
+ * static asset. Value is a predicate (true = header matches expected policy).
+ */
+const REQUIRED_HEADERS: Record<string, (value: string | null) => boolean> = {
+  "Content-Security-Policy": (v) => v === CONTENT_SECURITY_POLICY,
+  "X-Frame-Options": (v) => v === X_FRAME_OPTIONS,
+  "Strict-Transport-Security": (v) => v === STRICT_TRANSPORT_SECURITY,
+  "Referrer-Policy": (v) => v === REFERRER_POLICY,
+  "X-Content-Type-Options": (v) => v === X_CONTENT_TYPE_OPTIONS,
+};
+
+/** Directives that must NOT appear in the served script-src (rejects unsafe inline/eval). */
+const FORBIDDEN_SCRIPT_DIRECTIVES = ["'unsafe-inline'", "'unsafe-eval'"];
+
+/** Extract the value of a single CSP directive (e.g. script-src …; -> 'self'). */
+function cspDirective(csp: string, name: string): string | null {
+  const match = csp.match(new RegExp(`(?:^|;)\\s*${name}\\s+([^;]+)`));
+  return match ? match[1].trim() : null;
+}
+
+/** Assert that `response` satisfies the full required-header policy. */
+function assertPolicyOnResponse(name: string, response: APIResponse): void {
+  for (const [header, matches] of Object.entries(REQUIRED_HEADERS)) {
+    const value = response.headers()[header.toLowerCase()] ?? null;
+    expect(
+      matches(value),
+      `[${name}] missing or weakened header "${header}". ` +
+        `Expected "${header}" to match the policy; got ${JSON.stringify(value || null)}`,
+    ).toBe(true);
+  }
+
+  // The policy must reject unsafe inline / eval'd scripts and cross-origin framing.
+  const csp = response.headers()["content-security-policy"] ?? "";
+  const scriptSrc = cspDirective(csp, "script-src");
+  expect(
+    scriptSrc,
+    `[${name}] CSP must define a script-src directive`,
+  ).toBeTruthy();
+  for (const directive of FORBIDDEN_SCRIPT_DIRECTIVES) {
+    expect(
+      scriptSrc!.includes(directive),
+      `[${name}] script-src must reject ${directive} (unsafe inline/eval)`,
+    ).toBe(false);
+  }
+  expect(
+    csp.includes("frame-ancestors 'none'"),
+    `[${name}] CSP must deny framing via frame-ancestors 'none'`,
+  ).toBe(true);
+}
+
+test.describe("Security headers on representative routes", () => {
+  for (const route of REPRESENTATIVE_ROUTES) {
+    test(`responds with the required security policy on ${route}`, async ({
+      request,
+      baseURL,
+    }) => {
+      const res = await request.get(`${baseURL}${route}`);
+      expect(res.status(), `${route} should return 200`).toBe(200);
+      assertPolicyOnResponse(route, res);
+    });
+  }
+});
+
+test.describe("Security headers on static assets", () => {
+  test("responds with content-type and framing protection on a hashed asset", async ({
+    request,
+    baseURL,
+  }) => {
+    // Fetch the landing page first to discover a real content-hashed asset.
+    const page = await request.get(`${baseURL}/`);
+    expect(page.status()).toBe(200);
+
+    const html = await page.text();
+    const match =
+      html.match(/src="(\/_next\/static\/[^"]+\.js)"/) ??
+      html.match(/href="(\/_next\/static\/[^"]+\.css)"/);
+    expect(
+      match,
+      "landing page should reference a _next/static asset",
+    ).toBeTruthy();
+
+    const assetUrl = `${baseURL}${match![1]}`;
+    const asset = await request.get(assetUrl);
+    expect(asset.status()).toBe(200);
+
+    assertPolicyOnResponse("static asset", asset);
+  });
+});
+
+test.describe("Security policy rejects unsafe behavior", () => {
+  test("script-src rejects unsafe-inline and unsafe-eval on every representative route", async ({
+    request,
+    baseURL,
+  }) => {
+    for (const route of REPRESENTATIVE_ROUTES) {
+      const res = await request.get(`${baseURL}${route}`);
+      const csp = res.headers()["content-security-policy"] ?? "";
+      const scriptSrc = cspDirective(csp, "script-src");
+      expect(
+        scriptSrc,
+        `[${route}] CSP must define a script-src directive`,
+      ).toBeTruthy();
+      for (const directive of FORBIDDEN_SCRIPT_DIRECTIVES) {
+        expect(
+          scriptSrc!.includes(directive),
+          `[${route}] script-src must reject ${directive}`,
+        ).toBe(false);
+      }
+    }
+  });
+});

--- a/utils/transactionUtils.test.ts
+++ b/utils/transactionUtils.test.ts
@@ -4,6 +4,7 @@ import type { SortField, SortConfig, Transaction } from "@/types/transaction";
 import { formatDate } from "@/utils/date-utils";
 import { formatCurrency } from "@/utils/formatUtils";
 import {
+  dedupeTransactionsById,
   filterTransactions,
   formatAmount,
   formatTransactionDate,
@@ -1325,5 +1326,47 @@ describe("sortAndFilterTransactions", () => {
     );
 
     expect(transactions.map((t) => t.id)).toEqual(originalOrder);
+  });
+});
+
+describe("dedupeTransactionsById", () => {
+  const tx = (id: string): Transaction =>
+    ({
+      id,
+      type: "Payment Sent",
+      txId: `#${id}`,
+      address: `A${id}`,
+      date: "2023-04-12",
+      time: "09:32AM",
+      token: "USDC",
+      amount: -10,
+      status: "Completed",
+      statusColor: "success",
+    }) as Transaction;
+
+  it("returns an empty array unchanged", () => {
+    expect(dedupeTransactionsById([])).toEqual([]);
+  });
+
+  it("keeps an already-unique list unchanged and preserves order", () => {
+    const input = [tx("1"), tx("2"), tx("3")];
+    expect(dedupeTransactionsById(input).map((t) => t.id)).toEqual([
+      "1",
+      "2",
+      "3",
+    ]);
+  });
+
+  it("removes duplicate ids, keeping the first occurrence", () => {
+    const input = [tx("1"), tx("2"), tx("1"), tx("3"), tx("2")];
+    const result = dedupeTransactionsById(input);
+    expect(result.map((t) => t.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("does not mutate the input array (adjacent-page overlap safety)", () => {
+    const input = [tx("1"), tx("1"), tx("2")];
+    const snapshot = input.map((t) => t.id);
+    dedupeTransactionsById(input);
+    expect(input.map((t) => t.id)).toEqual(snapshot);
   });
 });

--- a/utils/transactionUtils.ts
+++ b/utils/transactionUtils.ts
@@ -328,3 +328,30 @@ export const getStatusIcon = (status: string): LucideIcon => {
   const normalizedStatus = status.toLowerCase() as KnownTransactionStatus;
   return STATUS_ICON_MAP[normalizedStatus] ?? UNKNOWN_STATUS_ICON;
 };
+
+/**
+ * Removes duplicate transactions by their stable `id`, keeping the first
+ * occurrence of each and preserving order.
+ *
+ * The backend can change between cursor requests (records reordered or
+ * duplicated across page boundaries). Rendering deduplicates by identity so
+ * the UI never shows the same transaction twice, even if a page contains a
+ * row already returned by the previous page. When applied per page it is a
+ * safety net on top of the cursor walk; when applied across a paginated
+ * accumulation it guarantees a globally unique list.
+ *
+ * @param transactions - Transactions that may contain duplicate ids
+ * @returns A new array with one entry per unique id (first occurrence)
+ */
+export const dedupeTransactionsById = <T extends { id: string }>(
+  transactions: T[],
+): T[] => {
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const transaction of transactions) {
+    if (seen.has(transaction.id)) continue;
+    seen.add(transaction.id);
+    result.push(transaction);
+  }
+  return result;
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
         "components/common/notification-panel.tsx",
         "components/common/app-layout.tsx",
         "components/common/network-switcher.tsx",
+        "components/common/scoped-error-boundary.tsx",
         "components/common/search-bar.tsx",
         "components/ui/pagination.tsx",
        "components/dashboard/account-summary-card.tsx",


### PR DESCRIPTION
Closes #1168 

## Description
 Added getTransactionsCursor: keyset/cursor pagination over a stable total order (sort configs + id tiebreaker). Cursor resumes "after a boundary record" by comparison, not offset, so:
- deletion/reordering between requests can't shift the window (no dup/skip)
- adjacent pages never duplicate ids
- nextCursor === null/hasMore === false = end-of-list; repeated/invalid cursors are deterministic (no infinite loop)
- getTransactions now reuses the same stable order
- Implemented  function to remove duplicate transactions based on their uid=197609(USER) gid=197121 groups=197121, preserving the order of first occurrences.
- Added unit tests for  to ensure functionality, including cases for empty arrays, unique lists, and adjacent-page overlap safety.

## Related Issue

<!-- Link to the issue(s) this pull request addresses, if any. -->

## Checklist

- [ ] I have tested the changes locally.
- [ ] I have added/updated documentation as needed.
- [ ] I have reviewed the code and ensured it follows the project guidelines.
- [ ] I have added necessary tests.

## Screenshots/Recordings

<!-- Attach relevant images or videos to show the effect of your changes. -->

## Additional Notes

<!-- Any other information reviewers should be aware of. -->
