### PR TITLE
fix: guard destructive actions against duplicate requests

### DIFF
--- a/app/settings/preferences/components/destructive-action-dialog.test.tsx
+++ b/app/settings/preferences/components/destructive-action-dialog.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import DestructiveActionDialog from "./destructive-action-dialog";
@@ -23,6 +29,25 @@ function renderOpenDialog(onConfirm = vi.fn()) {
 
   fireEvent.click(screen.getByRole("button", { name: "Deactivate account" }));
   return { onConfirm };
+}
+
+/** Opens the dialog and types the exact token so the confirm button is enabled. */
+function openDialogAndType(onConfirm = vi.fn()) {
+  renderOpenDialog(onConfirm);
+  fireEvent.change(getInput(), { target: { value: "DEACTIVATE" } });
+  return { onConfirm };
+}
+
+/** An `onConfirm` handler backed by a manually-resolved promise. */
+function deferredConfirm() {
+  let resolve!: () => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  const onConfirm = vi.fn(() => promise);
+  return { onConfirm, resolve, reject };
 }
 
 const getInput = () => screen.getByLabelText('Type "DEACTIVATE" to confirm');
@@ -104,7 +129,7 @@ describe("DestructiveActionDialog", () => {
     expect(getConfirmButton()).toBeDisabled();
   });
 
