### PR TITLE
 feat(api): validate transaction and notification response payloads

### DIFF
--- a/components/common/notification-panel.tsx
+++ b/components/common/notification-panel.tsx
@@ -12,8 +12,10 @@ import {
   formatRelativeTime,
   toIsoDateTime,
 } from "@/utils/date-utils";
+import { ApiResponseValidationError, parseNotifications } from "@/lib/api";
 
-export type NotificationFetcher = (signal: AbortSignal) => Promise<NotificationItem[]>;
+/** Fetchers return unknown because network JSON is untrusted until validated. */
+export type NotificationFetcher = (signal: AbortSignal) => Promise<unknown>;
 
 interface NotificationRequestEntry {
   fetcher: NotificationFetcher;
@@ -43,10 +45,11 @@ function getSharedNotificationRequest(
     const controller = new AbortController();
     const promise = fetcher(controller.signal)
       .then((data) => {
+        const notifications = parseNotifications(data);
         if (notificationRequests.get(cacheKey)?.promise === promise) {
-          notificationDataCache.set(cacheKey, data);
+          notificationDataCache.set(cacheKey, notifications);
         }
-        return data;
+        return notifications;
       })
       .finally(() => {
         if (notificationRequests.get(cacheKey)?.promise === promise) {
@@ -106,6 +109,7 @@ export function useSharedNotifications(
   const [isLoading, setIsLoading] = useState(
     () => !notificationDataCache.has(cacheKey),
   );
+  const [error, setError] = useState<ApiResponseValidationError | null>(null);
 
   const fetcherRef = useRef(fetcher);
 
@@ -123,10 +127,12 @@ export function useSharedNotifications(
         currentPromise = null;
         setData(notificationDataCache.get(cacheKey) ?? []);
         setIsLoading(false);
+        setError(null);
         return;
       }
 
       setIsLoading(true);
+      setError(null);
       const request = getSharedNotificationRequest(cacheKey, fetcherRef.current);
       release = request.release;
       currentPromise = request.promise;
@@ -136,8 +142,9 @@ export function useSharedNotifications(
           setData(items);
           setIsLoading(false);
         })
-        .catch(() => {
+        .catch((reason: unknown) => {
           if (active && currentPromise === request.promise) {
+            setError(reason instanceof ApiResponseValidationError ? reason : null);
             setIsLoading(false);
           }
         });
@@ -168,7 +175,7 @@ export function useSharedNotifications(
     invalidateNotifications(cacheKey);
   }, [cacheKey]);
 
-  return { data, isLoading, refetch };
+  return { data, isLoading, error, refetch };
 }
 
 export const useNotifications = useSharedNotifications;

--- a/hooks/useAccountScopedSubscription.ts
+++ b/hooks/useAccountScopedSubscription.ts
@@ -49,6 +49,11 @@ import { useEffect, useRef } from "react";
 import { useWallet } from "@/context/wallet-context";
 import { createAccountScope, realtimeRegistry } from "@/lib/realtime-registry";
 import type { RealtimeListener } from "@/lib/realtime-registry";
+import {
+  ApiResponseValidationError,
+  parseStreamPayload,
+} from "@/lib/api";
+import type { ValidatedStreamPayload } from "@/lib/api";
 
 // Map of active shared subscriptions keyed by `${scope}:${channel}`.
 // This implements a shared request/cache layer: concurrent consumers with the
@@ -137,4 +142,34 @@ export function useAccountScopedSubscription<T = unknown>(
       }
     };
   }, [scope, channel]);
+}
+
+/**
+ * Subscribe to a typed realtime envelope. Invalid payloads never reach the
+ * listener, so a state update can only be made from validated data.
+ */
+export function useValidatedAccountScopedSubscription(
+  channel: string,
+  listener: RealtimeListener<ValidatedStreamPayload>,
+  onValidationError?: (error: ApiResponseValidationError) => void,
+): void {
+  const listenerRef = useRef(listener);
+  const errorRef = useRef(onValidationError);
+
+  useEffect(() => {
+    listenerRef.current = listener;
+    errorRef.current = onValidationError;
+  }, [listener, onValidationError]);
+
+  useAccountScopedSubscription(channel, (payload: unknown) => {
+    try {
+      listenerRef.current(parseStreamPayload(payload));
+    } catch (error) {
+      if (error instanceof ApiResponseValidationError) {
+        errorRef.current?.(error);
+        return;
+      }
+      throw error;
+    }
+  });
 }

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -15,3 +15,14 @@ export type {
   PaginatedTransactions,
   PaymentHistoryItem,
 } from "./transactions";
+export {
+  ApiResponseValidationError,
+  parseAccountSummary,
+  parseCursorPaginatedTransactions,
+  parseNotification,
+  parseNotifications,
+  parsePaginatedTransactions,
+  parseStreamPayload,
+  parseTransaction,
+} from "./response-validation";
+export type { ValidatedStreamPayload } from "./response-validation";

--- a/lib/api/response-validation.test.ts
+++ b/lib/api/response-validation.test.ts
@@ -1,0 +1,52 @@
+import {
+  ApiResponseValidationError,
+  parseAccountSummary,
+  parseNotifications,
+  parsePaginatedTransactions,
+  parseStreamPayload,
+} from "./response-validation";
+
+const transaction = {
+  id: "tx-1", type: "Payment Sent", txId: "stellar-1", address: "GABC",
+  date: "2026-01-01", time: "10:00", token: "USDC", amount: 12.5,
+  status: "Completed", statusColor: "success",
+};
+const summary = {
+  balance: "$ 12.50 USDC", balanceRaw: 12.5, paidThisMonth: "$ 1 USDC",
+  paidThisMonthCount: 1, toBePaid: "$ 0", toBePaidCount: 0, walletAddress: "GABC",
+};
+const notification = {
+  id: "notice-1", title: "Payment received", message: "Your payment arrived", read: false,
+  timestamp: "2026-01-01T10:00:00.000Z",
+};
+
+describe("API response validation", () => {
+  it("accepts valid payloads and drops unknown fields", () => {
+    const page = parsePaginatedTransactions({
+      data: [{ ...transaction, serverOnly: "ignored" }], total: 1, page: 1, pageSize: 10, totalPages: 1,
+      deploymentMetadata: { version: "next" },
+    });
+    expect(page.data[0]).toEqual(transaction);
+    expect(page).not.toHaveProperty("deploymentMetadata");
+    expect(parseAccountSummary({ ...summary, addedLater: true })).toEqual(summary);
+    expect(parseNotifications([{ ...notification, extra: 42 }])).toEqual([notification]);
+  });
+
+  it.each([
+    ["missing transaction identity", () => parsePaginatedTransactions({ data: [{ ...transaction, id: undefined }], total: 1, page: 1, pageSize: 1, totalPages: 1 })],
+    ["wrong money type", () => parseAccountSummary({ ...summary, balanceRaw: "12.5" })],
+    ["invalid notification field", () => parseNotifications([{ ...notification, read: "false" }])],
+    ["invalid stream payload", () => parseStreamPayload({ type: "transaction", payload: { ...transaction, amount: Number.NaN } })],
+  ])("returns a typed recoverable error for %s", (_label, parse) => {
+    expect(parse).toThrow(ApiResponseValidationError);
+    try { parse(); } catch (error) {
+      expect(error).toMatchObject({ code: "INVALID_API_RESPONSE" });
+    }
+  });
+
+  it("validates stream payloads before exposing them", () => {
+    expect(parseStreamPayload({ type: "notification", payload: notification })).toEqual({
+      type: "notification", payload: notification,
+    });
+  });
+});

--- a/lib/api/response-validation.ts
+++ b/lib/api/response-validation.ts
@@ -1,0 +1,88 @@
+/** Runtime validation for data received from API and realtime transports. */
+import { z, ZodError } from "zod";
+
+import type {
+  AccountSummary,
+  CursorPaginatedTransactions,
+  PaginatedTransactions,
+} from "./transactions";
+import type { Transaction } from "@/types/transaction";
+import type { NotificationItem } from "@/types/notification-item";
+
+/** A recoverable error: callers may show an error state and safely retry. */
+export class ApiResponseValidationError extends Error {
+  readonly code = "INVALID_API_RESPONSE" as const;
+  readonly issues: ReadonlyArray<{ path: string; message: string }>;
+
+  constructor(resource: string, error: ZodError) {
+    super(`Received an invalid ${resource} response. Please try again.`);
+    this.name = "ApiResponseValidationError";
+    this.issues = error.issues.map((issue) => ({
+      path: issue.path.join(".") || "response",
+      message: issue.message,
+    }));
+  }
+}
+
+const nonEmptyString = z.string().trim().min(1);
+const finiteNumber = z.number().refine(Number.isFinite, "Expected a finite number");
+const isoDateTime = nonEmptyString.refine(
+  (value) => !Number.isNaN(Date.parse(value)),
+  "Expected an ISO date-time string",
+);
+
+// z.object strips unknown keys by default. This lets a partially deployed API
+// add fields without making the UI depend on them.
+const transactionSchema = z.object({
+  id: nonEmptyString, type: nonEmptyString, txId: nonEmptyString,
+  address: nonEmptyString, date: nonEmptyString, time: nonEmptyString,
+  token: nonEmptyString, amount: finiteNumber, status: nonEmptyString,
+  statusColor: z.enum(["success", "warning", "destructive"]), memo: z.string().optional(),
+});
+const paginatedTransactionsSchema = z.object({
+  data: z.array(transactionSchema), total: z.number().int().nonnegative(),
+  page: z.number().int().positive(), pageSize: z.number().int().positive(),
+  totalPages: z.number().int().positive(),
+});
+const cursorPaginatedTransactionsSchema = z.object({
+  data: z.array(transactionSchema), total: z.number().int().nonnegative(),
+  nextCursor: z.string().nullable(), hasMore: z.boolean(),
+});
+const accountSummarySchema = z.object({
+  balance: nonEmptyString, balanceRaw: finiteNumber, paidThisMonth: nonEmptyString,
+  paidThisMonthCount: z.number().int().nonnegative(), toBePaid: nonEmptyString,
+  toBePaidCount: z.number().int().nonnegative(), walletAddress: nonEmptyString,
+});
+const notificationSchema = z.object({
+  id: nonEmptyString, title: nonEmptyString, message: nonEmptyString, read: z.boolean(),
+  timestamp: isoDateTime.optional(), category: z.string().optional(), readAt: isoDateTime.optional(),
+});
+
+function parse<T>(schema: z.ZodType<T>, input: unknown, resource: string): T {
+  const result = schema.safeParse(input);
+  if (!result.success) throw new ApiResponseValidationError(resource, result.error);
+  return result.data;
+}
+
+export const parseTransaction = (input: unknown): Transaction => parse(transactionSchema, input, "transaction");
+export const parsePaginatedTransactions = (input: unknown): PaginatedTransactions => parse(paginatedTransactionsSchema, input, "transactions");
+export const parseCursorPaginatedTransactions = (input: unknown): CursorPaginatedTransactions => parse(cursorPaginatedTransactionsSchema, input, "transactions");
+export const parseAccountSummary = (input: unknown): AccountSummary => parse(accountSummarySchema, input, "account summary");
+export const parseNotifications = (input: unknown): NotificationItem[] => parse(z.array(notificationSchema), input, "notifications");
+export const parseNotification = (input: unknown): NotificationItem => parse(notificationSchema, input, "notification");
+
+const streamEnvelopeSchema = z.object({ type: z.enum(["transaction", "account-summary", "notification"]), payload: z.unknown() });
+export type ValidatedStreamPayload =
+  | { type: "transaction"; payload: Transaction }
+  | { type: "account-summary"; payload: AccountSummary }
+  | { type: "notification"; payload: NotificationItem };
+
+/** Validate a realtime envelope before a subscriber is allowed to update state. */
+export function parseStreamPayload(input: unknown): ValidatedStreamPayload {
+  const envelope = parse(streamEnvelopeSchema, input, "stream");
+  switch (envelope.type) {
+    case "transaction": return { type: envelope.type, payload: parseTransaction(envelope.payload) };
+    case "account-summary": return { type: envelope.type, payload: parseAccountSummary(envelope.payload) };
+    case "notification": return { type: envelope.type, payload: parseNotification(envelope.payload) };
+  }
+}

--- a/lib/api/transactions.ts
+++ b/lib/api/transactions.ts
@@ -16,6 +16,11 @@ import { allTransactions } from "@/lib/transactions";
 import {
   filterTransactions,
 } from "@/utils/transactionUtils";
+import {
+  parseAccountSummary,
+  parseCursorPaginatedTransactions,
+  parsePaginatedTransactions,
+} from "./response-validation";
 
 export interface PaginatedTransactions {
   data: Transaction[];
@@ -365,7 +370,7 @@ export async function getTransactionsCursor(
   const remaining = window.length - page.length;
   const last = page[page.length - 1];
 
-  return {
+  return parseCursorPaginatedTransactions({
     data: page.map(({ transaction }) => transaction),
     total: appliedStable.length,
     nextCursor:
@@ -373,7 +378,7 @@ export async function getTransactionsCursor(
         ? encodeCursor({ values: last.values, id: last.transaction.id })
         : null,
     hasMore: remaining > 0,
-  };
+  });
 }
 
 /**
@@ -517,7 +522,13 @@ export async function getTransactions(
     .slice(start, start + safePageSize)
     .map(({ transaction }) => transaction);
 
-  return { data, total, page: safePage, pageSize: safePageSize, totalPages };
+  return parsePaginatedTransactions({
+    data,
+    total,
+    page: safePage,
+    pageSize: safePageSize,
+    totalPages,
+  });
 }
 
 export interface AccountSummary {
@@ -538,7 +549,7 @@ export async function getAccountSummary(): Promise<AccountSummary> {
     await new Promise((r) => setTimeout(r, 400));
   }
 
-  return {
+  return parseAccountSummary({
     balance: "$ 2,432 USDC",
     balanceRaw: 2432,
     paidThisMonth: "$ 0",
@@ -546,7 +557,7 @@ export async function getAccountSummary(): Promise<AccountSummary> {
     toBePaid: "$ 0",
     toBePaidCount: 0,
     walletAddress: "BaDE1b23U45...67890UzZ",
-  };
+  });
 }
 
 export interface PaymentHistoryItem {


### PR DESCRIPTION
- closes #1166  

## Summary

  Adds runtime validation at client data boundaries for transactions, account summaries, notifications, and realtime stream payloads.

  ## Changes

  - Added Zod schemas for API and stream response validation.
  - Introduced typed, recoverable `ApiResponseValidationError` errors.
  - Validates transaction pages, cursor pages, and account summaries before UI state updates.
  - Validates notification payloads before caching or rendering.
  - Added a validated realtime subscription helper that prevents malformed stream events from reaching state handlers.
  - Added coverage for missing fields, incorrect types, unknown fields, and valid payloads.

  ## Validation

  - `git diff --check` passes.