-  it("confirms only on an exact, case-correct token", () => {
+  it("confirms only on an exact, case-correct token", async () => {
     const { onConfirm } = renderOpenDialog();
 
     fireEvent.change(getInput(), { target: { value: "DEACTIVATE" } });
@@ -116,7 +141,129 @@ describe("DestructiveActionDialog", () => {
     const confirmButton = getConfirmButton();
     expect(confirmButton).toBeEnabled();
 
-    fireEvent.click(confirmButton);
+    await act(async () => {
+      fireEvent.click(confirmButton);
+    });
     expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Idempotency: one request per confirmation
+  // -------------------------------------------------------------------------
+
+  it("issues exactly one request on a rapid double click", async () => {
+    const { onConfirm, resolve } = deferredConfirm();
+    openDialogAndType(onConfirm);
+
+    const confirmButton = getConfirmButton();
+    // Both click events arrive before React re-renders, mimicking a fast
+    // double click / held pointer.
+    fireEvent.click(confirmButton);
+    fireEvent.click(confirmButton);
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await act(async () => resolve());
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("issues exactly one request on keyboard (Enter) repeat", async () => {
+    const { onConfirm, resolve } = deferredConfirm();
+    openDialogAndType(onConfirm);
+
+    const confirmButton = getConfirmButton();
+    confirmButton.focus();
+    // A held Enter synthesizes a click per keydown on the focused button; each
+    // keyboard-activated click carries `detail: 0`.
+    fireEvent.click(confirmButton, { detail: 0 });
+    fireEvent.click(confirmButton, { detail: 0 });
+    fireEvent.click(confirmButton, { detail: 0 });
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    // Once pending, the button is disabled so further key repeats are inert.
+    expect(confirmButton).toBeDisabled();
+
+    await act(async () => resolve());
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Pending state: dialog must not close before the request resolves
+  // -------------------------------------------------------------------------
+
+  it("stays open and disables its controls while the request is pending", async () => {
+    const { onConfirm, resolve } = deferredConfirm();
+    openDialogAndType(onConfirm);
+
+    fireEvent.click(getConfirmButton());
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(getConfirmButton()).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(getInput()).toBeDisabled();
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-busy", "true");
+
+    // Escape and the close (X) affordance must not dismiss while in flight.
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await act(async () => resolve());
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Rejection + retry
+  // -------------------------------------------------------------------------
+
+  it("keeps the dialog open and re-enables confirm when the request rejects", async () => {
+    const onConfirm = vi.fn(() => Promise.reject(new Error("Request failed")));
+    openDialogAndType(onConfirm);
+
+    fireEvent.click(getConfirmButton());
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/request failed/i);
+    expect(alert).toHaveTextContent(/retry/i);
+
+    // Dialog never closed, token is preserved, confirm is available again.
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(getInput()).toHaveValue("DEACTIVATE");
+    expect(getConfirmButton()).toBeEnabled();
+  });
+
+  it("allows a retry after a recoverable failure", async () => {
+    const onConfirm = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Request failed"))
+      .mockResolvedValueOnce(undefined);
+    openDialogAndType(onConfirm);
+
+    fireEvent.click(getConfirmButton());
+    await screen.findByRole("alert");
+
+    // Retry succeeds and the dialog closes once the request resolves.
+    fireEvent.click(getConfirmButton());
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    expect(onConfirm).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the failure notice when the user edits the confirmation input", async () => {
+    const onConfirm = vi.fn(() => Promise.reject(new Error("Request failed")));
+    openDialogAndType(onConfirm);
+
+    fireEvent.click(getConfirmButton());
+    await screen.findByRole("alert");
+
+    fireEvent.change(getInput(), { target: { value: "DEACTIVAT" } });
+    expect(screen.queryByText(/request failed/i)).not.toBeInTheDocument();
   });
 });

--- a/app/settings/preferences/components/destructive-action-dialog.tsx
+++ b/app/settings/preferences/components/destructive-action-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,6 +13,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { usePendingAction } from "@/hooks/usePendingAction";
 
 interface DestructiveActionDialogProps {
   triggerLabel: string;
@@ -22,7 +23,13 @@ interface DestructiveActionDialogProps {
   confirmationToken: string;
   confirmationLabel: string;
   confirmLabel: string;
-  onConfirm: () => void;
+  /**
+   * Runs once per confirmation. May return a promise; the dialog stays open
+   * (in a pending state) until it resolves, and only closes on success. When
+   * it rejects, the dialog stays open with an inline error so the user can
+   * retry.
+   */
+  onConfirm: () => void | Promise<void>;
 }
 
 /**
@@ -65,19 +72,29 @@ function getConfirmationError(value: string, token: string): string | null {
 
 /**
  * A confirmation dialog for irreversible, high-impact actions (e.g. account
- * deactivation, wallet removal).
+ * deactivation, wallet removal, key revocation).
  *
- * Accessibility & safety behaviour:
+ * Safety & idempotency behaviour:
+ * - Exactly one request is issued per confirmation. While `onConfirm` is
+ *   pending the dialog disables its controls (confirm, cancel, close, typed
+ *   input) and guards against re-entry, so a rapid double click or a held /
+ *   repeated Enter key can never fire the action twice.
+ * - The dialog only closes after `onConfirm` resolves successfully. It never
+ *   looks "done" while the request is still in flight.
+ * - If `onConfirm` rejects, the dialog stays open, surfaces the failure
+ *   inline, and leaves the confirm button enabled so the user can retry.
+ * - The confirm action requires an **exact** token match — the value is *not*
+ *   trimmed or lower-cased — so accidental whitespace or wrong casing can never
+ *   bypass the user's intent. Any mismatch is surfaced inline (including a
+ *   whitespace-specific hint) instead of failing silently.
+ *
+ * Accessibility:
  * - The confirmation input is auto-focused when the dialog opens
  *   (`onOpenAutoFocus`), and focus returns to the trigger button on close —
  *   focus trapping and restoration are provided by Radix's `Dialog`.
  * - The input is wired with `aria-required`, `aria-invalid`, and
  *   `aria-describedby` (instruction text + error) via the shared `Input`
- *   component.
- * - The confirm action requires an **exact** token match — the value is *not*
- *   trimmed or lower-cased — so accidental whitespace or wrong casing can never
- *   bypass the user's intent. Any mismatch is surfaced inline (including a
- *   whitespace-specific hint) instead of failing silently.
+ *   component, and the dialog signals `aria-busy` while the action runs.
  */
 export default function DestructiveActionDialog({
   triggerLabel,
@@ -91,11 +108,18 @@ export default function DestructiveActionDialog({
 }: DestructiveActionDialogProps) {
   const [open, setOpen] = useState(false);
   const [confirmationText, setConfirmationText] = useState("");
+  const {
+    isPending,
+    error: actionError,
+    run,
+    reset: resetAction,
+  } = usePendingAction();
 
   const inputId = `confirmation-${confirmationToken.toLowerCase()}`;
   const labelId = `${inputId}-label`;
   const instructionId = `${inputId}-instruction`;
   const errorId = `${inputId}-error`;
+  const actionErrorId = `${inputId}-action-error`;
 
   // Strict, exact comparison: whitespace and casing must match the token.
   const isConfirmed = confirmationText === confirmationToken;
@@ -105,18 +129,37 @@ export default function DestructiveActionDialog({
     [confirmationText, confirmationToken],
   );
 
-  const handleOpenChange = (nextOpen: boolean) => {
-    setOpen(nextOpen);
+  const closeDialog = () => {
+    setOpen(false);
     setConfirmationText("");
+    resetAction();
   };
 
-  const handleConfirm = () => {
-    if (!isConfirmed) {
+  const handleOpenChange = (nextOpen: boolean) => {
+    // Never let the dialog dismiss (Escape, overlay, close button, cancel)
+    // while a request is in flight — closing early would imply success.
+    if (isPending) {
       return;
     }
 
-    onConfirm();
-    handleOpenChange(false);
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setConfirmationText("");
+      resetAction();
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!isConfirmed || isPending) {
+      return;
+    }
+
+    const succeeded = await run(onConfirm);
+    if (succeeded) {
+      // Close directly: `handleOpenChange` would still see the stale pending
+      // state in this closure and refuse to dismiss.
+      closeDialog();
+    }
   };
 
   return (
@@ -131,8 +174,11 @@ export default function DestructiveActionDialog({
           // Override Radix's default (focus the content/close button) so the
           // user lands directly on the field they must fill in.
           event.preventDefault();
-          document.getElementById(inputId)?.focus();
+          if (!isPending) {
+            document.getElementById(inputId)?.focus();
+          }
         }}
+        aria-busy={isPending}
       >
         <DialogHeader className="space-y-3 text-left">
           <div className="flex items-center gap-3">
@@ -180,11 +226,17 @@ export default function DestructiveActionDialog({
             <Input
               id={inputId}
               value={confirmationText}
-              onChange={(event) => setConfirmationText(event.target.value)}
+              onChange={(event) => {
+                setConfirmationText(event.target.value);
+                if (actionError) {
+                  resetAction();
+                }
+              }}
               placeholder={confirmationToken}
               className="border-zinc-200 bg-white dark:border-white/10 dark:bg-white/5"
               required
               aria-required
+              disabled={isPending}
               error={Boolean(validationError)}
               labelId={labelId}
               descriptionId={instructionId}
@@ -200,19 +252,41 @@ export default function DestructiveActionDialog({
                 {validationError}
               </p>
             )}
+            {actionError && (
+              <p
+                id={actionErrorId}
+                role="alert"
+                aria-live="polite"
+                className="flex items-center gap-1.5 rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs font-medium text-red-500"
+              >
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                {actionError}. You can retry.
+              </p>
+            )}
           </div>
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+          <Button
+            variant="outline"
+            disabled={isPending}
+            onClick={() => handleOpenChange(false)}
+          >
             Cancel
           </Button>
           <Button
             variant="destructive"
-            disabled={!isConfirmed}
+            disabled={!isConfirmed || isPending}
             onClick={handleConfirm}
           >
-            {confirmLabel}
+            {isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {confirmLabel}
+              </>
+            ) : (
+              confirmLabel
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/app/settings/preferences/components/security-tab.test.tsx
+++ b/app/settings/preferences/components/security-tab.test.tsx
@@ -1428,3 +1428,52 @@ describe("SecurityTab — 2FA verification security", () => {
     expect(err).not.toContain("12345");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Destructive API-key actions — idempotent confirmation
+// ---------------------------------------------------------------------------
+
+describe("SecurityTab — API key revocation", () => {
+  it("issues a single revoke request across a rapid double click and closes only after it resolves", async () => {
+    render(<SecurityTab />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^revoke$/i })[0]);
+    fireEvent.change(screen.getByLabelText('Type "REVOKE" to continue'), {
+      target: { value: "REVOKE" },
+    });
+    const confirm = screen.getByRole("button", { name: "Revoke key" });
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+
+    // The key stays visible until the simulated request resolves (~350 ms),
+    // then the dialog closes and the key is removed exactly once.
+    await waitFor(
+      () =>
+        expect(
+          screen.queryByText("Mobile payouts service"),
+        ).not.toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.getByText("Reporting sync")).toBeInTheDocument();
+  });
+
+  it("keeps the revoke dialog pending (controls disabled) until the request resolves", async () => {
+    render(<SecurityTab />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^revoke$/i })[0]);
+    fireEvent.change(screen.getByLabelText('Type "REVOKE" to continue'), {
+      target: { value: "REVOKE" },
+    });
+    const confirm = screen.getByRole("button", { name: "Revoke key" });
+
+    fireEvent.click(confirm);
+    // Immediately after confirming, the confirm button is disabled while pending.
+    expect(confirm).toBeDisabled();
+
+    await waitFor(
+      () => expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+  });
+});

--- a/app/settings/preferences/components/security-tab.tsx
+++ b/app/settings/preferences/components/security-tab.tsx
@@ -41,7 +41,6 @@ import {
 } from "@/utils/authUtils";
 import DestructiveActionDialog from "./destructive-action-dialog";
 import { DEMO_SECURITY, DEMO_CONNECTED_APPS } from "@/lib/demo-data";
-import { DEMO_SECURITY } from "@/lib/demo-data";
 import { generateTotpSecret, verifyTotpCode } from "@/lib/totp";
 import QRCode from "qrcode";
 
@@ -635,7 +634,7 @@ export default function SecurityTab({
   };
 
   const handleRotateApiKey = (key: ApiKeyRecord) => {
-    void queueApiKeyAction(`rotate-${key.id}`, () => {
+    return queueApiKeyAction(`rotate-${key.id}`, () => {
       const secret = createApiKeySecret(key.name);
 
       setApiKeys((current) =>
@@ -661,7 +660,7 @@ export default function SecurityTab({
   };
 
   const handleRevokeApiKey = (key: ApiKeyRecord) => {
-    void queueApiKeyAction(`revoke-${key.id}`, () => {
+    return queueApiKeyAction(`revoke-${key.id}`, () => {
       setApiKeys((current) => current.filter((item) => item.id !== key.id));
       if (revealedApiSecret?.keyId === key.id) {
         setRevealedApiSecret(null);

--- a/app/settings/preferences/components/wallets-section.test.tsx
+++ b/app/settings/preferences/components/wallets-section.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { WalletsSection, WalletItem } from "./wallets-section";
@@ -30,7 +30,9 @@ describe("WalletsSection", () => {
 
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText("Remove Connected Wallet")).toBeInTheDocument();
-    expect(screen.getByText("Test Wallet 1")).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("dialog")).getByText("Test Wallet 1"),
+    ).toBeInTheDocument();
   });
 
   it("cancels wallet removal when cancel button is clicked", () => {
@@ -42,7 +44,7 @@ describe("WalletsSection", () => {
     expect(screen.getByText("Test Wallet 1")).toBeInTheDocument();
   });
 
-  it("removes wallet and calls onRemoveWallet when confirmed", () => {
+  it("removes wallet and calls onRemoveWallet when confirmed", async () => {
     const handleRemove = vi.fn();
     render(<WalletsSection wallets={mockWallets} onRemoveWallet={handleRemove} />);
 
@@ -50,7 +52,59 @@ describe("WalletsSection", () => {
     fireEvent.click(screen.getByRole("button", { name: /^remove wallet$/i }));
 
     expect(handleRemove).toHaveBeenCalledWith("1");
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
     expect(screen.queryByText("Test Wallet 1")).not.toBeInTheDocument();
+  });
+
+  it("issues a single removal request across a rapid double click on the confirm button", async () => {
+    const removeSpy = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, 50);
+        }),
+    );
+    render(<WalletsSection wallets={mockWallets} onRemoveWallet={removeSpy} />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /remove/i })[0]);
+    const confirm = screen.getByRole("button", { name: /^remove wallet$/i });
+    fireEvent.click(confirm);
+    // While the request is in flight the confirm button is disabled.
+    expect(confirm).toBeDisabled();
+    fireEvent.click(confirm);
+
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the dialog open with an error on failure, then retries successfully", async () => {
+    const removeSpy = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Network down"))
+      .mockResolvedValueOnce(undefined);
+    render(<WalletsSection wallets={mockWallets} onRemoveWallet={removeSpy} />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /remove/i })[0]);
+    fireEvent.click(screen.getByRole("button", { name: /^remove wallet$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/you can retry/i),
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("dialog")).getByText("Test Wallet 1"),
+    ).toBeInTheDocument();
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /^remove wallet$/i }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    expect(removeSpy).toHaveBeenCalledTimes(2);
   });
 
   // ── nickname editing ──────────────────────────────────────────────

--- a/app/settings/preferences/components/wallets-section.tsx
+++ b/app/settings/preferences/components/wallets-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { Check, Pencil, Trash2, Wallet as WalletIcon, X } from "lucide-react";
+import { Check, Loader2, Pencil, Trash2, Wallet as WalletIcon, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -13,6 +13,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { truncateStellarAddress } from "@/utils/stellarAddress";
+import { useSearchHighlight } from "@/hooks/useSearchHighlight";
+import { usePendingAction } from "@/hooks/usePendingAction";
 
 export interface WalletItem {
   id: string;
@@ -22,8 +24,11 @@ export interface WalletItem {
 
 interface WalletsSectionProps {
   wallets?: WalletItem[];
-  onRemoveWallet?: (id: string) => void;
+  /** May return a promise; the remove dialog stays pending until it resolves. */
+  onRemoveWallet?: (id: string) => void | Promise<void>;
   onUpdateNickname?: (id: string, nickname: string) => void;
+  /** When set, scrolls to and highlights the matching control. */
+  highlightedSearchLabel?: string | null;
 }
 
 const MAX_NICKNAME_LENGTH = 40;
@@ -37,12 +42,24 @@ export function WalletsSection({
   wallets = DEFAULT_WALLETS,
   onRemoveWallet,
   onUpdateNickname,
+  highlightedSearchLabel,
 }: WalletsSectionProps) {
   useSearchHighlight(highlightedSearchLabel ?? null);
   const [walletList, setWalletList] = useState<WalletItem[]>(wallets);
   const [walletToRemove, setWalletToRemove] = useState<WalletItem | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState("");
+  const {
+    isPending: isRemoving,
+    error: removeError,
+    run: runRemove,
+    reset: resetRemove,
+  } = usePendingAction({ genericErrorMessage: "Failed to remove the wallet." });
+
+  const openRemoveDialog = (wallet: WalletItem) => {
+    resetRemove();
+    setWalletToRemove(wallet);
+  };
 
   const startEditing = (wallet: WalletItem) => {
     setEditingId(wallet.id);
@@ -74,11 +91,13 @@ export function WalletsSection({
   };
 
   const handleConfirmRemove = () => {
-    if (!walletToRemove) return;
+    if (!walletToRemove || isRemoving) return;
     const { id } = walletToRemove;
-    setWalletList((prev) => prev.filter((w) => w.id !== id));
-    onRemoveWallet?.(id);
-    setWalletToRemove(null);
+    void runRemove(async () => {
+      setWalletList((prev) => prev.filter((w) => w.id !== id));
+      await onRemoveWallet?.(id);
+      setWalletToRemove(null);
+    });
   };
 
   return (
@@ -167,9 +186,10 @@ export function WalletsSection({
                 <Button
                   variant="ghost"
                   size="icon"
-                  onClick={() => setWalletToRemove(wallet)}
+                  onClick={() => openRemoveDialog(wallet)}
                   aria-label={`Remove ${displayName} (${wallet.address})`}
                   className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  disabled={isRemoving}
                 >
                   <Trash2 className="h-4 w-4" />
                 </Button>
@@ -180,8 +200,18 @@ export function WalletsSection({
       )}
 
       {/* WCAG 2.1 AA – Remove Confirmation Dialog */}
-      <Dialog open={!!walletToRemove} onOpenChange={(open) => !open && setWalletToRemove(null)}>
-        <DialogContent className="sm:max-w-[425px]">
+      <Dialog
+        open={!!walletToRemove}
+        onOpenChange={(nextOpen) => {
+          // Never dismiss while the removal request is in flight.
+          if (isRemoving) return;
+          if (!nextOpen) setWalletToRemove(null);
+        }}
+      >
+        <DialogContent
+          className="sm:max-w-[425px]"
+          showCloseButton={!isRemoving}
+        >
           <DialogHeader>
             <DialogTitle>Remove Connected Wallet</DialogTitle>
             <DialogDescription className="pt-2 text-sm">
@@ -195,11 +225,37 @@ export function WalletsSection({
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="mt-4 gap-2 sm:gap-0">
-            <Button type="button" variant="outline" onClick={() => setWalletToRemove(null)}>
+            {removeError && (
+              <p
+                role="alert"
+                aria-live="polite"
+                className="w-full text-xs font-medium text-destructive"
+              >
+                {removeError}. You can retry.
+              </p>
+            )}
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setWalletToRemove(null)}
+              disabled={isRemoving}
+            >
               Cancel
             </Button>
-            <Button type="button" variant="destructive" onClick={handleConfirmRemove}>
-              Remove Wallet
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleConfirmRemove}
+              disabled={isRemoving}
+            >
+              {isRemoving ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Removing...
+                </>
+              ) : (
+                "Remove Wallet"
+              )}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/hooks/usePendingAction.test.tsx
+++ b/hooks/usePendingAction.test.tsx
@@ -1,0 +1,130 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { usePendingAction } from "./usePendingAction";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("usePendingAction", () => {
+  it("starts idle with no error", () => {
+    const { result } = renderHook(() => usePendingAction());
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("marks pending while the action runs and clears it afterwards", async () => {
+    const d = deferred<void>();
+    const action = vi.fn(() => d.promise);
+    const { result } = renderHook(() => usePendingAction());
+
+    let runPromise: Promise<boolean> | undefined;
+    act(() => {
+      runPromise = result.current.run(action);
+    });
+
+    expect(result.current.isPending).toBe(true);
+    expect(action).toHaveBeenCalledTimes(1);
+
+    await act(async () => d.resolve());
+    const succeeded = await runPromise;
+    expect(succeeded).toBe(true);
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("ignores a second run while one is still in flight (the action runs once)", async () => {
+    const d = deferred<void>();
+    const action = vi.fn(() => d.promise);
+    const { result } = renderHook(() => usePendingAction());
+
+    let first: Promise<boolean> | undefined;
+    let second: Promise<boolean> | undefined;
+    act(() => {
+      first = result.current.run(action);
+      second = result.current.run(action);
+    });
+    expect(action).toHaveBeenCalledTimes(1);
+
+    await act(async () => d.resolve());
+    expect(await first).toBe(true);
+    expect(await second).toBe(false);
+  });
+
+  it("surfaces a rejection and returns false so the caller can retry", async () => {
+    const action = vi.fn(() => Promise.reject(new Error("Network down")));
+    const { result } = renderHook(() => usePendingAction());
+
+    let runPromise: Promise<boolean> | undefined;
+    act(() => {
+      runPromise = result.current.run(action);
+    });
+
+    await act(async () => {
+      await runPromise;
+    });
+    expect(result.current.error).toBe("Network down");
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("uses the generic message when a rejection carries no error message", async () => {
+    const action = vi.fn(() => Promise.reject(new Error("")));
+    const { result } = renderHook(() =>
+      usePendingAction({ genericErrorMessage: "Nope." }),
+    );
+
+    await act(async () => {
+      await result.current.run(action);
+    });
+
+    expect(result.current.error).toBe("Nope.");
+  });
+
+  it("re-runs after a failure when asked (retry path)", async () => {
+    const action = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("First attempt failed"))
+      .mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => usePendingAction());
+
+    let first: Promise<boolean> | undefined;
+    let second: Promise<boolean> | undefined;
+    await act(async () => {
+      first = result.current.run(action);
+      second = undefined;
+    });
+    await act(async () => {
+      await first;
+    });
+    expect(result.current.error).not.toBeNull();
+    expect(action).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      second = result.current.run(action);
+    });
+    await act(async () => {
+      await second;
+    });
+    expect(result.current.error).toBeNull();
+    expect(action).toHaveBeenCalledTimes(2);
+  });
+
+  it("reset clears a stored error", async () => {
+    const action = vi.fn(() => Promise.reject(new Error("boom")));
+    const { result } = renderHook(() => usePendingAction());
+
+    await act(async () => {
+      await result.current.run(action);
+    });
+    expect(result.current.error).toBe("boom");
+
+    act(() => result.current.reset());
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/hooks/usePendingAction.ts
+++ b/hooks/usePendingAction.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+export interface UsePendingActionOptions {
+  /** Human-readable error to show when the action rejects with no message. */
+  genericErrorMessage?: string;
+}
+
+export interface UsePendingActionResult {
+  /** `true` while the action is in flight (confirm button disabled/loading). */
+  isPending: boolean;
+  /** Message from the most recent rejected attempt, or `null` when idle. */
+  error: string | null;
+  /**
+   * Runs `action` exactly once per confirmation. Any call made while a run is
+   * still in flight is ignored, so a double click or keyboard repeat can never
+   * issue the request twice.
+   *
+   * Resolves `true` when the action completed, `false` when it rejected
+   * (in which case `error` is populated and the caller may retry).
+   */
+  run: (action: () => void | Promise<void>) => Promise<boolean>;
+  /** Clears the stored error (e.g. when the user starts over). */
+  reset: () => void;
+}
+
+/**
+ * Centralizes the "one request per confirmation" guard shared by destructive
+ * action dialogs.
+ *
+ * - The first `run` call wins; later calls before the previous run settles are
+ *   no-ops (idempotent from the UI's perspective), which makes rapid double
+ *   clicks and held/repeated Enter keys safe.
+ * - While a run is pending, `isPending` is `true` so the caller can disable its
+ *   controls and show progress.
+ * - A rejected attempt leaves `error` populated and resolves `false`, letting
+ *   the caller keep its dialog open and offer a retry.
+ */
+export function usePendingAction(
+  options: UsePendingActionOptions = {},
+): UsePendingActionResult {
+  const { genericErrorMessage = "Something went wrong. Please try again." } =
+    options;
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inFlightRef = useRef(false);
+
+  const run = useCallback(
+    async (action: () => void | Promise<void>) => {
+      if (inFlightRef.current) {
+        return false;
+      }
+
+      inFlightRef.current = true;
+      setIsPending(true);
+      setError(null);
+
+      try {
+        await action();
+        return true;
+      } catch (caught) {
+        setError(
+          caught instanceof Error && caught.message
+            ? caught.message
+            : genericErrorMessage,
+        );
+        return false;
+      } finally {
+        inFlightRef.current = false;
+        setIsPending(false);
+      }
+    },
+    [genericErrorMessage],
+  );
+
+  const reset = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return { isPending, error, run, reset };
+}


### PR DESCRIPTION
## What & why

Closes #1178. A rapid double click — or a held/repeated Enter key — on a **delete**, **revoke**, or **disconnect** confirmation could fire the underlying request twice, because the confirm hander was synchronous and the dialog closed immediately.

This change makes those final destructive actions idempotent from the UI:

- Exactly **one request per confirmation**: re-entrant confirm calls while a run is in flight are ignored (a ref-based single-flight guard, not just a disabled button).
- The dialog **cannot look "done" while the request is still in flight**. It stays open and disabled (confirm, cancel, close button, typed input; Escape/overlay dismissal blocked) until `onConfirm` resolves.
- On rejection the dialog **keeps the user's intent**: it stays open, shows the failure inline, and leaves the confirm button enabled for a **retry**.
- Confirmation still requires an exact token match (unchanged behaviour).

## Implementation

- **`hooks/usePendingAction.ts`** (new): centralized single-flight hook — `run()` runs exactly once per confirmation and resolves `true`/`false`; concurrent calls are no-ops; `isPending` + `error` drive dialog state.
- **`DestructiveActionDialog`**: `onConfirm: () => void | Promise<void>`, `aria-busy`, spinner + pending labels, close gating, inline error with "You can retry.", auto-reset of error and input on next open.
- **`SecurityTab`**: rotate/revoke handlers now `return` the queued action (previously `void`) so the dialog stays pending until the request settles. Also removed a duplicated `DEMO_SECURITY` import (would fail to parse).
- **`WalletsSection`** (disconnect): removal runs through `usePendingAction`, spinner during removal, `onOpenChange` won't dismiss while pending, inline error + retry.
- **Bugfix:** `WalletsSection` referenced `highlightedSearchLabel`/`useSearchHighlight` without declaring them (a pre-existing crash whenever the hook was exercised) — added the import and prop.

## Test coverage (130 passing)

- **Double-click** on confirm fires the request exactly once (delete dialog, remove wallet, revoke key).
- **Keyboard repeat / Enter** likewise constrained (destructive-action-dialog).
- Confirm controls are **disabled while pending**; re-entry is a no-op.
- **Rejection** keeps the dialog open with an inline error and enables **retry**, which then succeeds and closes.
- `usePendingAction` unit tests (concurrency, error message fallback, retry, reset).

## Verification

- `npx vitest run` on the touched suites: 130/130 pass.
- `npx tsc --noEmit`: no errors in touched files (the repo has pre-existing unrelated tsc errors; `npm run lint` is broken repo-wide on this branch — ESLint v9 with only `.eslintrc.json`).